### PR TITLE
feat(graphify): add confirmed community naming

### DIFF
--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -4,7 +4,7 @@ Graphify builds a local knowledge graph for selected workspaces. It also merges 
 
 ## What it costs
 
-Only the first build of a workspace, and each rebuild, use the AI model. Everything else is local and free: incremental updates, the profile merge, and every search.
+The first build of a workspace, each rebuild, and optional community naming use the AI model. Everything else is local and free: incremental updates, the profile merge, and every search.
 
 Graphify does not spend on a default. Before the first build you must select a backend and a model in the Graphify panel. While no model is selected, Graphify indexes nothing.
 
@@ -12,13 +12,15 @@ Before each paid build, Graphify counts the files and bytes it will read, estima
 
 Graphify records the estimate against your daily limit before the build starts. If the build then fails, the record stays: a build can use tokens and still fail, and the limit must include that. If a build finishes but does not report its token use, Graphify keeps the estimate instead of recording zero.
 
-Community names are not made yet. Naming uses the AI model a second time, and that cost is not in the estimate, so Graphify does not do it. Your graph uses `Community 1`, `Community 2`, and so on.
+Community naming is a separate paid job. Graphify first makes the graph with placeholder names, then uses the measured community count to estimate naming. Select **Name communities** on the workspace card to see the model and estimate. Graphify asks before it starts, reserves the estimate, and settles the record from the token count in the generated report.
 
-These limits stop a build, and Sero shows the reason:
+An unpriced model always asks before each paid job. Graphify has no total-token stop for extraction or labeling, so Sero cannot enforce a token cap after the process starts. Ask the agent to use `graphify_configure` with the model price if you want the cost limits to control it.
+
+These limits stop a paid job, and Sero shows the reason:
 
 | Limit | Default |
 | --- | --- |
-| Maximum cost for one build | $2 |
+| Maximum cost for one paid job | $2 |
 | Maximum cost for one day | $10 |
 | Maximum files in one workspace | 5000 |
 
@@ -31,7 +33,7 @@ The **Spent today** line shows the total against the daily limit. Use **Pause** 
 3. Select or type a model. The list shows the models Sero knows. You can type any model name.
 4. Select **Use this model**.
 
-Sero sends this model to both AI steps. If you select the Claude Code subscription, always set a model: that backend uses Opus when you do not.
+Sero sends this model to extraction and community naming. If you select the Claude Code subscription, always set a model: that backend uses Opus when you do not.
 
 ## Index your first workspace
 
@@ -57,6 +59,8 @@ Graphify installs its Python tools in Sero's shared machine tool area. It does n
 
 Each workspace card shows its state and, after a build, the cost, the node and edge counts, the token use, the model, and the Graphify version. Use the **Rebuild** icon to pay for a new build after you change the model or when a graph is not correct.
 
+Select **Name communities** after a build to replace placeholder names with AI-generated names. The confirmation is separate from the build because the number of communities is not known before extraction finishes. Select **Rename communities** to run that paid job again.
+
 Graphify queues a free AST update after an agent edits files in an enabled workspace. It also runs an update when Sero starts, so it can include changes made while Sero was closed. These updates do not use the AI model.
 
 A restart never starts a paid build. A workspace with no graph shows **not built** and waits for you. A workspace whose build failed shows **error** with the reason and a **Try again** button. Graphify does not repeat a failed build on its own.
@@ -80,7 +84,8 @@ The agent can use these tools:
 | `graphify_path` | Find the shortest connection between two concepts. |
 | `graphify_explain` | Show the connections for one concept. |
 | `graphify_status` | Show provisioning, graph, and workspace states. |
-| `graphify_index` | Enable, disable, rebuild, refresh, synchronize indexing, or update the tool. |
+| `graphify_index` | Enable, disable, rebuild, name communities, refresh, synchronize indexing, or update the tool. |
+| `graphify_configure` | Select the backend and model, add a custom price, set limits, or pause paid work. |
 
 The agent can ask for a workspace to be indexed, but it cannot select a directory: it names a workspace, and Sero checks that name against its own workspace list. A build that Sero cannot confirm does not run.
 

--- a/docs/plans/graphify-spend-guardrails.md
+++ b/docs/plans/graphify-spend-guardrails.md
@@ -816,18 +816,15 @@ with no timers, and an interval would become a spend-latency knob.
 
 The acceptance tests the reviewer asked for are listed in #385.
 
-### Follow-up: community naming as its own confirmed job
+### Follow-up: community naming as its own confirmed job — implemented
 
-Naming is a second LLM pass whose cost the extraction estimate never covered,
-so a build that ran it left part of the authorised work outside both caps.
-`cluster-only` now always runs `--no-label` and the setting is gone; graphs read
-`Community 1`, `Community 2`.
-
-Restoring it means a separate job: priced from `stats.communities` (which the
-free clustering pass produces), shown with its model and estimate, confirmed,
-reserved and settled like any other paid work. A pre-flight uplift inside the
-build was rejected — naming scales with community count, which is unknown until
-after the extraction, so any number would have been invented.
+Naming is now a separate `name-communities` job. It is priced from
+`stats.communities` (which the free clustering pass produces), shown with its
+model and estimate, confirmed, reserved at the spawn boundary, and settled from
+the token count Graphify writes to `GRAPH_REPORT.md`. A failed naming pass keeps
+the reservation and leaves the graph usable. A pre-flight uplift inside the
+build remains rejected: naming scales with community count, which is unknown
+until after extraction.
 
 Known and deliberate:
 
@@ -839,9 +836,12 @@ Known and deliberate:
   read-parse-rebuild to a single rename. Closing it completely needs one shared
   write path for both processes, which is a host change rather than a plugin
   one.
-* **A cap cannot hold a model Sero has no price for.** Such a build always asks
-  first, and is recorded in the ledger at zero so it still appears in the day's
-  record. A user who wants it inside the caps can supply the price.
+* **A cap cannot hold a model Sero has no price for.** This is sufficient for
+  now. Such a job always asks first and is recorded in the ledger at zero, so it
+  still appears in the day's record. Graphify exposes a per-chunk packing limit,
+  not a total-token stop, so adding a Sero token cap would be a control the child
+  process cannot enforce. A user who wants the job inside the cost caps can
+  supply the model price.
 
 Still open, tracked as sero-labs/sero#386:
 

--- a/docs/prototypes/graphify-community-naming.html
+++ b/docs/prototypes/graphify-community-naming.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Graphify community naming</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; background: #090d0c; color: #edf3f0; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: radial-gradient(circle at 30% 20%, #11241d, #090d0c 46%); }
+    main { width: min(880px, calc(100% - 32px)); display: grid; gap: 18px; }
+    h1 { margin: 0; font-size: 20px; font-weight: 650; }
+    .muted { color: #8e9b96; font-size: 13px; }
+    .card { border: 1px solid #26322e; border-radius: 12px; background: #111715; padding: 16px; box-shadow: 0 16px 50px #0007; }
+    .workspace { display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .title { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; }
+    .badge { border: 1px solid #315e4d; border-radius: 999px; padding: 2px 8px; color: #9ee7c5; font-size: 12px; }
+    button { border: 1px solid #3b4c46; border-radius: 8px; padding: 8px 12px; color: #edf3f0; background: #19221f; font-weight: 600; }
+    .dialog { width: min(560px, 100%); justify-self: center; border-color: #3b5b4f; }
+    .dialog h2 { margin: 0 0 12px; font-size: 17px; }
+    .estimate { padding: 12px; border-radius: 8px; background: #0b110f; line-height: 1.7; }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
+    .primary { background: #1f8a61; border-color: #2bad7b; color: white; }
+  </style>
+</head>
+<body>
+  <main>
+    <section>
+      <h1>Graphify</h1>
+      <p class="muted">Community naming is optional and paid separately from extraction.</p>
+    </section>
+    <section class="card workspace">
+      <div>
+        <div class="title"><strong>Sero</strong><span class="badge">indexed</span></div>
+        <div class="muted">$0.18 · 1,284 nodes · 2,106 edges · 18 communities · gpt-4.1-mini</div>
+      </div>
+      <button>Name communities</button>
+    </section>
+    <section class="card dialog">
+      <h2>Name communities in Sero?</h2>
+      <div class="estimate">
+        <div>18 communities · up to ~5k tokens · &lt;$0.01</div>
+        <div class="muted">Model: gpt-4.1-mini (openai)</div>
+        <div class="muted">This is a separate paid job. It does not rebuild the graph.</div>
+      </div>
+      <div class="actions"><button>Cancel</button><button class="primary">Name communities</button></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/plugins/sero-graphify-plugin/GUIDE.md
+++ b/plugins/sero-graphify-plugin/GUIDE.md
@@ -76,8 +76,8 @@ free.
 - **A failed build still counts.** A build can use the model and then fail, so
   Graphify records what it was allowed to spend before it starts. A failure
   that never reached the model is not counted.
-- **Community names are not made yet.** That is a second use of the model, and
-  its cost is not in the estimate, so your graph uses `Community 1` and so on.
+- **Community names need a separate paid pass.** Select **Name communities**
+  after the graph is built. Graphify asks before it spends again.
 - **Pause** stops all paid work at once.
 
 ## Sensible defaults & safety

--- a/plugins/sero-graphify-plugin/README.md
+++ b/plugins/sero-graphify-plugin/README.md
@@ -15,15 +15,14 @@ One rule drives the whole plugin:
 > **Money is spent only by an explicit user action, with the model, the size and
 > the estimated cost known first. A restart never spends.**
 
-`graphify extract` is the only step that costs anything. `update`,
-`merge-graphs`, `cluster-only` (always `--no-label`) and every query are local.
+`graphify extract` and the optional `graphify label` job can cost money.
+`update`, `merge-graphs`, `cluster-only --no-label` and every query are local.
 
-Community naming is a second LLM pass and is **not run**. The pre-flight
-estimate prices the extraction, so naming inside a build would leave part of the
-authorised job outside both caps. It belongs in its own confirmed job, priced
-from the community count the free clustering pass produces.
+Community naming is separate from extraction. The runtime prices it from the
+community count produced by free clustering, confirms it, reserves the estimate
+at the spawn boundary, and settles it from the token line in `GRAPH_REPORT.md`.
 
-Before any paid build the runtime: refuses if paused or if no model is chosen;
+Before any paid job the runtime: refuses if paused or if no model is chosen;
 scans the tree the build will read (files **and bytes** — graphify chunks by
 tokens, so dense prose costs more than its file count suggests); checks the
 per-build, per-day and file caps against a durable ledger; and asks the user.
@@ -77,7 +76,7 @@ The profile graph re-merges after every change. The toolchain (`uv` + pinned
 | `graphify_path` | Shortest connection between two concepts |
 | `graphify_explain` | Neighborhood explanation of a single node |
 | `graphify_status` | Index status per workspace + profile graph |
-| `graphify_index` | enable / disable / rebuild / refresh / enable-all / sync / upgrade |
+| `graphify_index` | enable / disable / rebuild / name-communities / refresh / enable-all / sync / upgrade |
 
 All tools are CLI-bridged (`sero graphify_search ...`).
 
@@ -95,7 +94,7 @@ caches, fully idle when no graph exists.
 | Setting | Default | Notes |
 |---|---|---|
 | `model` | `null` | `{ backend, modelId, chosenAt, price? }`. **null blocks every paid job.** There is no "backend default" — that is how a build could run with nobody able to say what it cost |
-| `caps.maxCostPerBuildUsd` | `2` | A build estimated above this is refused |
+| `caps.maxCostPerBuildUsd` | `2` | A paid job estimated above this is refused |
 | `caps.maxCostPerDayUsd` | `10` | Profile-wide, measured against `state.spend` |
 | `caps.maxFilesPerBuild` | `5000` | Bigger trees are refused, not truncated |
 | `paused` | `false` | Blocks all paid work |
@@ -115,10 +114,9 @@ workspaces that do not exist there, and queue paid builds on arrival.
 
 ### Applying the model
 
-The chosen model is sent **twice**, because the two paid passes take it
-differently: `extract` reads `--model`, while the naming pass resolves
-`_default_model_for_backend(backend)` and ignores the flag entirely — only the
-backend's model environment variable (`GRAPHIFY_OPENAI_MODEL`, …) reaches it.
+The chosen model is sent by flag and environment variable. Extraction reads
+`--model`; the pinned naming command reads `--model=<id>`. The backend-specific
+environment variable (`GRAPHIFY_OPENAI_MODEL`, and others) is a second guard.
 
 The child environment is an allow-list plus the one selected provider key.
 `cluster-only` otherwise scans the environment and takes the first provider with

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -135,7 +135,8 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       lines.push(`Profile graph: ${state.profileGraph.status}${state.profileGraph.nodes ? ` — ${state.profileGraph.nodes} nodes / ${state.profileGraph.edges} edges` : ''}`);
       for (const entry of Object.values(state.workspaces)) {
         const stats = entry.stats ? ` ${entry.stats.nodes}n/${entry.stats.edges}e` : '';
-        lines.push(`• ${entry.name} [${entry.enabled ? entry.status : 'disabled'}]${stats}${entry.lastError ? ` — ${entry.lastError}` : ''}`);
+        const named = entry.communityNaming ? ` · names: ${entry.communityNaming.model}` : '';
+        lines.push(`• ${entry.name} [${entry.enabled ? entry.status : 'disabled'}]${stats}${named}${entry.lastError ? ` — ${entry.lastError}` : ''}`);
       }
       return text(lines.join('\n'));
     },
@@ -144,9 +145,9 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'graphify_index',
     label: 'Graphify Index',
-    description: 'Manage workspace indexing: enable, disable, rebuild, refresh a workspace, enable-all, or sync the workspace list. A first build or a rebuild costs money and asks the user first. Track progress with graphify_status.',
+    description: 'Manage workspace indexing and community names. A first build, rebuild, or community naming job costs money and asks the user first. Track progress with graphify_status.',
     parameters: Type.Object({
-      action: StringEnum(['enable', 'disable', 'rebuild', 'refresh', 'enable-all', 'sync', 'upgrade'] as const),
+      action: StringEnum(['enable', 'disable', 'rebuild', 'refresh', 'name-communities', 'enable-all', 'sync', 'upgrade'] as const),
       workspace: Type.Optional(Type.String({ description: 'Workspace id or name (omit for enable-all/sync, or to target the current workspace)' })),
       workspaceId: Type.Optional(Type.String({ description: 'Exact workspace id supplied by a host contribution' })),
     }),
@@ -183,7 +184,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'graphify_configure',
     label: 'Graphify Settings',
-    description: 'Change Graphify settings: the backend and model every paid build runs on, the spend limits, community naming, and pause. Nothing is indexed until a model is set.',
+    description: 'Change Graphify settings: the backend and model every paid job runs on, the spend limits, and pause. Nothing is indexed until a model is set.',
     parameters: Type.Object({
       backend: Type.Optional(StringEnum(BACKENDS)),
       model: Type.Optional(Type.String({ description: 'Exact model id, e.g. gpt-5.6-luna. Requires backend.' })),

--- a/plugins/sero-graphify-plugin/runtime/community-naming-job.ts
+++ b/plugins/sero-graphify-plugin/runtime/community-naming-job.ts
@@ -1,0 +1,114 @@
+import { settleRun } from '../shared/ledger';
+import { costUsd } from '../shared/pricing';
+import type { GraphifyState, WorkspaceIndexEntry, WorkspaceIndexStatus } from '../shared/types';
+import { authorizeCommunityNaming, type CommunityNamingDecision } from './community-naming';
+import type { IndexerHost } from './indexer-host';
+import { reserveEstimate } from './spend-record';
+
+interface Helpers {
+  refuse(workspaceId: string, decision: Extract<CommunityNamingDecision, { allowed: false }>): Promise<void>;
+  merge(): Promise<void>;
+}
+
+async function setStatus(
+  host: IndexerHost,
+  workspaceId: string,
+  status: WorkspaceIndexStatus,
+  patch: Partial<WorkspaceIndexEntry>,
+): Promise<void> {
+  await host.updateState((state) => {
+    const entry = state.workspaces[workspaceId];
+    if (!entry) return state;
+    return { ...state, workspaces: { ...state.workspaces, [workspaceId]: { ...entry, ...patch, status } } };
+  });
+}
+
+/** Execute, reserve and settle the separately confirmed community-name pass. */
+export async function runCommunityNamingJob(
+  host: IndexerHost,
+  state: GraphifyState,
+  entry: WorkspaceIndexEntry,
+  helpers: Helpers,
+): Promise<void> {
+  const decision = await authorizeCommunityNaming(host, state, entry, new Date());
+  if (!decision.allowed) {
+    await helpers.refuse(entry.workspaceId, decision);
+    return;
+  }
+
+  const startedAt = new Date().toISOString();
+  let reservationId: string | null = null;
+  await setStatus(host, entry.workspaceId, 'naming', {
+    progress: 'Starting community naming…',
+    lastAttemptAt: startedAt,
+    lastPaidAttemptAt: startedAt,
+  });
+  try {
+    await host.ensureProvisioned();
+    const outcome = await host.nameCommunities(
+      { workspaceId: entry.workspaceId, path: entry.path },
+      state.settings,
+      {
+        beforePaidSpawn: async () => {
+          reservationId = await reserveEstimate(
+            host,
+            entry.workspaceId,
+            state.settings,
+            decision.estimate,
+            startedAt,
+            'community-naming',
+          );
+        },
+        onProgress: (message) => void setStatus(host, entry.workspaceId, 'naming', { progress: message.slice(0, 300) }),
+      },
+    );
+    const choice = state.settings.model!;
+    const spentUsd = costUsd(choice, outcome.stats.inputTokens, outcome.stats.outputTokens);
+    await host.updateState((current) => {
+      const currentEntry = current.workspaces[entry.workspaceId];
+      if (!currentEntry) return current;
+      const next: GraphifyState = {
+        ...current,
+        workspaces: {
+          ...current.workspaces,
+          [entry.workspaceId]: {
+            ...currentEntry,
+            status: 'idle',
+            progress: undefined,
+            lastError: undefined,
+            communityNaming: {
+              communities: outcome.stats.communities || entry.stats?.communities || 0,
+              inputTokens: outcome.stats.inputTokens,
+              outputTokens: outcome.stats.outputTokens,
+              costUsd: outcome.usageMeasured ? spentUsd ?? undefined : undefined,
+              model: choice.modelId,
+              backend: choice.backend,
+              namedAt: new Date().toISOString(),
+            },
+          },
+        },
+      };
+      if (!reservationId || !outcome.usageMeasured) return next;
+      return {
+        ...next,
+        spend: settleRun(current.spend, reservationId, {
+          inputTokens: outcome.stats.inputTokens,
+          outputTokens: outcome.stats.outputTokens,
+          usd: spentUsd ?? 0,
+        }),
+      };
+    });
+    await helpers.merge();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await setStatus(host, entry.workspaceId, 'idle', {
+      progress: undefined,
+      lastError: `Community naming failed: ${message}`,
+    });
+    host.notify({
+      kind: 'refused',
+      message: `Community naming for ${entry.name} failed: ${message}`,
+      at: new Date().toISOString(),
+    });
+  }
+}

--- a/plugins/sero-graphify-plugin/runtime/community-naming.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/community-naming.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_STATE, type GraphifyState, type WorkspaceIndexEntry } from '../shared/types';
+import { authorizeCommunityNaming } from './community-naming';
+
+const NOW = new Date('2026-08-20T10:00:00Z');
+const WORKSPACE: WorkspaceIndexEntry = {
+  workspaceId: 'ws1',
+  name: 'One',
+  path: '/p/one',
+  enabled: true,
+  status: 'idle',
+  stats: { nodes: 10, edges: 20, communities: 12, inputTokens: 100, outputTokens: 50 },
+};
+
+function state(): GraphifyState {
+  const value = structuredClone(DEFAULT_STATE);
+  value.settings.model = { backend: 'openai', modelId: 'gpt-4.1-mini', chosenAt: 'now' };
+  return value;
+}
+
+describe('authorizeCommunityNaming', () => {
+  it('prices from the measured community count and always asks', async () => {
+    const host = { confirm: vi.fn().mockResolvedValue(true) };
+    const decision = await authorizeCommunityNaming(host, state(), WORKSPACE, NOW);
+    expect(decision.allowed).toBe(true);
+    expect(host.confirm).toHaveBeenCalledOnce();
+    expect(host.confirm.mock.calls[0][0].body).toContain('12 communities');
+    expect(host.confirm.mock.calls[0][0].body).toContain('gpt-4.1-mini');
+  });
+
+  it('refuses when there is no built community count', async () => {
+    const host = { confirm: vi.fn() };
+    const decision = await authorizeCommunityNaming(host, state(), { ...WORKSPACE, stats: undefined }, NOW);
+    expect(decision).toMatchObject({ allowed: false, kind: 'refused' });
+    expect(host.confirm).not.toHaveBeenCalled();
+  });
+
+  it('applies the daily cost cap before asking', async () => {
+    const value = state();
+    value.settings.caps.maxCostPerDayUsd = 0;
+    const host = { confirm: vi.fn() };
+    const decision = await authorizeCommunityNaming(host, value, WORKSPACE, NOW);
+    expect(decision).toMatchObject({ allowed: false, kind: 'cap' });
+    expect(host.confirm).not.toHaveBeenCalled();
+  });
+
+  it('explains that an unpriced model has no enforceable total-token cap', async () => {
+    const value = state();
+    value.settings.model = { backend: 'openai', modelId: 'unknown-model', chosenAt: 'now' };
+    const host = { confirm: vi.fn().mockResolvedValue(true) };
+    await authorizeCommunityNaming(host, value, WORKSPACE, NOW);
+    expect(host.confirm.mock.calls[0][0].body).toMatch(/no total-token stop/i);
+  });
+});

--- a/plugins/sero-graphify-plugin/runtime/community-naming.ts
+++ b/plugins/sero-graphify-plugin/runtime/community-naming.ts
@@ -1,0 +1,71 @@
+import { ledgerForDay, utcDay } from '../shared/ledger';
+import {
+  estimateCommunityNaming,
+  formatCommunityNamingEstimate,
+  formatUsd,
+} from '../shared/pricing';
+import type { BuildEstimate, GraphifyState, WorkspaceIndexEntry } from '../shared/types';
+
+export type CommunityNamingDecision =
+  | { allowed: true; estimate: BuildEstimate }
+  | { allowed: false; reason: string; kind: 'paused' | 'no-model' | 'cap' | 'declined' | 'refused' };
+
+interface ConfirmationHost {
+  confirm(options: { title: string; body: string; confirmLabel: string }): Promise<boolean>;
+}
+
+/** Authorise the second paid pass from the measured community count. */
+export async function authorizeCommunityNaming(
+  host: ConfirmationHost,
+  state: GraphifyState,
+  workspace: WorkspaceIndexEntry,
+  now: Date,
+): Promise<CommunityNamingDecision> {
+  if (state.settings.paused) {
+    return { allowed: false, kind: 'paused', reason: 'Graphify indexing is paused. Turn it back on before naming communities.' };
+  }
+  const choice = state.settings.model;
+  if (!choice) {
+    return { allowed: false, kind: 'no-model', reason: 'Choose a backend and model before naming communities.' };
+  }
+  const communities = workspace.stats?.communities ?? 0;
+  if (communities === 0) {
+    return { allowed: false, kind: 'refused', reason: `${workspace.name} has no communities to name. Build its graph first.` };
+  }
+
+  const estimate = estimateCommunityNaming(communities, choice);
+  const caps = state.settings.caps;
+  const spentToday = ledgerForDay(state.spend, utcDay(now)).usd;
+  if (estimate.estimatedCostUsd !== null) {
+    if (estimate.estimatedCostUsd > caps.maxCostPerBuildUsd) {
+      return {
+        allowed: false,
+        kind: 'cap',
+        reason: `Naming ${workspace.name} is estimated at ${formatUsd(estimate.estimatedCostUsd)}, over the ${formatUsd(caps.maxCostPerBuildUsd)} per-job limit.`,
+      };
+    }
+    if (spentToday + estimate.estimatedCostUsd > caps.maxCostPerDayUsd) {
+      return {
+        allowed: false,
+        kind: 'cap',
+        reason: `Today's Graphify spend plus community naming would pass the ${formatUsd(caps.maxCostPerDayUsd)} daily limit.`,
+      };
+    }
+  }
+
+  const approved = await host.confirm({
+    title: `Name communities in ${workspace.name}?`,
+    body: [
+      formatCommunityNamingEstimate(communities, estimate, choice),
+      `Model: ${choice.modelId} (${choice.backend})`,
+      estimate.estimatedCostUsd === null
+        ? 'Sero has no price for this model. Graphify has no total-token stop for extraction or labeling, so Sero cannot enforce a token cap after the process starts.'
+        : `Spent today: ${formatUsd(spentToday)} of ${formatUsd(caps.maxCostPerDayUsd)}.`,
+      'This is a separate paid job. It does not rebuild the graph.',
+    ].join('\n'),
+    confirmLabel: 'Name communities',
+  });
+  return approved
+    ? { allowed: true, estimate }
+    : { allowed: false, kind: 'declined', reason: `Community naming for ${workspace.name} was not approved.` };
+}

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
@@ -62,6 +62,12 @@ describe('parseBuildStats', () => {
       stats: { nodes: 0, edges: 0, communities: 0, inputTokens: 0, outputTokens: 0 },
     });
   });
+  it('does not treat a zero-token line as measured usage', () => {
+    expect(parseBuildStats('10 nodes, 20 edges, 2 communities\ntokens: 0 in / 0 out')).toMatchObject({
+      usageMeasured: false,
+      stats: { inputTokens: 0, outputTokens: 0 },
+    });
+  });
 });
 
 describe('community naming', () => {
@@ -70,6 +76,27 @@ describe('community naming', () => {
       usageMeasured: true,
       stats: { inputTokens: 1234, outputTokens: 567 },
     });
+  });
+
+  it('does not treat a free report as measured label usage', () => {
+    expect(parseCommunityNamingUsage('- Token cost: 0 input · 0 output')).toMatchObject({
+      usageMeasured: false,
+      stats: { inputTokens: 0, outputTokens: 0 },
+    });
+  });
+
+  it.each([
+    'Warning: using Community N placeholders',
+    'Warning: no LLM backend configured',
+  ])('fails when Graphify exits zero with a degraded label pass: %s', async (stderr) => {
+    const exec = vi.fn().mockResolvedValue({ ...ok(), stderr });
+    const beforePaidSpawn = vi.fn().mockResolvedValue(undefined);
+
+    await expect(nameWorkspaceCommunities(
+      { exec, graphifyPath: 'g', env: {} },
+      { workspaceDir: STORE, inputPath: '/p', model: MODEL, maxConcurrency: 0, beforePaidSpawn },
+    )).rejects.toThrow(/fallback names/i);
+    expect(beforePaidSpawn).toHaveBeenCalledOnce();
   });
 
   it('runs a forced label job with the chosen model and settles from the report', async () => {
@@ -101,6 +128,7 @@ describe('community naming', () => {
       'label', workspaceDir, '--no-viz', '--backend=claude',
       '--model=gpt-5.6-luna', '--max-concurrency=2',
     ]);
+    expect(exec.mock.calls[0][2].env.GRAPHIFY_API_TIMEOUT).toBe('300');
     expect(outcome).toEqual({
       usageMeasured: true,
       stats: { nodes: 0, edges: 0, communities: 10, inputTokens: 2100, outputTokens: 736 },

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
-import { buildWorkspaceGraph, updateWorkspaceGraph, mergeProfileGraph, parseBuildStats, ensureGraphifyIgnore } from './graphify-runner';
+import {
+  buildWorkspaceGraph,
+  ensureGraphifyIgnore,
+  mergeProfileGraph,
+  nameWorkspaceCommunities,
+  parseBuildStats,
+  parseCommunityNamingUsage,
+  updateWorkspaceGraph,
+} from './graphify-runner';
 import type { BuildOptions } from './graphify-runner';
 import type { ModelChoice } from '../shared/types';
 import type { ExecResult } from './bounded-exec';
@@ -52,6 +60,50 @@ describe('parseBuildStats', () => {
     expect(parseBuildStats('done')).toEqual({
       usageMeasured: false,
       stats: { nodes: 0, edges: 0, communities: 0, inputTokens: 0, outputTokens: 0 },
+    });
+  });
+});
+
+describe('community naming', () => {
+  it('parses the measured label usage from the generated report', () => {
+    expect(parseCommunityNamingUsage('- Token cost: 1,234 input · 567 output')).toMatchObject({
+      usageMeasured: true,
+      stats: { inputTokens: 1234, outputTokens: 567 },
+    });
+  });
+
+  it('runs a forced label job with the chosen model and settles from the report', async () => {
+    const { mkdtemp, mkdir, writeFile } = await import('node:fs/promises');
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), 'graphify-label-'));
+    await mkdir(path.join(workspaceDir, 'graphify-out'));
+    await writeFile(
+      path.join(workspaceDir, 'graphify-out', 'GRAPH_REPORT.md'),
+      '- Token cost: 2,100 input · 736 output',
+    );
+    const order: string[] = [];
+    const exec = vi.fn().mockImplementation(async () => {
+      order.push('exec');
+      return ok('Done - 10 communities. GRAPH_REPORT.md and graph.json updated');
+    });
+    const outcome = await nameWorkspaceCommunities(
+      { exec, graphifyPath: 'g', env: { PATH: '/bin' } },
+      {
+        workspaceDir,
+        inputPath: '/p',
+        model: MODEL,
+        maxConcurrency: 2,
+        beforePaidSpawn: async () => { order.push('reserve'); },
+      },
+    );
+
+    expect(order).toEqual(['reserve', 'exec']);
+    expect(exec.mock.calls[0][1]).toEqual([
+      'label', workspaceDir, '--no-viz', '--backend=claude',
+      '--model=gpt-5.6-luna', '--max-concurrency=2',
+    ]);
+    expect(outcome).toEqual({
+      usageMeasured: true,
+      stats: { nodes: 0, edges: 0, communities: 10, inputTokens: 2100, outputTokens: 736 },
     });
   });
 });

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
@@ -36,6 +36,13 @@ export interface BuildOptions extends UpdateOptions {
   exclude: string[];
 }
 
+export interface CommunityNamingOptions extends UpdateOptions {
+  /** Called at the last boundary before graphify starts the paid label pass. */
+  beforePaidSpawn?: () => Promise<void>;
+  model: ModelChoice;
+  maxConcurrency: number;
+}
+
 const BUILD_TIMEOUT_MS = 60 * 60_000;
 /** Passed to the CLI so a hung request fails instead of holding a paid slot. */
 const API_TIMEOUT_SECONDS = 300;
@@ -73,7 +80,23 @@ export function parseBuildStats(stdout: string): BuildOutcome {
     stats: {
       nodes: parse(summary?.[1] ?? stdout.match(/(\d[\d,]*)\s+nodes?/i)?.[1]),
       edges: parse(summary?.[2] ?? stdout.match(/(\d[\d,]*)\s+edges?/i)?.[1]),
-      communities: parse(summary?.[3]),
+      communities: parse(summary?.[3] ?? stdout.match(/(\d[\d,]*)\s+communities/i)?.[1]),
+      inputTokens: parse(tokens?.[1]),
+      outputTokens: parse(tokens?.[2]),
+    },
+  };
+}
+
+/** Parse the measured label tokens Graphify 0.9.47 writes to GRAPH_REPORT.md. */
+export function parseCommunityNamingUsage(report: string): Pick<BuildOutcome, 'stats' | 'usageMeasured'> {
+  const tokens = report.match(/Token cost:\s*(\d[\d,]*)\s+input\s*[·|/]\s*(\d[\d,]*)\s+output/i);
+  const parse = (value: string | undefined) => (value ? Number.parseInt(value.replace(/,/g, ''), 10) : 0);
+  return {
+    usageMeasured: tokens !== null,
+    stats: {
+      nodes: 0,
+      edges: 0,
+      communities: 0,
       inputTokens: parse(tokens?.[1]),
       outputTokens: parse(tokens?.[2]),
     },
@@ -199,6 +222,46 @@ async function clusterGraph(
     return { nodes: 0, edges: 0, communities: 0, inputTokens: 0, outputTokens: 0 };
   }
   return parseBuildStats(result.stdout).stats;
+}
+
+/** Run the separately authorised paid pass that replaces placeholder names. */
+export async function nameWorkspaceCommunities(
+  deps: RunnerDeps,
+  options: CommunityNamingOptions,
+): Promise<BuildOutcome> {
+  const env = { ...liveEnv(deps.env), GRAPHIFY_OUT: path.join(options.workspaceDir, 'graphify-out') };
+  const args = [
+    'label',
+    options.workspaceDir,
+    '--no-viz',
+    `--backend=${options.model.backend}`,
+    `--model=${options.model.modelId}`,
+  ];
+  if (options.maxConcurrency > 0) args.push(`--max-concurrency=${options.maxConcurrency}`);
+
+  await options.beforePaidSpawn?.();
+  const result = await deps.exec(deps.graphifyPath, args, {
+    cwd: options.workspaceDir,
+    env,
+    timeoutMs: BUILD_TIMEOUT_MS,
+    maxOutputBytes: BUILD_MAX_OUTPUT_BYTES,
+    onOutputLimit: 'truncate',
+    onLine: options.onProgress,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`graphify label failed (exit ${result.exitCode}): ${tail(result.stderr || result.stdout)}`);
+  }
+
+  const report = await readFile(path.join(options.workspaceDir, 'graphify-out', 'GRAPH_REPORT.md'), 'utf8').catch(() => '');
+  const usage = parseCommunityNamingUsage(report);
+  return {
+    usageMeasured: usage.usageMeasured,
+    stats: {
+      ...parseBuildStats(result.stdout).stats,
+      inputTokens: usage.stats.inputTokens,
+      outputTokens: usage.stats.outputTokens,
+    },
+  };
 }
 
 export async function updateWorkspaceGraph(deps: RunnerDeps, options: UpdateOptions): Promise<BuildOutcome> {

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
@@ -75,14 +75,16 @@ export function parseBuildStats(stdout: string): BuildOutcome {
   const summary = stdout.match(/(\d[\d,]*)\s+nodes?,\s*(\d[\d,]*)\s+edges?,\s*(\d[\d,]*)\s+communities/i);
   const parse = (value: string | undefined) => (value ? Number.parseInt(value.replace(/,/g, ''), 10) : 0);
   const tokens = stdout.match(/(\d[\d,]*)\s+in\s*\/\s*(\d[\d,]*)\s+out/i);
+  const inputTokens = parse(tokens?.[1]);
+  const outputTokens = parse(tokens?.[2]);
   return {
-    usageMeasured: tokens !== null,
+    usageMeasured: tokens !== null && inputTokens + outputTokens > 0,
     stats: {
       nodes: parse(summary?.[1] ?? stdout.match(/(\d[\d,]*)\s+nodes?/i)?.[1]),
       edges: parse(summary?.[2] ?? stdout.match(/(\d[\d,]*)\s+edges?/i)?.[1]),
       communities: parse(summary?.[3] ?? stdout.match(/(\d[\d,]*)\s+communities/i)?.[1]),
-      inputTokens: parse(tokens?.[1]),
-      outputTokens: parse(tokens?.[2]),
+      inputTokens,
+      outputTokens,
     },
   };
 }
@@ -91,14 +93,16 @@ export function parseBuildStats(stdout: string): BuildOutcome {
 export function parseCommunityNamingUsage(report: string): Pick<BuildOutcome, 'stats' | 'usageMeasured'> {
   const tokens = report.match(/Token cost:\s*(\d[\d,]*)\s+input\s*[·|/]\s*(\d[\d,]*)\s+output/i);
   const parse = (value: string | undefined) => (value ? Number.parseInt(value.replace(/,/g, ''), 10) : 0);
+  const inputTokens = parse(tokens?.[1]);
+  const outputTokens = parse(tokens?.[2]);
   return {
-    usageMeasured: tokens !== null,
+    usageMeasured: tokens !== null && inputTokens + outputTokens > 0,
     stats: {
       nodes: 0,
       edges: 0,
       communities: 0,
-      inputTokens: parse(tokens?.[1]),
-      outputTokens: parse(tokens?.[2]),
+      inputTokens,
+      outputTokens,
     },
   };
 }
@@ -229,7 +233,11 @@ export async function nameWorkspaceCommunities(
   deps: RunnerDeps,
   options: CommunityNamingOptions,
 ): Promise<BuildOutcome> {
-  const env = { ...liveEnv(deps.env), GRAPHIFY_OUT: path.join(options.workspaceDir, 'graphify-out') };
+  const env = {
+    ...liveEnv(deps.env),
+    GRAPHIFY_OUT: path.join(options.workspaceDir, 'graphify-out'),
+    GRAPHIFY_API_TIMEOUT: String(API_TIMEOUT_SECONDS),
+  };
   const args = [
     'label',
     options.workspaceDir,
@@ -250,6 +258,9 @@ export async function nameWorkspaceCommunities(
   });
   if (result.exitCode !== 0) {
     throw new Error(`graphify label failed (exit ${result.exitCode}): ${tail(result.stderr || result.stdout)}`);
+  }
+  if (/using Community N placeholders|no LLM backend configured/i.test(result.stderr)) {
+    throw new Error(`graphify label used fallback names: ${tail(result.stderr)}`);
   }
 
   const report = await readFile(path.join(options.workspaceDir, 'graphify-out', 'GRAPH_REPORT.md'), 'utf8').catch(() => '');

--- a/plugins/sero-graphify-plugin/runtime/host-adapter.ts
+++ b/plugins/sero-graphify-plugin/runtime/host-adapter.ts
@@ -7,11 +7,17 @@ import { estimateFromScan } from '../shared/pricing';
 import { graphifyPathsFromHome, workspaceGraphDir, workspaceGraphJson, type GraphifyPaths } from '../shared/paths';
 import { boundedExec } from './bounded-exec';
 import { provisionGraphify, graphifyBinPath, uvEnv, GRAPHIFY_VERSION } from './provisioner';
-import { buildWorkspaceGraph, updateWorkspaceGraph, mergeProfileGraph as runMerge, type BuildOutcome } from './graphify-runner';
+import {
+  buildWorkspaceGraph,
+  mergeProfileGraph as runMerge,
+  nameWorkspaceCommunities,
+  updateWorkspaceGraph,
+  type BuildOutcome,
+} from './graphify-runner';
 import { cleanEnv, extractionEnv } from './credentials';
 import { scanWorkspace } from './estimator';
 import { graphStats, loadGraph } from '../shared/query-engine';
-import type { IndexerHost } from './indexer';
+import type { IndexerHost } from './indexer-host';
 
 /** A build with no model chosen is a bug the guard should have stopped first. */
 function requireModel(settings: GraphifyState['settings']): ModelChoice {
@@ -174,6 +180,15 @@ export function createIndexerHost(ctx: AppRuntimeContext): { host: IndexerHost; 
       // throws when either is missing — before beforePaidSpawn can debit.
       withAuthoritativeStats(workspace.workspaceId, await buildWorkspaceGraph(await extractionDeps(settings), {
         ...buildOptionsFor(workspace, settings),
+        onProgress: hooks.onProgress,
+        beforePaidSpawn: hooks.beforePaidSpawn,
+      })),
+    nameCommunities: async (workspace, settings, hooks) =>
+      withAuthoritativeStats(workspace.workspaceId, await nameWorkspaceCommunities(await extractionDeps(settings), {
+        workspaceDir: workspaceGraphDir(paths, workspace.workspaceId),
+        inputPath: workspace.path,
+        model: requireModel(settings),
+        maxConcurrency: settings.maxConcurrency,
         onProgress: hooks.onProgress,
         beforePaidSpawn: hooks.beforePaidSpawn,
       })),

--- a/plugins/sero-graphify-plugin/runtime/indexer-host.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer-host.ts
@@ -1,0 +1,34 @@
+import type { GraphifyNotice, GraphifyState } from '../shared/types';
+import type { BuildOutcome } from './graphify-runner';
+import type { SpendHost } from './spend-guard';
+
+export interface IndexerWorkspace {
+  id: string;
+  name: string;
+  path: string;
+  open: boolean;
+}
+
+export interface JobHooks {
+  onProgress?: (message: string) => void;
+  /** Fires at the last moment before a paid child process starts. */
+  beforePaidSpawn?: () => Promise<void>;
+}
+
+export interface IndexerHost extends SpendHost {
+  readState(): Promise<GraphifyState | null>;
+  updateState(updater: (current: GraphifyState) => GraphifyState): Promise<void>;
+  listWorkspaces(): Promise<IndexerWorkspace[]>;
+  ensureProvisioned(): Promise<void>;
+  buildGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], hooks: JobHooks): Promise<BuildOutcome>;
+  nameCommunities(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], hooks: JobHooks): Promise<BuildOutcome>;
+  updateGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], hooks: JobHooks): Promise<BuildOutcome>;
+  mergeProfileGraph(workspaceIds: string[]): Promise<{ nodes: number; edges: number }>;
+  removeWorkspaceArtifacts(workspaceId: string): Promise<void>;
+  listArtifactWorkspaceIds(): Promise<string[]>;
+  graphExists(workspaceId: string): Promise<boolean>;
+  graphifyVersion(): Promise<string | undefined>;
+  upgradeGraphify(version: string): Promise<void>;
+  notify(notice: GraphifyNotice): void;
+  log(message: string): void;
+}

--- a/plugins/sero-graphify-plugin/runtime/indexer-spend.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer-spend.test.ts
@@ -229,6 +229,63 @@ describe('GraphifyIndexer — community naming is a separate paid job', () => {
     expect(getState().spend.runs.at(-1)).toMatchObject({ job: 'community-naming', estimated: true });
     expect(getState().workspaces.ws1.status).toBe('idle');
     expect(getState().workspaces.ws1.lastError).toMatch(/community naming failed/i);
+    expect(getState().workspaces.ws1.communityNaming).toBeUndefined();
+    indexer.dispose();
+  });
+
+  it('drops a rebuild queued after naming for the same workspace', async () => {
+    const { host, getState } = makeHost({ built: ['ws1'] }, (state) => {
+      enabled(state, 'ws1', { lastBuiltAt: 'yesterday', stats: STATS });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+    (host.buildGraph as ReturnType<typeof vi.fn>).mockClear();
+
+    await deliver(
+      indexer,
+      host,
+      request(1, 'name-communities', 'ws1'),
+      request(2, 'rebuild', 'ws1'),
+    );
+    await indexer.idle();
+
+    expect(host.nameCommunities).toHaveBeenCalledTimes(1);
+    expect(host.buildGraph).not.toHaveBeenCalled();
+    expect(getState().workspaces.ws1.communityNaming).toBeDefined();
+    indexer.dispose();
+  });
+
+  it('drops naming queued after a rebuild for the same workspace', async () => {
+    const { host, getState } = makeHost({ built: ['ws1'] }, (state) => {
+      enabled(state, 'ws1', {
+        lastBuiltAt: 'yesterday',
+        stats: STATS,
+        communityNaming: {
+          communities: 2,
+          inputTokens: 100,
+          outputTokens: 50,
+          model: 'old-model',
+          namedAt: 'yesterday',
+        },
+      });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+    (host.buildGraph as ReturnType<typeof vi.fn>).mockClear();
+
+    await deliver(
+      indexer,
+      host,
+      request(1, 'rebuild', 'ws1'),
+      request(2, 'name-communities', 'ws1'),
+    );
+    await indexer.idle();
+
+    expect(host.buildGraph).toHaveBeenCalledTimes(1);
+    expect(host.nameCommunities).not.toHaveBeenCalled();
+    expect(getState().workspaces.ws1.communityNaming).toBeUndefined();
     indexer.dispose();
   });
 });

--- a/plugins/sero-graphify-plugin/runtime/indexer-spend.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer-spend.test.ts
@@ -168,6 +168,71 @@ describe('GraphifyIndexer — a failed build still costs', () => {
   });
 });
 
+describe('GraphifyIndexer — community naming is a separate paid job', () => {
+  it('refuses naming before a graph exists', async () => {
+    const { host } = makeHost();
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await deliver(indexer, host, request(1, 'name-communities', 'ws1'));
+    await indexer.idle();
+    expect(host.nameCommunities).not.toHaveBeenCalled();
+    expect(host.notify).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringMatching(/build and enable/i) }));
+    indexer.dispose();
+  });
+
+  it('confirms, reserves and settles community naming without rebuilding', async () => {
+    const { host, getState } = makeHost({ built: ['ws1'] }, (state) => {
+      enabled(state, 'ws1', { lastBuiltAt: 'yesterday', stats: STATS });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+    (host.confirm as ReturnType<typeof vi.fn>).mockClear();
+    (host.mergeProfileGraph as ReturnType<typeof vi.fn>).mockClear();
+
+    await deliver(indexer, host, request(1, 'name-communities', 'ws1'));
+    await indexer.idle();
+
+    expect(host.nameCommunities).toHaveBeenCalledTimes(1);
+    expect(host.buildGraph).not.toHaveBeenCalled();
+    expect((host.confirm as ReturnType<typeof vi.fn>).mock.calls[0][0].body).toContain('2 communities');
+    expect(getState().spend.runs.at(-1)).toMatchObject({ job: 'community-naming', estimated: false });
+    expect(getState().workspaces.ws1.communityNaming).toMatchObject({
+      communities: 2,
+      inputTokens: 2_100,
+      outputTokens: 736,
+      model: 'gpt-4.1-mini',
+    });
+    expect(host.mergeProfileGraph).toHaveBeenCalledWith(['ws1']);
+    indexer.dispose();
+  });
+
+  it('keeps the reservation when naming fails after the process starts', async () => {
+    const nameCommunities = vi.fn(async (
+      _workspace: unknown,
+      _settings: unknown,
+      hooks: { beforePaidSpawn?: () => Promise<void> },
+    ) => {
+      await hooks.beforePaidSpawn?.();
+      throw new Error('provider unavailable');
+    });
+    const { host, getState } = makeHost({ built: ['ws1'], overrides: { nameCommunities } }, (state) => {
+      enabled(state, 'ws1', { lastBuiltAt: 'yesterday', stats: STATS });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+
+    await deliver(indexer, host, request(1, 'name-communities', 'ws1'));
+    await indexer.idle();
+
+    expect(getState().spend.runs.at(-1)).toMatchObject({ job: 'community-naming', estimated: true });
+    expect(getState().workspaces.ws1.status).toBe('idle');
+    expect(getState().workspaces.ws1.lastError).toMatch(/community naming failed/i);
+    indexer.dispose();
+  });
+});
+
 describe('GraphifyIndexer — the watermark cannot be rolled back', () => {
   it('ignores a request resurrected by another process overwriting state', async () => {
     // The extension appends from its own process, so one of its writes can land

--- a/plugins/sero-graphify-plugin/runtime/indexer.fixtures.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.fixtures.ts
@@ -28,7 +28,14 @@ export function makeHost(options: HostOptions = {}, seed?: (state: GraphifyState
     graphExists: async (id) => built.has(id),
     graphifyVersion: async () => '0.9.47',
     upgradeGraphify: vi.fn().mockResolvedValue(undefined),
-    estimateBuild: async () => ({ files: 10, bytes: 40_000, truncated: false, estimatedInputTokens: 10_000, estimatedCostUsd: 0.02 }),
+    estimateBuild: async () => ({
+      files: 10,
+      bytes: 40_000,
+      truncated: false,
+      estimatedInputTokens: 10_000,
+      estimatedOutputTokens: 2_000,
+      estimatedCostUsd: 0.02,
+    }),
     confirm: vi.fn().mockResolvedValue(true),
     notify: vi.fn(),
     buildGraph: vi.fn().mockImplementation(async (
@@ -40,6 +47,14 @@ export function makeHost(options: HostOptions = {}, seed?: (state: GraphifyState
       await hooks.beforePaidSpawn?.();
       built.add(workspace.workspaceId);
       return { stats: STATS, usageMeasured: true };
+    }),
+    nameCommunities: vi.fn().mockImplementation(async (
+      _workspace: unknown,
+      _settings: unknown,
+      hooks: { beforePaidSpawn?: () => Promise<void> },
+    ) => {
+      await hooks.beforePaidSpawn?.();
+      return { stats: { ...STATS, inputTokens: 2_100, outputTokens: 736 }, usageMeasured: true };
     }),
     updateGraph: vi.fn().mockResolvedValue({ stats: STATS, usageMeasured: false }),
     mergeProfileGraph: vi.fn().mockResolvedValue({ nodes: 20, edges: 40 }),

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -164,6 +164,10 @@ export class GraphifyIndexer {
 
     const hasGraph = await this.host.graphExists(workspaceId);
     const paid = options.rebuild || !hasGraph;
+    if (paid && !this.enqueue({ workspaceId, paid: true, confirm: true })) {
+      this.host.notify(notice('refused', `${workspaceId} already has a paid Graphify job queued or running.`));
+      return;
+    }
     await this.host.updateState((state) => {
       const entry = state.workspaces[workspaceId];
       if (!entry) return state;
@@ -182,7 +186,6 @@ export class GraphifyIndexer {
       await this.merge();
       return;
     }
-    this.enqueue({ workspaceId, paid: true, confirm: true });
   }
 
   private async applyRequest(request: IndexRequest): Promise<void> {
@@ -212,8 +215,11 @@ export class GraphifyIndexer {
           this.host.notify(notice('refused', `Build and enable ${entry?.name ?? request.workspaceId} before naming its communities.`));
           break;
         }
+        if (!this.enqueue({ workspaceId: request.workspaceId, paid: true, confirm: true, naming: true })) {
+          this.host.notify(notice('refused', `${entry.name} already has a paid Graphify job queued or running.`));
+          break;
+        }
         await this.setStatus(request.workspaceId, 'queued', { lastError: undefined });
-        this.enqueue({ workspaceId: request.workspaceId, paid: true, confirm: true, naming: true });
         break;
       }
       case 'sync':
@@ -260,20 +266,28 @@ export class GraphifyIndexer {
    * workspace already building appended a second build that ran the moment the
    * first finished.
    */
-  private enqueue(job: Job): void {
+  private enqueue(job: Job): boolean {
+    const paidConflict = job.paid && (
+      (this.activeJob?.workspaceId === job.workspaceId && this.activeJob.paid)
+      || (this.activeJob?.workspaceId === job.workspaceId && this.rerunRequested)
+      || this.queue.some((candidate) => candidate.workspaceId === job.workspaceId && candidate.paid)
+    );
+    if (paidConflict) return false;
+
     const sameKind = (candidate: Job) => candidate.workspaceId === job.workspaceId
       && Boolean(candidate.naming) === Boolean(job.naming);
     if (this.activeJob && sameKind(this.activeJob)) {
       if (job.paid && !this.activeJob.paid) this.rerunRequested = true;
-      return;
+      return true;
     }
     const existing = this.queue.find(sameKind);
     if (existing) {
       existing.paid = existing.paid || job.paid;
       existing.confirm = existing.confirm || job.confirm;
-      return;
+      return true;
     }
     this.queue.push({ ...job });
+    return true;
   }
 
   private kick(): void {
@@ -427,6 +441,7 @@ export class GraphifyIndexer {
             lastError: undefined,
             progress: undefined,
             failureCount: 0,
+            communityNaming: job.paid ? undefined : entry.communityNaming,
           },
         },
       };

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -8,47 +8,15 @@ import type {
 } from '../shared/types';
 import { isIndexableWorkspace } from '../shared/types';
 import type { BuildOutcome } from './graphify-runner';
-import { authorizePaidBuild, type SpendHost } from './spend-guard';
+import { authorizePaidBuild } from './spend-guard';
 import { settleRun } from '../shared/ledger';
 import { reserveEstimate, settleStats } from './spend-record';
 import { sweepOrphanArtifacts, syncWorkspaceList } from './workspace-sync';
 import { applySettingsPatch, upgradeGraphifyTool } from './settings';
+import type { IndexerHost } from './indexer-host';
+import { runCommunityNamingJob } from './community-naming-job';
 
-export interface IndexerWorkspace {
-  id: string;
-  name: string;
-  path: string;
-  open: boolean;
-}
-
-export interface IndexerHost extends SpendHost {
-  readState(): Promise<GraphifyState | null>;
-  updateState(updater: (current: GraphifyState) => GraphifyState): Promise<void>;
-  listWorkspaces(): Promise<IndexerWorkspace[]>;
-  ensureProvisioned(): Promise<void>;
-  buildGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], hooks: JobHooks): Promise<BuildOutcome>;
-  updateGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], hooks: JobHooks): Promise<BuildOutcome>;
-  mergeProfileGraph(workspaceIds: string[]): Promise<{ nodes: number; edges: number }>;
-  /** Delete a workspace's on-disk graph artifacts (idempotent — no-op if absent). */
-  removeWorkspaceArtifacts(workspaceId: string): Promise<void>;
-  /** Ids of every workspace that has graph artifacts on disk. */
-  listArtifactWorkspaceIds(): Promise<string[]>;
-  /** True when a built graph is already on disk — the difference between free and paid. */
-  graphExists(workspaceId: string): Promise<boolean>;
-  /** graphifyy version currently installed, recorded against each build. */
-  graphifyVersion(): Promise<string | undefined>;
-  /** Install a specific graphifyy version. Always a user-approved action. */
-  upgradeGraphify(version: string): Promise<void>;
-  /** Surface something the user must see. */
-  notify(notice: GraphifyNotice): void;
-  log(message: string): void;
-}
-
-export interface JobHooks {
-  onProgress?: (message: string) => void;
-  /** Fires at the last moment before a paid child process starts. */
-  beforePaidSpawn?: () => Promise<void>;
-}
+export type { IndexerHost } from './indexer-host';
 
 interface Job {
   workspaceId: string;
@@ -56,6 +24,8 @@ interface Job {
   paid: boolean;
   /** Ask before spending, even when the estimate is inside every cap. */
   confirm: boolean;
+  /** The second paid pass. False/absent means extraction or a free update. */
+  naming?: boolean;
 }
 
 function notice(kind: GraphifyNotice['kind'], message: string): GraphifyNotice {
@@ -234,6 +204,18 @@ export class GraphifyIndexer {
         }
         break;
       }
+      case 'name-communities': {
+        if (!request.workspaceId) break;
+        const state = await this.host.readState();
+        const entry = state?.workspaces[request.workspaceId];
+        if (!entry?.enabled || !await this.host.graphExists(request.workspaceId)) {
+          this.host.notify(notice('refused', `Build and enable ${entry?.name ?? request.workspaceId} before naming its communities.`));
+          break;
+        }
+        await this.setStatus(request.workspaceId, 'queued', { lastError: undefined });
+        this.enqueue({ workspaceId: request.workspaceId, paid: true, confirm: true, naming: true });
+        break;
+      }
       case 'sync':
         await this.syncWorkspaces();
         break;
@@ -279,11 +261,13 @@ export class GraphifyIndexer {
    * first finished.
    */
   private enqueue(job: Job): void {
-    if (this.activeJob?.workspaceId === job.workspaceId) {
+    const sameKind = (candidate: Job) => candidate.workspaceId === job.workspaceId
+      && Boolean(candidate.naming) === Boolean(job.naming);
+    if (this.activeJob && sameKind(this.activeJob)) {
       if (job.paid && !this.activeJob.paid) this.rerunRequested = true;
       return;
     }
-    const existing = this.queue.find((queued) => queued.workspaceId === job.workspaceId);
+    const existing = this.queue.find(sameKind);
     if (existing) {
       existing.paid = existing.paid || job.paid;
       existing.confirm = existing.confirm || job.confirm;
@@ -343,6 +327,13 @@ export class GraphifyIndexer {
     const state = await this.host.readState();
     const entry = state?.workspaces[job.workspaceId];
     if (!state || !entry?.enabled) return;
+    if (job.naming) {
+      await runCommunityNamingJob(this.host, state, entry, {
+        refuse: (workspaceId, decision) => this.refuse(workspaceId, decision),
+        merge: () => this.merge(),
+      });
+      return;
+    }
 
     const runningStatus: WorkspaceIndexStatus = job.paid ? 'building' : 'updating';
     const startedAt = new Date().toISOString();

--- a/plugins/sero-graphify-plugin/runtime/settings.ts
+++ b/plugins/sero-graphify-plugin/runtime/settings.ts
@@ -1,5 +1,5 @@
 import type { GraphifyNotice, SettingsPatch } from '../shared/types';
-import type { IndexerHost } from './indexer';
+import type { IndexerHost } from './indexer-host';
 
 /**
  * Configuration changes: settings the panel queued, and the library upgrade.

--- a/plugins/sero-graphify-plugin/runtime/spend-guard.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/spend-guard.test.ts
@@ -8,7 +8,15 @@ const MODEL: ModelChoice = { backend: 'openai', modelId: 'gpt-4.1-mini', chosenA
 const WORKSPACE = { workspaceId: 'ws1', name: 'One', path: '/p/one' };
 
 function estimate(overrides: Partial<BuildEstimate> = {}): BuildEstimate {
-  return { files: 10, bytes: 40_000, truncated: false, estimatedInputTokens: 10_000, estimatedCostUsd: 0.01, ...overrides };
+  return {
+    files: 10,
+    bytes: 40_000,
+    truncated: false,
+    estimatedInputTokens: 10_000,
+    estimatedOutputTokens: 2_000,
+    estimatedCostUsd: 0.01,
+    ...overrides,
+  };
 }
 
 function makeHost(value: BuildEstimate, confirmed = true): SpendHost & { confirm: ReturnType<typeof vi.fn> } {
@@ -92,7 +100,7 @@ describe('the spend ledger', () => {
   });
 
   it('accumulates within a day', () => {
-    const run = { id: 'ws1:t1', workspaceId: 'ws1', backend: 'openai' as const, model: 'm', inputTokens: 1, outputTokens: 1, usd: 0.5, at: 'now' };
+    const run = { id: 'ws1:t1', workspaceId: 'ws1', job: 'build' as const, backend: 'openai' as const, model: 'm', inputTokens: 1, outputTokens: 1, usd: 0.5, at: 'now' };
     const first = recordRun({ day: '2026-08-20', usd: 0, runs: [] }, run, '2026-08-20');
     const second = recordRun(first, { ...run, id: 'ws1:t2' }, '2026-08-20');
     expect(second.usd).toBe(1);
@@ -101,7 +109,7 @@ describe('the spend ledger', () => {
 
   it('settles a reservation against measured usage', () => {
     const reserved = recordRun({ day: '2026-08-20', usd: 0, runs: [] }, {
-      id: 'ws1:t1', workspaceId: 'ws1', backend: 'openai', model: 'm',
+      id: 'ws1:t1', workspaceId: 'ws1', job: 'build', backend: 'openai', model: 'm',
       inputTokens: 10_000, outputTokens: 0, usd: 2, at: 'now', estimated: true,
     }, '2026-08-20');
     expect(reserved.usd).toBe(2);
@@ -116,7 +124,7 @@ describe('the spend ledger', () => {
     // its debit would let the same workspace be retried all day against a cap
     // that still reads $0.
     const reserved = recordRun({ day: '2026-08-20', usd: 0, runs: [] }, {
-      id: 'ws1:t1', workspaceId: 'ws1', backend: 'openai', model: 'm',
+      id: 'ws1:t1', workspaceId: 'ws1', job: 'build', backend: 'openai', model: 'm',
       inputTokens: 10_000, outputTokens: 0, usd: 2, at: 'now', estimated: true,
     }, '2026-08-20');
     expect(settleRun(reserved, 'ws1:other', { inputTokens: 1, outputTokens: 1, usd: 9 })).toEqual(reserved);

--- a/plugins/sero-graphify-plugin/runtime/spend-record.ts
+++ b/plugins/sero-graphify-plugin/runtime/spend-record.ts
@@ -1,7 +1,7 @@
 import type { BuildEstimate, GraphifyState, WorkspaceIndexStats } from '../shared/types';
 import { costUsd } from '../shared/pricing';
 import { recordRun, utcDay } from '../shared/ledger';
-import type { IndexerHost } from './indexer';
+import type { IndexerHost } from './indexer-host';
 
 /**
  * Writing down what a build was authorised to spend, and what it actually did.
@@ -26,19 +26,21 @@ export async function reserveEstimate(
   settings: GraphifyState['settings'],
   estimate: BuildEstimate,
   startedAt: string,
+  job: 'build' | 'community-naming' = 'build',
 ): Promise<string | null> {
   const choice = settings.model;
   if (!choice) return null;
-  const id = `${workspaceId}:${startedAt}`;
+  const id = `${workspaceId}:${job}:${startedAt}`;
   await host.updateState((current) => ({
     ...current,
     spend: recordRun(current.spend, {
       id,
       workspaceId,
+      job,
       backend: choice.backend,
       model: choice.modelId,
       inputTokens: estimate.estimatedInputTokens,
-      outputTokens: 0,
+      outputTokens: estimate.estimatedOutputTokens,
       usd: estimate.estimatedCostUsd ?? 0,
       at: startedAt,
       estimated: true,

--- a/plugins/sero-graphify-plugin/runtime/workspace-sync.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/workspace-sync.test.ts
@@ -52,4 +52,17 @@ describe('an unreadable workspace list is not a deletion', () => {
     expect(getState().workspaces.ws1).toBeUndefined();
     expect(getState().removedWorkspaces.map((entry) => entry.workspaceId)).toEqual(['ws1']);
   });
+
+  it('does not remove a workspace while its paid naming job is active', async () => {
+    const { host, getState } = makeHost([{ id: 'ws2', name: 'Two', path: '/p/two', open: true }], (state) => {
+      state.workspaces.ws1 = {
+        workspaceId: 'ws1', name: 'One', path: '/p/one', enabled: true,
+        status: 'naming', lastBuiltAt: 'yesterday',
+      };
+    });
+    const result = await syncWorkspaceList(host);
+    expect(result.removedIds).toEqual([]);
+    expect(getState().workspaces.ws1.status).toBe('naming');
+    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/sero-graphify-plugin/runtime/workspace-sync.ts
+++ b/plugins/sero-graphify-plugin/runtime/workspace-sync.ts
@@ -1,6 +1,6 @@
 import type { GraphifyNotice, GraphifyState, WorkspaceIndexStatus } from '../shared/types';
 import { DEFAULT_STATE, isIndexableWorkspace } from '../shared/types';
-import type { IndexerHost } from './indexer';
+import type { IndexerHost } from './indexer-host';
 
 /**
  * Reconciling the profile's workspace list into graphify state.
@@ -11,7 +11,7 @@ import type { IndexerHost } from './indexer';
  */
 
 function isIndexing(status: WorkspaceIndexStatus): boolean {
-  return status === 'queued' || status === 'building' || status === 'updating';
+  return status === 'queued' || status === 'building' || status === 'updating' || status === 'naming';
 }
 
 export interface SyncResult {

--- a/plugins/sero-graphify-plugin/shared/pricing.test.ts
+++ b/plugins/sero-graphify-plugin/shared/pricing.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { costUsd, estimateFromScan, formatEstimate, MODEL_ENV_VAR, priceFor } from './pricing';
+import {
+  costUsd,
+  estimateCommunityNaming,
+  estimateFromScan,
+  formatEstimate,
+  MODEL_ENV_VAR,
+  priceFor,
+} from './pricing';
 import type { GraphifyBackend, ModelChoice } from './types';
 
 const choice = (backend: ModelChoice['backend'], modelId: string, price?: ModelChoice['price']): ModelChoice =>
@@ -46,6 +53,22 @@ describe('estimateFromScan', () => {
 
   it('has no cost at all without a chosen model', () => {
     expect(estimateFromScan({ files: 1, bytes: 100, truncated: false }, null).estimatedCostUsd).toBeNull();
+  });
+});
+
+describe('estimateCommunityNaming', () => {
+  it('scales from the measured community count and batch shape', () => {
+    const small = estimateCommunityNaming(10, choice('openai', 'gpt-4.1-mini'));
+    const large = estimateCommunityNaming(110, choice('openai', 'gpt-4.1-mini'));
+    expect(small.estimatedInputTokens).toBe(2_100);
+    expect(small.estimatedOutputTokens).toBe(736);
+    expect(large.estimatedInputTokens).toBe(22_200);
+    expect(large.estimatedOutputTokens).toBe(5_792);
+    expect(large.estimatedCostUsd!).toBeGreaterThan(small.estimatedCostUsd!);
+  });
+
+  it('does not invent a cost for an unpriced model', () => {
+    expect(estimateCommunityNaming(12, choice('openai', 'gpt-5.6-luna')).estimatedCostUsd).toBeNull();
   });
 });
 

--- a/plugins/sero-graphify-plugin/shared/pricing.ts
+++ b/plugins/sero-graphify-plugin/shared/pricing.ts
@@ -47,6 +47,18 @@ export const BYTES_PER_TOKEN = 4;
  */
 const OUTPUT_TOKEN_RATIO = 0.2;
 
+/**
+ * graphify 0.9.47 labels at most 100 communities per request. Each prompt row
+ * contains up to 12 labels of 60 characters, and each response asks for a
+ * short JSON name. These constants reserve the documented upper shape rather
+ * than an invented percentage of the extraction cost.
+ */
+const NAMING_BATCH_SIZE = 100;
+const NAMING_PROMPT_TOKENS_PER_BATCH = 100;
+const NAMING_INPUT_TOKENS_PER_COMMUNITY = 200;
+const NAMING_OUTPUT_TOKENS_PER_BATCH = 256;
+const NAMING_OUTPUT_TOKENS_PER_COMMUNITY = 48;
+
 export function estimateFromScan(
   scan: { files: number; bytes: number; truncated: boolean; unsupportedPatterns?: string[] },
   choice: ModelChoice | null,
@@ -59,7 +71,25 @@ export function estimateFromScan(
     truncated: scan.truncated,
     unsupportedPatterns: scan.unsupportedPatterns,
     estimatedInputTokens,
+    estimatedOutputTokens: outputTokens,
     estimatedCostUsd: choice ? costUsd(choice, estimatedInputTokens, outputTokens) : null,
+  };
+}
+
+/** Price the separate label pass from the community count already measured. */
+export function estimateCommunityNaming(communities: number, choice: ModelChoice | null): BuildEstimate {
+  const batches = Math.ceil(communities / NAMING_BATCH_SIZE);
+  const estimatedInputTokens = communities * NAMING_INPUT_TOKENS_PER_COMMUNITY
+    + batches * NAMING_PROMPT_TOKENS_PER_BATCH;
+  const estimatedOutputTokens = communities * NAMING_OUTPUT_TOKENS_PER_COMMUNITY
+    + batches * NAMING_OUTPUT_TOKENS_PER_BATCH;
+  return {
+    files: 0,
+    bytes: 0,
+    truncated: false,
+    estimatedInputTokens,
+    estimatedOutputTokens,
+    estimatedCostUsd: choice ? costUsd(choice, estimatedInputTokens, estimatedOutputTokens) : null,
   };
 }
 
@@ -74,6 +104,18 @@ export function formatEstimate(estimate: BuildEstimate, choice: ModelChoice | nu
     ? `cost unknown for ${choice ? choice.modelId : 'this model'}`
     : `~${formatUsd(estimate.estimatedCostUsd)}`;
   return `${estimate.files} files · ${mb} MB · ~${tokens} · ${cost}`;
+}
+
+export function formatCommunityNamingEstimate(
+  communities: number,
+  estimate: BuildEstimate,
+  choice: ModelChoice,
+): string {
+  const cost = estimate.estimatedCostUsd === null
+    ? `cost unknown for ${choice.modelId}`
+    : `~${formatUsd(estimate.estimatedCostUsd)}`;
+  const tokens = estimate.estimatedInputTokens + estimate.estimatedOutputTokens;
+  return `${communities} communities · up to ~${Math.round(tokens / 1000)}k tokens · ${cost}`;
 }
 
 /**

--- a/plugins/sero-graphify-plugin/shared/types.ts
+++ b/plugins/sero-graphify-plugin/shared/types.ts
@@ -95,11 +95,23 @@ export interface WorkspaceIndexStats {
   graphifyVersion?: string;
 }
 
+/** Measured result of the separate paid community-naming job. */
+export interface CommunityNamingStats {
+  communities: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd?: number;
+  model: string;
+  backend: GraphifyBackend;
+  namedAt: string;
+}
+
 export type WorkspaceIndexStatus =
   | 'idle'
   | 'queued'
   | 'building'
   | 'updating'
+  | 'naming'
   | 'error'
   /** Enabled, but no graph on disk. Waits for the user — a restart never spends. */
   | 'needs-build';
@@ -113,7 +125,9 @@ export interface WorkspaceIndexEntry {
   lastBuiltAt?: string;
   lastError?: string;
   stats?: WorkspaceIndexStats;
-  /** Latest build progress line; only set while building/updating. */
+  /** Present after the user separately approves AI-generated community names. */
+  communityNaming?: CommunityNamingStats;
+  /** Latest job progress line; only set while building, updating or naming. */
   progress?: string;
   /** Last time any job ran for this workspace, successful or not. */
   lastAttemptAt?: string;
@@ -130,6 +144,7 @@ export interface BuildEstimate {
   /** True when the scan stopped at the file cap — the real tree is larger. */
   truncated: boolean;
   estimatedInputTokens: number;
+  estimatedOutputTokens: number;
   /** Null when no price is known for the chosen model — never guess. */
   estimatedCostUsd: number | null;
   /**
@@ -143,6 +158,8 @@ export interface SpendRun {
   /** Identifies the attempt, so a reservation can be settled or kept. */
   id: string;
   workspaceId: string;
+  /** The paid operation, so extraction and naming stay distinct in the ledger. */
+  job: 'build' | 'community-naming';
   backend: GraphifyBackend;
   model: string;
   inputTokens: number;
@@ -179,7 +196,7 @@ export interface RemovedWorkspaceRecord {
   stats?: WorkspaceIndexStats;
 }
 
-export type IndexAction = 'enable' | 'disable' | 'rebuild' | 'refresh' | 'enable-all' | 'sync' | 'upgrade' | 'settings';
+export type IndexAction = 'enable' | 'disable' | 'rebuild' | 'refresh' | 'name-communities' | 'enable-all' | 'sync' | 'upgrade' | 'settings';
 
 /**
  * A settings change, queued rather than written.

--- a/plugins/sero-graphify-plugin/ui/GraphifySettings.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifySettings.tsx
@@ -91,7 +91,7 @@ export function SpendSettings({ state, onConfigure }: Props) {
   return (
     <Card className="flex flex-col gap-3 border-border/40 p-3">
       <div className="grid grid-cols-3 gap-2">
-        <NumberField key={`build-${caps.maxCostPerBuildUsd}`} label="Max per build" value={caps.maxCostPerBuildUsd} onCommit={(value) => onConfigure({ maxCostPerBuildUsd: value })} step="0.5" />
+        <NumberField key={`build-${caps.maxCostPerBuildUsd}`} label="Max per job" value={caps.maxCostPerBuildUsd} onCommit={(value) => onConfigure({ maxCostPerBuildUsd: value })} step="0.5" />
         <NumberField key={`day-${caps.maxCostPerDayUsd}`} label="Max per day" value={caps.maxCostPerDayUsd} onCommit={(value) => onConfigure({ maxCostPerDayUsd: value })} step="1" />
         <NumberField key={`files-${caps.maxFilesPerBuild}`} label="Max files" value={caps.maxFilesPerBuild} onCommit={(value) => onConfigure({ maxFilesPerBuild: value })} step="500" />
       </div>
@@ -130,4 +130,3 @@ function NumberField({ label, value, onCommit, step }: { label: string; value: n
     </div>
   );
 }
-

--- a/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
+++ b/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
@@ -8,6 +8,7 @@ function statusBadge(entry: WorkspaceIndexEntry) {
   switch (entry.status) {
     case 'building': return <Badge>building…</Badge>;
     case 'updating': return <Badge>updating…</Badge>;
+    case 'naming': return <Badge>naming…</Badge>;
     case 'queued': return <Badge variant="secondary">queued</Badge>;
     case 'needs-build': return <Badge variant="outline">not built</Badge>;
     case 'error': return <Badge variant="destructive">error</Badge>;
@@ -33,12 +34,13 @@ interface Props {
   entry: WorkspaceIndexEntry;
   /** True while no model is chosen — every paid action is unavailable. */
   blocked: boolean;
-  onIndex: (action: 'enable' | 'disable' | 'rebuild') => void;
+  onIndex: (action: 'enable' | 'disable' | 'rebuild' | 'name-communities') => void;
 }
 
 export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
   const stats = statsLine(entry);
-  const building = entry.status === 'building' || entry.status === 'updating';
+  const building = entry.status === 'building' || entry.status === 'updating' || entry.status === 'naming';
+  const canName = entry.enabled && (entry.stats?.communities ?? 0) > 0;
 
   return (
     <Card className="flex flex-row items-center justify-between border-border/40 p-3">
@@ -49,6 +51,12 @@ export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
         </div>
         <p className="truncate text-xs text-muted-foreground">{entry.path}</p>
         {stats && <p className="text-xs text-muted-foreground">{stats}</p>}
+        {entry.communityNaming && (
+          <p className="text-xs text-muted-foreground">
+            {entry.communityNaming.communities} communities named with {entry.communityNaming.model}
+            {entry.communityNaming.costUsd !== undefined ? ` · ${formatUsd(entry.communityNaming.costUsd)}` : ''}
+          </p>
+        )}
         {entry.progress && building && (
           <p className="truncate text-xs text-muted-foreground animate-pulse" title={entry.progress}>{entry.progress}</p>
         )}
@@ -60,6 +68,16 @@ export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
         {entry.enabled && (entry.status === 'needs-build' || entry.status === 'error') && (
           <Button size="sm" variant="outline" disabled={blocked} onClick={() => onIndex('rebuild')}>
             {entry.status === 'error' ? 'Try again' : 'Build'}
+          </Button>
+        )}
+        {canName && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={blocked || building}
+            onClick={() => onIndex('name-communities')}
+          >
+            {entry.communityNaming ? 'Rename communities' : 'Name communities'}
           </Button>
         )}
         <Button

--- a/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
+++ b/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
@@ -39,7 +39,8 @@ interface Props {
 
 export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
   const stats = statsLine(entry);
-  const building = entry.status === 'building' || entry.status === 'updating' || entry.status === 'naming';
+  const building = entry.status === 'queued' || entry.status === 'building'
+    || entry.status === 'updating' || entry.status === 'naming';
   const canName = entry.enabled && (entry.stats?.communities ?? 0) > 0;
 
   return (


### PR DESCRIPTION
## Summary

- add community naming as a separate paid `graphify label` job
- estimate the job from the measured community count
- show the selected model and estimate before every naming run
- reserve the estimate at the process spawn boundary and settle it from `GRAPH_REPORT.md` token usage
- keep a failed naming reservation without making the existing graph unusable
- add the workspace action, status, cost details, tests, prototype, and user documentation

## Spend decision

An unpriced model still requires confirmation. Sero does not add a token cap because Graphify has no total-token stop. Its `--token-budget` option controls each chunk and is not a spend cap. A user can supply the model price when cost limits must apply.

## Scope of #386

This PR implements community naming and records the unpriced-model decision. It does not close #386:

- the two-build Graphify 0.9.47 smoke test still needs a configured model credential
- the upstream report remains a human action, as the issue requires

## Validation

- `git diff --check` passes
- all touched TypeScript source files stay below 500 lines
- local tests and the full typecheck could not run because this clean sandbox has no installed workspace dependencies and cannot access the package registry; repository CI is the verification path

Refs #386