### PR TITLE
fix(graphify): force clean code-only rebuilds

### DIFF
--- a/.agents/skills/sero-code-review/SKILL.md
+++ b/.agents/skills/sero-code-review/SKILL.md
@@ -52,16 +52,7 @@ things. Each round must move towards a verdict, never away from one.
   fixed / changed), then the new ones.
 - Lead with the verdict, then the blocking findings, then the non-blocking notes.
 
-## 4. Second pass before posting
-
-Perform a fresh second pass with the review tools available in the current
-environment. Re-read the changed logic and verify each proposed finding against
-the source. Do not depend on a specific model, agent, or editor-only skill.
-
-Reconcile the second pass with the first **before** the comment goes up. A wrong finding corrected in session costs nothing; corrected on the PR it costs a round
-trip and the reader's trust.
-
-## 5. Scope
+## 4. Scope
 
 - Review when the branch is ready, not on every push, unless asked for a mid-flight pass.
 - Check type safety, the 500 LOC file limit, and whether `apps/docs-site` and `docs/prototypes` needed an update.

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -82,6 +82,7 @@ Graphify stores profile data under `<SERO_HOME>/apps/graphify/`:
 
 - `state.json` contains settings, each workspace indexing-mode version, and queued requests.
 - `graphs/<workspace-id>/graphify-out/` contains each workspace graph.
+- `graph-rebuilds/` temporarily holds clean rebuilds and recovery copies. On the next rebuild, Graphify removes old temporary builds and restores an old recovery copy if its active graph is missing.
 - `profile/graph.json` contains the merged graph.
 
 Graph artifacts do not enter your repositories.

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -35,11 +35,17 @@ Graphify installs its Python tools in Sero's shared machine tool area. It does n
 
 ## Check and update the graph
 
-Each workspace card shows its state, node and edge counts, and Graphify version. Use the **Rebuild** icon when a graph is not correct or after you update Graphify.
+Each workspace card shows its state, node and edge counts, and Graphify version. Use the **Rebuild** icon when a graph is not correct or after you update Graphify. A rebuild starts from an empty temporary graph and uses `--force --code-only`. Graphify replaces the current workspace graph only after extraction and clustering finish. If the rebuild fails, Sero keeps the current workspace graph and merged profile graph.
 
 Graphify queues a local AST update after an agent edits files in an enabled workspace. It also runs an update when Sero starts, so it can include changes made while Sero was closed.
 
 If no indexed file changed, Graphify keeps the current graph and skips clustering and the profile merge.
+
+### One-time code-only migration
+
+Graphs created before Sero changed Graphify to code-only indexing can contain old document, PDF, image, or media nodes. Sero detects these graphs from their missing indexing-mode version. It stops automatic refresh for the affected workspace and shows **clean rebuild needed**.
+
+Select **Rebuild** once. This local rebuild removes the old graph and creates a code-only graph. It makes no model calls and needs no API key. After it succeeds, Sero records the current indexing-mode version and automatic refresh starts again.
 
 A restart does not repeat an incomplete build. A workspace with no graph shows **not built** and waits for you. A failed build shows **error** with a **Try again** button.
 
@@ -74,7 +80,7 @@ Graphify can also add graph context to an agent session. Session orientation and
 
 Graphify stores profile data under `<SERO_HOME>/apps/graphify/`:
 
-- `state.json` contains settings, workspace state, and queued requests.
+- `state.json` contains settings, each workspace indexing-mode version, and queued requests.
 - `graphs/<workspace-id>/graphify-out/` contains each workspace graph.
 - `profile/graph.json` contains the merged graph.
 

--- a/docs/prototypes/graphify-free-code-indexing.html
+++ b/docs/prototypes/graphify-free-code-indexing.html
@@ -110,6 +110,21 @@ code{color:var(--text)}
   <p class="note">The card shows graph size and tool version. It does not show model, token, or cost fields because the code graph made no model call.</p>
 </div>
 
+<h2>One-time clean rebuild</h2>
+<div class="row">
+  <div class="panel">
+    <div class="card between">
+      <div>
+        <div class="left"><span class="name">legacy-app</span><span class="badge">clean rebuild needed</span></div>
+        <div class="path">~/code/legacy-app</div>
+        <div class="stats">Graph created before code-only indexing</div>
+      </div>
+      <div class="actions"><button class="button">Rebuild</button><span class="switch on"></span></div>
+    </div>
+  </div>
+  <p class="note">Sero pauses incremental refresh until one forced code-only rebuild succeeds. A failed rebuild keeps the existing workspace and profile graphs.</p>
+</div>
+
 <h2>Failure waits for the user</h2>
 <div class="row">
   <div class="panel">

--- a/plugins/sero-graphify-plugin/extension/auto-context/graph-state.test.ts
+++ b/plugins/sero-graphify-plugin/extension/auto-context/graph-state.test.ts
@@ -4,8 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { detectGraphArtifacts } from './graph-state';
 import { graphifyPathsFromHome } from '../../shared/paths';
-import { writeStateFile } from '../../shared/state-io';
-import { DEFAULT_STATE, type GraphifyState } from '../../shared/types';
+import { readStateFile, writeStateFile } from '../../shared/state-io';
+import { CURRENT_INDEX_MODE_VERSION, DEFAULT_STATE, type GraphifyState } from '../../shared/types';
 
 const FIXTURE = path.join(__dirname, '..', '..', 'shared', 'query-engine', 'fixtures', 'small-graph.json');
 
@@ -15,7 +15,10 @@ async function makeHome(options: { workspaceGraph?: boolean; report?: boolean; p
   const state: GraphifyState = {
     ...structuredClone(DEFAULT_STATE),
     workspaces: {
-      ws1: { workspaceId: 'ws1', name: 'One', path: options.cwd, enabled: true, status: 'idle' },
+      ws1: {
+        workspaceId: 'ws1', name: 'One', path: options.cwd, enabled: true,
+        status: 'idle', indexModeVersion: CURRENT_INDEX_MODE_VERSION,
+      },
     },
   };
   await writeStateFile(paths.stateFile, state);
@@ -51,6 +54,23 @@ describe('detectGraphArtifacts', () => {
     const paths = await makeHome({ profileGraph: true, cwd });
     const info = await detectGraphArtifacts(paths, cwd);
     expect(info.graphExists).toBe(false);
+  });
+
+  it('stays absent while the workspace needs a clean rebuild', async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), 'graphify-ws-'));
+    const paths = await makeHome({ workspaceGraph: true, report: true, cwd });
+    const current = await readStateFile(paths.stateFile);
+    await writeStateFile(paths.stateFile, {
+      ...current!,
+      workspaces: {
+        ...current!.workspaces,
+        ws1: { ...current!.workspaces.ws1, indexModeVersion: undefined },
+      },
+    });
+
+    const info = await detectGraphArtifacts(paths, cwd);
+    expect(info.graphExists).toBe(false);
+    expect(info.reportExists).toBe(false);
   });
 
   it('stays absent for cwds that resolve to no workspace at all', async () => {

--- a/plugins/sero-graphify-plugin/extension/auto-context/graph-state.ts
+++ b/plugins/sero-graphify-plugin/extension/auto-context/graph-state.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import type { GraphifyPaths } from '../../shared/paths';
 import { workspaceGraphJson, workspaceGraphReport } from '../../shared/paths';
 import { readStateFile } from '../../shared/state-io';
+import { CURRENT_INDEX_MODE_VERSION } from '../../shared/types';
 import { resolveCurrentWorkspace } from '../current-workspace';
 import type { GraphContextState } from './state';
 
@@ -24,7 +25,7 @@ export interface GraphArtifactInfo {
 export async function detectGraphArtifacts(paths: GraphifyPaths, cwd: string): Promise<GraphArtifactInfo> {
   const state = await readStateFile(paths.stateFile);
   const entry = state ? resolveCurrentWorkspace(state, cwd) : null;
-  if (!entry) {
+  if (!entry || entry.indexModeVersion !== CURRENT_INDEX_MODE_VERSION) {
     return { graphPath: '', reportPath: '', graphExists: false, reportExists: false, graphSize: 0, reportSize: 0 };
   }
 

--- a/plugins/sero-graphify-plugin/extension/auto-context/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/auto-context/index.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { registerAutoContext } from './index';
 import { graphifyPathsFromHome, type GraphifyPaths } from '../../shared/paths';
 import { writeStateFile } from '../../shared/state-io';
-import { DEFAULT_STATE, type GraphifyState } from '../../shared/types';
+import { CURRENT_INDEX_MODE_VERSION, DEFAULT_STATE, type GraphifyState } from '../../shared/types';
 
 const FIXTURE = path.join(__dirname, '..', '..', 'shared', 'query-engine', 'fixtures', 'small-graph.json');
 
@@ -39,7 +39,10 @@ async function makeEnv(options: HomeOptions = {}) {
       autoContext: { ...structuredClone(DEFAULT_STATE.settings.autoContext), ...options.autoContext },
     },
     workspaces: {
-      ws1: { workspaceId: 'ws1', name: 'One', path: cwd, enabled: true, status: 'idle' },
+      ws1: {
+        workspaceId: 'ws1', name: 'One', path: cwd, enabled: true,
+        status: 'idle', indexModeVersion: CURRENT_INDEX_MODE_VERSION,
+      },
     },
   };
   await writeStateFile(paths.stateFile, state);

--- a/plugins/sero-graphify-plugin/extension/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/index.test.ts
@@ -1,10 +1,13 @@
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { readStateFile } from '../shared/state-io';
+import { graphifyPathsFromHome, workspaceGraphJson } from '../shared/paths';
+import { readStateFile, writeStateFile } from '../shared/state-io';
+import { CURRENT_INDEX_MODE_VERSION, DEFAULT_STATE, type GraphifyState } from '../shared/types';
 
 const originalSeroHome = process.env.SERO_HOME;
+const GRAPH_FIXTURE = path.join(__dirname, '..', 'shared', 'query-engine', 'fixtures', 'small-graph.json');
 
 afterEach(() => {
   vi.resetModules();
@@ -13,6 +16,64 @@ afterEach(() => {
 });
 
 describe('graphify workspace creation indexing', () => {
+  it('does not query workspace or profile graphs from the old indexing mode', async () => {
+    const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-migration-'));
+    const cwd = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-workspace-'));
+    process.env.SERO_HOME = seroHome;
+
+    try {
+      const paths = graphifyPathsFromHome(path.join(seroHome, 'apps', 'graphify'));
+      const graphPath = workspaceGraphJson(paths, 'ws1');
+      await mkdir(path.dirname(graphPath), { recursive: true });
+      await mkdir(paths.profileDir, { recursive: true });
+      await Promise.all([copyFile(GRAPH_FIXTURE, graphPath), copyFile(GRAPH_FIXTURE, paths.profileGraph)]);
+      const legacyState = {
+        ...structuredClone(DEFAULT_STATE),
+        workspaces: {
+          ws1: {
+            workspaceId: 'ws1', name: 'One', path: cwd, enabled: true,
+            status: 'needs-build', lastBuiltAt: 'yesterday',
+          },
+        },
+        profileGraph: { status: 'ready', workspaceIds: ['ws1'] },
+      } satisfies GraphifyState;
+      await writeStateFile(paths.stateFile, legacyState);
+
+      type RegisteredTool = { name: string; execute: (...args: unknown[]) => Promise<unknown> };
+      const registeredTools: RegisteredTool[] = [];
+      const pi = { registerTool: vi.fn((tool: RegisteredTool) => registeredTools.push(tool)), on: vi.fn() };
+      const { default: registerGraphify } = await import('./index');
+      registerGraphify(pi as never);
+      const queryTool = registeredTools.find((tool) => tool.name === 'graphify_query');
+
+      const result = await queryTool!.execute('call-1', { question: 'authentication' }, undefined, undefined, { cwd });
+      expect(result).toMatchObject({
+        content: [{ text: expect.stringMatching(/^Profile graph not built yet/) }],
+      });
+
+      await writeStateFile(paths.stateFile, {
+        ...legacyState,
+        workspaces: {
+          ws1: { ...legacyState.workspaces.ws1, indexModeVersion: CURRENT_INDEX_MODE_VERSION },
+        },
+      });
+      const currentResult = await queryTool!.execute('call-2', { question: 'authentication' }, undefined, undefined, { cwd });
+      expect(currentResult).toMatchObject({
+        content: [{ text: expect.stringMatching(/^Traversal:/) }],
+      });
+      const searchTool = registeredTools.find((tool) => tool.name === 'graphify_search');
+      const searchResult = await searchTool!.execute('call-3', { question: 'authentication' });
+      expect(searchResult).toMatchObject({
+        content: [{ text: expect.stringMatching(/^Traversal:/) }],
+      });
+    } finally {
+      await Promise.all([
+        rm(seroHome, { recursive: true, force: true }),
+        rm(cwd, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
   it('queues an enable by id and never carries a path', async () => {
     const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-'));
     process.env.SERO_HOME = seroHome;

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -11,10 +11,10 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
-import { resolveGraphifyPaths, workspaceGraphJson } from '../shared/paths';
+import { resolveGraphifyPaths, workspaceGraphJson, type GraphifyPaths } from '../shared/paths';
 import { readStateFile, appendIndexRequest, appendSettingsRequest } from '../shared/state-io';
-import { loadGraphResult, queryGraph, searchGraph, findPath, explainNode, type GraphLoadFailure } from '../shared/query-engine';
-import type { SettingsPatch } from '../shared/types';
+import { loadGraphResult, queryGraph, searchGraph, findPath, explainNode, type GraphLoadFailure, type GraphLoadResult } from '../shared/query-engine';
+import { CURRENT_INDEX_MODE_VERSION, type GraphifyState, type SettingsPatch } from '../shared/types';
 import { resolveCurrentWorkspace } from './current-workspace';
 import { registerAutoContext } from './auto-context';
 import { registerRefreshOnEdit } from './refresh-on-edit';
@@ -42,6 +42,19 @@ function unavailableMessage(failure: GraphLoadFailure, detail?: string): string 
   }
 }
 
+function profileUsesCurrentIndexMode(state: GraphifyState | null): boolean {
+  const ids = state?.profileGraph.workspaceIds;
+  return state?.profileGraph.status === 'ready'
+    && Array.isArray(ids)
+    && ids.every((id) => state.workspaces[id]?.indexModeVersion === CURRENT_INDEX_MODE_VERSION);
+}
+
+async function loadCurrentProfileGraph(paths: GraphifyPaths): Promise<GraphLoadResult> {
+  const state = await readStateFile(paths.stateFile);
+  if (!profileUsesCurrentIndexMode(state)) return { failure: 'absent' };
+  return loadGraphResult(paths.profileGraph);
+}
+
 export default function graphifyExtension(pi: ExtensionAPI): void {
   const paths = resolveGraphifyPaths();
 
@@ -55,7 +68,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       budget: Type.Optional(Type.Number({ description: 'Max answer tokens (default 1200)' })),
     }),
     async execute(_toolCallId, params) {
-      const result = await loadGraphResult(paths.profileGraph);
+      const result = await loadCurrentProfileGraph(paths);
       if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
       const { text: answer, files } = searchGraph(result.graph, params.question, { mode: params.mode, budget: params.budget });
       // `files` rides on `details` (UI-only) so the search panel can open them;
@@ -75,9 +88,10 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const state = await readStateFile(paths.stateFile);
-      const entry = state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
+      const resolved = state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
+      const entry = resolved?.indexModeVersion === CURRENT_INDEX_MODE_VERSION ? resolved : null;
       const graphPath = entry ? workspaceGraphJson(paths, entry.workspaceId) : paths.profileGraph;
-      const primary = await loadGraphResult(graphPath);
+      const primary = entry ? await loadGraphResult(graphPath) : await loadCurrentProfileGraph(paths);
       if ('graph' in primary) return text(queryGraph(primary.graph, params.question, { mode: params.mode, budget: params.budget }));
       // Fall back to the profile graph only when the workspace simply has no graph
       // of its own. A built-but-unreadable workspace graph (too-large/invalid)
@@ -85,7 +99,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       if (primary.failure !== 'absent' || graphPath === paths.profileGraph) {
         return text(unavailableMessage(primary.failure, primary.detail));
       }
-      const fallback = await loadGraphResult(paths.profileGraph);
+      const fallback = await loadCurrentProfileGraph(paths);
       if ('graph' in fallback) return text(queryGraph(fallback.graph, params.question, { mode: params.mode, budget: params.budget }));
       return text(unavailableMessage(fallback.failure, fallback.detail));
     },
@@ -100,7 +114,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       to: Type.String({ description: 'Target concept name or node id' }),
     }),
     async execute(_toolCallId, params) {
-      const result = await loadGraphResult(paths.profileGraph);
+      const result = await loadCurrentProfileGraph(paths);
       if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
       return text(findPath(result.graph, params.from, params.to));
     },
@@ -114,7 +128,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       concept: Type.String({ description: 'Concept name or node id to explain' }),
     }),
     async execute(_toolCallId, params) {
-      const result = await loadGraphResult(paths.profileGraph);
+      const result = await loadCurrentProfileGraph(paths);
       if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
       return text(explainNode(result.graph, params.concept));
     },

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
-import { buildWorkspaceGraph, mergeProfileGraph, parseBuildStats, ensureGraphifyIgnore, rebuildWorkspaceGraph } from './graphify-runner';
+import { mkdir, mkdtemp, readFile, readdir, utimes, writeFile } from 'node:fs/promises';
+import { buildWorkspaceGraph, cleanupStaleRebuilds, mergeProfileGraph, parseBuildStats, ensureGraphifyIgnore, rebuildWorkspaceGraph } from './graphify-runner';
 import type { BuildOptions } from './graphify-runner';
 import type { ExecResult } from './bounded-exec';
 
@@ -20,6 +20,7 @@ const ok = (stdout = ''): ExecResult => ({ stdout, stderr: '', exitCode: 0, trun
 function buildOpts(overrides: Partial<BuildOptions> = {}): BuildOptions {
   return {
     workspaceDir: STORE,
+    rebuildsDir: path.join(os.tmpdir(), 'graphify-runner-test', 'graph-rebuilds'),
     inputPath: '/p',
     exclude: [],
     ...overrides,
@@ -162,7 +163,7 @@ describe('rebuildWorkspaceGraph', () => {
 
     await rebuildWorkspaceGraph(
       { exec, graphifyPath: 'g', env: {} },
-      buildOpts({ workspaceDir }),
+      buildOpts({ workspaceDir, rebuildsDir: path.join(parent, 'graph-rebuilds') }),
     );
 
     expect(exec.mock.calls[0][1]).toEqual([
@@ -181,11 +182,41 @@ describe('rebuildWorkspaceGraph', () => {
 
     await expect(rebuildWorkspaceGraph(
       { exec, graphifyPath: 'g', env: {} },
-      buildOpts({ workspaceDir }),
+      buildOpts({ workspaceDir, rebuildsDir: path.join(parent, 'graph-rebuilds') }),
     )).rejects.toThrow(/extract failed/);
 
     expect(await readFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'utf8')).toBe('valid-profile-source');
     expect(await readdir(path.join(parent, 'graph-rebuilds'))).toEqual([]);
+  });
+
+  it('removes old recovery directories but keeps recent ones', async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-rebuild-cleanup-'));
+    const graphsDir = path.join(parent, 'graphs');
+    const oldDir = path.join(parent, 'ws1.rebuild-old');
+    const recentDir = path.join(parent, 'ws1.rebuild-recent');
+    await Promise.all([mkdir(oldDir), mkdir(recentDir)]);
+    const now = Date.now();
+    await utimes(oldDir, new Date(now - 25 * 60 * 60_000), new Date(now - 25 * 60 * 60_000));
+
+    await cleanupStaleRebuilds(parent, graphsDir, now);
+
+    expect(await readdir(parent)).toEqual(['ws1.rebuild-recent']);
+  });
+
+  it('restores a stale backup when the active workspace graph is missing', async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-backup-recovery-'));
+    const rebuildsDir = path.join(parent, 'graph-rebuilds');
+    const graphsDir = path.join(parent, 'graphs');
+    const backupDir = path.join(rebuildsDir, 'ws1.backup-old');
+    await mkdir(backupDir, { recursive: true });
+    await writeFile(path.join(backupDir, 'valid'), 'graph');
+    const now = Date.now();
+    await utimes(backupDir, new Date(now - 25 * 60 * 60_000), new Date(now - 25 * 60 * 60_000));
+
+    await cleanupStaleRebuilds(rebuildsDir, graphsDir, now);
+
+    expect(await readFile(path.join(graphsDir, 'ws1', 'valid'), 'utf8')).toBe('graph');
+    expect(await readdir(rebuildsDir)).toEqual([]);
   });
 });
 

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
-import { buildWorkspaceGraph, mergeProfileGraph, parseBuildStats, ensureGraphifyIgnore } from './graphify-runner';
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { buildWorkspaceGraph, mergeProfileGraph, parseBuildStats, ensureGraphifyIgnore, rebuildWorkspaceGraph } from './graphify-runner';
 import type { BuildOptions } from './graphify-runner';
 import type { ExecResult } from './bounded-exec';
 
@@ -59,6 +60,13 @@ describe('buildWorkspaceGraph', () => {
     // Report generation runs against the store dir (where graphify-out/ lives).
     const [, reportArgs] = exec.mock.calls[1];
     expect(reportArgs).toEqual(['cluster-only', STORE, '--no-viz']);
+  });
+
+  it('keeps incremental refresh arguments free of --force', async () => {
+    const exec = vi.fn().mockResolvedValue(ok(EXTRACT_STDOUT));
+    await buildWorkspaceGraph({ exec, graphifyPath: 'g', env: {} }, buildOpts());
+
+    expect(exec.mock.calls[0][1]).not.toContain('--force');
   });
 
   it('redirects the extraction cache into the store dir via GRAPHIFY_OUT', async () => {
@@ -138,9 +146,51 @@ describe('buildWorkspaceGraph', () => {
   });
 });
 
+describe('rebuildWorkspaceGraph', () => {
+  it('passes --force and replaces the active graph after clustering succeeds', async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-rebuild-'));
+    const workspaceDir = path.join(parent, 'ws1');
+    await mkdir(path.join(workspaceDir, 'graphify-out'), { recursive: true });
+    await writeFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'old');
+    const exec = vi.fn().mockImplementation(async (_cmd, args, options) => {
+      if (args[0] === 'extract') {
+        await mkdir(path.join(options.cwd, 'graphify-out'), { recursive: true });
+        await writeFile(path.join(options.cwd, 'graphify-out', 'graph.json'), 'clean-code-only');
+      }
+      return ok(EXTRACT_STDOUT);
+    });
+
+    await rebuildWorkspaceGraph(
+      { exec, graphifyPath: 'g', env: {} },
+      buildOpts({ workspaceDir }),
+    );
+
+    expect(exec.mock.calls[0][1]).toEqual([
+      'extract', '/p', '--force', '--code-only', '--no-cluster', '--out', expect.stringContaining('.rebuild-'),
+    ]);
+    expect(await readFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'utf8')).toBe('clean-code-only');
+    expect((await readdir(parent)).filter((name) => name.includes('.rebuild-') || name.includes('.backup-'))).toEqual([]);
+  });
+
+  it('keeps the active graph when clean extraction fails', async () => {
+    const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-rebuild-fail-'));
+    const workspaceDir = path.join(parent, 'ws1');
+    await mkdir(path.join(workspaceDir, 'graphify-out'), { recursive: true });
+    await writeFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'valid-profile-source');
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: 'extract failed', exitCode: 1, truncated: false });
+
+    await expect(rebuildWorkspaceGraph(
+      { exec, graphifyPath: 'g', env: {} },
+      buildOpts({ workspaceDir }),
+    )).rejects.toThrow(/extract failed/);
+
+    expect(await readFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'utf8')).toBe('valid-profile-source');
+    expect((await readdir(parent)).filter((name) => name.includes('.rebuild-'))).toEqual([]);
+  });
+});
+
 describe('ensureGraphifyIgnore', () => {
   it('creates .graphifyignore with all Sero internals in the workspace', async () => {
-    const { mkdtemp, readFile } = await import('node:fs/promises');
     const ws = await mkdtemp(path.join(os.tmpdir(), 'graphify-ws-'));
     await ensureGraphifyIgnore(ws);
     const content = await readFile(path.join(ws, '.graphifyignore'), 'utf8');
@@ -149,7 +199,6 @@ describe('ensureGraphifyIgnore', () => {
   });
 
   it('appends to an existing ignore file without clobbering it', async () => {
-    const { mkdtemp, readFile, writeFile } = await import('node:fs/promises');
     const ws = await mkdtemp(path.join(os.tmpdir(), 'graphify-ws-'));
     await writeFile(path.join(ws, '.graphifyignore'), 'custom-dir/\n');
     await ensureGraphifyIgnore(ws);
@@ -160,7 +209,6 @@ describe('ensureGraphifyIgnore', () => {
   });
 
   it('tops up files written by older versions with newly required entries', async () => {
-    const { mkdtemp, readFile, writeFile } = await import('node:fs/promises');
     const ws = await mkdtemp(path.join(os.tmpdir(), 'graphify-ws-'));
     await writeFile(path.join(ws, '.graphifyignore'), '# Added by Sero Graphify: keep Sero workspace internals out of the knowledge graph\n.sero/\n');
     await ensureGraphifyIgnore(ws);
@@ -170,7 +218,6 @@ describe('ensureGraphifyIgnore', () => {
   });
 
   it('is idempotent and never throws on bad paths', async () => {
-    const { mkdtemp, readFile } = await import('node:fs/promises');
     const ws = await mkdtemp(path.join(os.tmpdir(), 'graphify-ws-'));
     await ensureGraphifyIgnore(ws);
     const first = await readFile(path.join(ws, '.graphifyignore'), 'utf8');
@@ -188,7 +235,6 @@ describe('mergeProfileGraph', () => {
   });
 
   it('copies the single graph when only one workspace is indexed (merge-graphs needs two)', async () => {
-    const { mkdtemp, mkdir, writeFile, readFile } = await import('node:fs/promises');
     const dir = await mkdtemp(path.join(os.tmpdir(), 'graphify-merge-'));
     const source = path.join(dir, 'ws1', 'graph.json');
     await mkdir(path.dirname(source), { recursive: true });

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.test.ts
@@ -149,7 +149,7 @@ describe('buildWorkspaceGraph', () => {
 describe('rebuildWorkspaceGraph', () => {
   it('passes --force and replaces the active graph after clustering succeeds', async () => {
     const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-rebuild-'));
-    const workspaceDir = path.join(parent, 'ws1');
+    const workspaceDir = path.join(parent, 'graphs', 'ws1');
     await mkdir(path.join(workspaceDir, 'graphify-out'), { recursive: true });
     await writeFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'old');
     const exec = vi.fn().mockImplementation(async (_cmd, args, options) => {
@@ -169,12 +169,12 @@ describe('rebuildWorkspaceGraph', () => {
       'extract', '/p', '--force', '--code-only', '--no-cluster', '--out', expect.stringContaining('.rebuild-'),
     ]);
     expect(await readFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'utf8')).toBe('clean-code-only');
-    expect((await readdir(parent)).filter((name) => name.includes('.rebuild-') || name.includes('.backup-'))).toEqual([]);
+    expect(await readdir(path.join(parent, 'graph-rebuilds'))).toEqual([]);
   });
 
   it('keeps the active graph when clean extraction fails', async () => {
     const parent = await mkdtemp(path.join(os.tmpdir(), 'graphify-rebuild-fail-'));
-    const workspaceDir = path.join(parent, 'ws1');
+    const workspaceDir = path.join(parent, 'graphs', 'ws1');
     await mkdir(path.join(workspaceDir, 'graphify-out'), { recursive: true });
     await writeFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'valid-profile-source');
     const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: 'extract failed', exitCode: 1, truncated: false });
@@ -185,7 +185,7 @@ describe('rebuildWorkspaceGraph', () => {
     )).rejects.toThrow(/extract failed/);
 
     expect(await readFile(path.join(workspaceDir, 'graphify-out', 'graph.json'), 'utf8')).toBe('valid-profile-source');
-    expect((await readdir(parent)).filter((name) => name.includes('.rebuild-'))).toEqual([]);
+    expect(await readdir(path.join(parent, 'graph-rebuilds'))).toEqual([]);
   });
 });
 

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
@@ -1,4 +1,5 @@
-import { copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { WORKSPACE_COMMON_IGNORES } from '@sero-ai/common';
 import type { ExecFn } from './bounded-exec';
@@ -20,6 +21,8 @@ export interface BuildOptions {
   /** Receives graphify's progress lines as they stream. */
   onProgress?: (message: string) => void;
   exclude: string[];
+  /** Ignore an existing Graphify baseline and extract the code corpus again. */
+  force?: boolean;
 }
 
 const BUILD_TIMEOUT_MS = 60 * 60_000;
@@ -71,6 +74,7 @@ function buildArgs(options: BuildOptions): string[] {
   // default output is input-path-relative, which would pollute the workspace).
   const args = [
     'extract', options.inputPath,
+    ...(options.force ? ['--force'] : []),
     // Code extraction is deterministic Tree-sitter work. This also prevents
     // Graphify from sending workspace documents to a model.
     '--code-only',
@@ -81,6 +85,10 @@ function buildArgs(options: BuildOptions): string[] {
   ];
   for (const pattern of options.exclude) args.push('--exclude', pattern);
   return args;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  return access(target).then(() => true).catch(() => false);
 }
 
 /** Python block-buffers stdout when piped; unbuffered keeps progress lines live. */
@@ -155,6 +163,38 @@ export async function buildWorkspaceGraph(deps: RunnerDeps, options: BuildOption
       communities: cluster.communities || extraction.stats.communities,
     },
   };
+}
+
+/**
+ * Build in a sibling directory and replace the active graph only after both
+ * extraction and clustering finish. A failed clean rebuild leaves the graph
+ * used by the profile merge unchanged.
+ */
+export async function rebuildWorkspaceGraph(deps: RunnerDeps, options: BuildOptions): Promise<BuildOutcome> {
+  const stagingDir = `${options.workspaceDir}.rebuild-${randomUUID()}`;
+  const backupDir = `${options.workspaceDir}.backup-${randomUUID()}`;
+  let movedCurrent = false;
+  try {
+    const outcome = await buildWorkspaceGraph(deps, {
+      ...options,
+      workspaceDir: stagingDir,
+      force: true,
+    });
+    if (await pathExists(options.workspaceDir)) {
+      await rename(options.workspaceDir, backupDir);
+      movedCurrent = true;
+    }
+    try {
+      await rename(stagingDir, options.workspaceDir);
+    } catch (error) {
+      if (movedCurrent) await rename(backupDir, options.workspaceDir);
+      throw error;
+    }
+    if (movedCurrent) await rm(backupDir, { recursive: true, force: true });
+    return outcome;
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
 }
 
 /** Clustering, deterministic hub labels, and the report are always local. */

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, cp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { WORKSPACE_COMMON_IGNORES } from '@sero-ai/common';
@@ -18,6 +18,8 @@ export interface BuildOptions {
   workspaceDir: string;
   /** Workspace root host path (graphify input). */
   inputPath: string;
+  /** Recovery area outside graphs/, which the workspace artifact sweep owns. */
+  rebuildsDir: string;
   /** Receives graphify's progress lines as they stream. */
   onProgress?: (message: string) => void;
   exclude: string[];
@@ -26,6 +28,7 @@ export interface BuildOptions {
 }
 
 const BUILD_TIMEOUT_MS = 60 * 60_000;
+const STALE_REBUILD_MS = 24 * 60 * 60_000;
 
 function tail(text: string, max = 2000): string {
   return text.length > max ? `…${text.slice(-max)}` : text;
@@ -89,6 +92,34 @@ function buildArgs(options: BuildOptions): string[] {
 
 async function pathExists(target: string): Promise<boolean> {
   return access(target).then(() => true).catch(() => false);
+}
+
+/** Remove rebuilds left by killed processes without touching active work. */
+export async function cleanupStaleRebuilds(
+  rebuildsDir: string,
+  graphsDir: string,
+  now = Date.now(),
+): Promise<void> {
+  const entries = await readdir(rebuildsDir, { withFileTypes: true }).catch(() => []);
+  await Promise.all(entries.filter((entry) => entry.isDirectory()).map(async (entry) => {
+    const target = path.join(rebuildsDir, entry.name);
+    const info = await stat(target).catch(() => null);
+    if (!info || now - info.mtimeMs < STALE_REBUILD_MS) return;
+    if (entry.name.includes('.rebuild-')) {
+      await rm(target, { recursive: true, force: true });
+      return;
+    }
+    const backupMarker = entry.name.lastIndexOf('.backup-');
+    if (backupMarker < 1) return;
+    const activeGraph = path.join(graphsDir, entry.name.slice(0, backupMarker));
+    if (await pathExists(activeGraph)) {
+      await rm(target, { recursive: true, force: true });
+      return;
+    }
+    await mkdir(graphsDir, { recursive: true });
+    // Keep the backup if recovery still fails. A later rebuild can retry.
+    await rename(target, activeGraph).catch(() => undefined);
+  }));
 }
 
 /** Python block-buffers stdout when piped; unbuffered keeps progress lines live. */
@@ -174,12 +205,12 @@ export async function rebuildWorkspaceGraph(deps: RunnerDeps, options: BuildOpti
   // Keep recovery directories outside graphs/. Workspace artifact sweeps treat
   // every directory under graphs/ as a workspace id and can run in another
   // runtime process while this rebuild is active.
-  const recoveryRoot = path.join(path.dirname(path.dirname(options.workspaceDir)), 'graph-rebuilds');
   const workspaceName = path.basename(options.workspaceDir);
-  const stagingDir = path.join(recoveryRoot, `${workspaceName}.rebuild-${randomUUID()}`);
-  const backupDir = path.join(recoveryRoot, `${workspaceName}.backup-${randomUUID()}`);
+  const stagingDir = path.join(options.rebuildsDir, `${workspaceName}.rebuild-${randomUUID()}`);
+  const backupDir = path.join(options.rebuildsDir, `${workspaceName}.backup-${randomUUID()}`);
   let movedCurrent = false;
   try {
+    await cleanupStaleRebuilds(options.rebuildsDir, path.dirname(options.workspaceDir));
     const outcome = await buildWorkspaceGraph(deps, {
       ...options,
       workspaceDir: stagingDir,
@@ -192,7 +223,13 @@ export async function rebuildWorkspaceGraph(deps: RunnerDeps, options: BuildOpti
     try {
       await rename(stagingDir, options.workspaceDir);
     } catch (error) {
-      if (movedCurrent) await rename(backupDir, options.workspaceDir);
+      if (movedCurrent && !(await pathExists(options.workspaceDir))) {
+        await rename(backupDir, options.workspaceDir).catch(async () => {
+          // A second rename failure must not strand the only valid graph in
+          // recovery storage. Copying is slower but keeps the documented path.
+          await cp(backupDir, options.workspaceDir, { recursive: true, force: false, errorOnExist: true });
+        });
+      }
       throw error;
     }
     if (movedCurrent) await rm(backupDir, { recursive: true, force: true });

--- a/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
+++ b/plugins/sero-graphify-plugin/runtime/graphify-runner.ts
@@ -171,8 +171,13 @@ export async function buildWorkspaceGraph(deps: RunnerDeps, options: BuildOption
  * used by the profile merge unchanged.
  */
 export async function rebuildWorkspaceGraph(deps: RunnerDeps, options: BuildOptions): Promise<BuildOutcome> {
-  const stagingDir = `${options.workspaceDir}.rebuild-${randomUUID()}`;
-  const backupDir = `${options.workspaceDir}.backup-${randomUUID()}`;
+  // Keep recovery directories outside graphs/. Workspace artifact sweeps treat
+  // every directory under graphs/ as a workspace id and can run in another
+  // runtime process while this rebuild is active.
+  const recoveryRoot = path.join(path.dirname(path.dirname(options.workspaceDir)), 'graph-rebuilds');
+  const workspaceName = path.basename(options.workspaceDir);
+  const stagingDir = path.join(recoveryRoot, `${workspaceName}.rebuild-${randomUUID()}`);
+  const backupDir = path.join(recoveryRoot, `${workspaceName}.backup-${randomUUID()}`);
   let movedCurrent = false;
   try {
     const outcome = await buildWorkspaceGraph(deps, {

--- a/plugins/sero-graphify-plugin/runtime/host-adapter.ts
+++ b/plugins/sero-graphify-plugin/runtime/host-adapter.ts
@@ -78,6 +78,7 @@ export function createIndexerHost(ctx: AppRuntimeContext): { host: IndexerHost; 
 
   const buildOptionsFor = (workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings']) => ({
     workspaceDir: workspaceGraphDir(paths, workspace.workspaceId),
+    rebuildsDir: paths.rebuildsDir,
     inputPath: workspace.path,
     exclude: settings.exclude,
   });

--- a/plugins/sero-graphify-plugin/runtime/host-adapter.ts
+++ b/plugins/sero-graphify-plugin/runtime/host-adapter.ts
@@ -6,7 +6,7 @@ import { withStateDefaults } from '../shared/types';
 import { graphifyPathsFromHome, workspaceGraphDir, workspaceGraphJson, type GraphifyPaths } from '../shared/paths';
 import { boundedExec } from './bounded-exec';
 import { provisionGraphify, graphifyBinPath, uvEnv, GRAPHIFY_VERSION } from './provisioner';
-import { buildWorkspaceGraph, mergeProfileGraph as runMerge, type BuildOutcome } from './graphify-runner';
+import { buildWorkspaceGraph, mergeProfileGraph as runMerge, rebuildWorkspaceGraph, type BuildOutcome } from './graphify-runner';
 import { cleanEnv } from './credentials';
 import { graphStats, loadGraph } from '../shared/query-engine';
 import type { IndexerHost } from './indexer';
@@ -135,7 +135,7 @@ export function createIndexerHost(ctx: AppRuntimeContext): { host: IndexerHost; 
         openTarget: { appId: 'graphify' },
       }),
     buildGraph: async (workspace, settings, hooks) =>
-      withAuthoritativeStats(workspace.workspaceId, await buildWorkspaceGraph(await localDeps(), {
+      withAuthoritativeStats(workspace.workspaceId, await rebuildWorkspaceGraph(await localDeps(), {
         ...buildOptionsFor(workspace, settings),
         onProgress: hooks.onProgress,
       })),

--- a/plugins/sero-graphify-plugin/runtime/indexer.fixtures.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.fixtures.ts
@@ -1,7 +1,7 @@
 /** Shared harness for the indexer suites. */
 import { vi } from 'vitest';
 import { GraphifyIndexer, type IndexerHost } from './indexer';
-import { DEFAULT_STATE, type GraphifyState, type WorkspaceIndexStats } from '../shared/types';
+import { CURRENT_INDEX_MODE_VERSION, DEFAULT_STATE, type GraphifyState, type WorkspaceIndexStats } from '../shared/types';
 
 export const STATS: WorkspaceIndexStats = { nodes: 10, edges: 20, communities: 2, inputTokens: 0, outputTokens: 0 };
 
@@ -67,6 +67,6 @@ export async function deliver(
 export function enabled(state: GraphifyState, id: string, patch: Partial<GraphifyState['workspaces'][string]> = {}) {
   state.workspaces[id] = {
     workspaceId: id, name: id === 'ws1' ? 'One' : 'Two', path: `/p/${id}`,
-    enabled: true, status: 'idle', ...patch,
+    enabled: true, status: 'idle', indexModeVersion: CURRENT_INDEX_MODE_VERSION, ...patch,
   };
 }

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -64,6 +64,24 @@ describe('GraphifyIndexer — restart recovery', () => {
     expect(host.notify).toHaveBeenCalledWith(expect.objectContaining({
       message: expect.stringMatching(/clean local rebuild/i),
     }));
+
+    await deliver(indexer, host, request(1, 'refresh', 'ws1'));
+    await indexer.idle();
+    expect(host.updateGraph).not.toHaveBeenCalled();
+    expect(getState().workspaces.ws1.status).toBe('needs-build');
+    indexer.dispose();
+  });
+
+  it('excludes old indexing modes from later profile merges', async () => {
+    const { host } = makeHost({ built: ['ws1', 'ws2'] }, (state) => {
+      enabled(state, 'ws1', { lastBuiltAt: 'yesterday', indexModeVersion: undefined });
+      enabled(state, 'ws2', { lastBuiltAt: 'yesterday' });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+
+    expect(host.mergeProfileGraph).toHaveBeenCalledWith(['ws2']);
     indexer.dispose();
   });
 });

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GraphifyIndexer } from './indexer';
 import type { WorkspaceIndexStats } from '../shared/types';
+import { CURRENT_INDEX_MODE_VERSION } from '../shared/types';
 import { deliver, enabled, makeHost, request, STATS } from './indexer.fixtures';
 
 describe('GraphifyIndexer — restart recovery', () => {
@@ -43,6 +44,26 @@ describe('GraphifyIndexer — restart recovery', () => {
     expect(host.buildGraph).not.toHaveBeenCalled();
     expect(getState().workspaces.ws1.stats?.graphifyVersion).toBe('0.9.47');
     expect(host.mergeProfileGraph).not.toHaveBeenCalled();
+    indexer.dispose();
+  });
+
+  it('marks a graph from the old indexing mode for one clean rebuild', async () => {
+    const { host, getState } = makeHost({ built: ['ws1'] }, (state) => {
+      enabled(state, 'ws1', {
+        lastBuiltAt: 'yesterday',
+        indexModeVersion: undefined,
+      });
+    });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+
+    expect(host.updateGraph).not.toHaveBeenCalled();
+    expect(host.buildGraph).not.toHaveBeenCalled();
+    expect(getState().workspaces.ws1.status).toBe('needs-build');
+    expect(host.notify).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringMatching(/clean local rebuild/i),
+    }));
     indexer.dispose();
   });
 });
@@ -101,7 +122,9 @@ describe('GraphifyIndexer — one action, one build', () => {
 
 describe('GraphifyIndexer — enable is not rebuild', () => {
   it('enabling a workspace that already has a graph does not rebuild it', async () => {
-    const { host, getState } = makeHost({ built: ['ws1'] });
+    const { host, getState } = makeHost({ built: ['ws1'] }, (state) => {
+      enabled(state, 'ws1', { enabled: false, indexModeVersion: CURRENT_INDEX_MODE_VERSION });
+    });
     const indexer = new GraphifyIndexer(host);
     await indexer.start();
     await deliver(indexer, host, request(1, 'enable', 'ws1'));
@@ -134,6 +157,7 @@ describe('GraphifyIndexer — enable is not rebuild', () => {
       outputTokens: 0,
       graphifyVersion: '0.9.47',
     });
+    expect(getState().workspaces.ws1.indexModeVersion).toBe(CURRENT_INDEX_MODE_VERSION);
     expect(host.confirm).not.toHaveBeenCalled();
     indexer.dispose();
   });
@@ -203,6 +227,7 @@ describe('GraphifyIndexer — build records', () => {
     await indexer.idle();
     expect(getState().workspaces.ws1).toMatchObject({ status: 'error', lastError: 'extract failed', failureCount: 1 });
     expect(host.buildGraph).toHaveBeenCalledTimes(1);
+    expect(host.mergeProfileGraph).not.toHaveBeenCalled();
     indexer.dispose();
   });
 });

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -53,6 +53,7 @@ describe('GraphifyIndexer — restart recovery', () => {
         lastBuiltAt: 'yesterday',
         indexModeVersion: undefined,
       });
+      state.profileGraph = { status: 'ready', workspaceIds: ['ws1'] };
     });
     const indexer = new GraphifyIndexer(host);
     await indexer.start();
@@ -61,6 +62,7 @@ describe('GraphifyIndexer — restart recovery', () => {
     expect(host.updateGraph).not.toHaveBeenCalled();
     expect(host.buildGraph).not.toHaveBeenCalled();
     expect(getState().workspaces.ws1.status).toBe('needs-build');
+    expect(getState().profileGraph.status).toBe('absent');
     expect(host.notify).toHaveBeenCalledWith(expect.objectContaining({
       message: expect.stringMatching(/clean local rebuild/i),
     }));

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -5,7 +5,7 @@ import type {
   WorkspaceIndexStats,
   WorkspaceIndexStatus,
 } from '../shared/types';
-import { isIndexableWorkspace } from '../shared/types';
+import { CURRENT_INDEX_MODE_VERSION, isIndexableWorkspace } from '../shared/types';
 import type { BuildOutcome } from './graphify-runner';
 import { sweepOrphanArtifacts, syncWorkspaceList } from './workspace-sync';
 import { applySettingsPatch, upgradeGraphifyTool } from './settings';
@@ -89,10 +89,18 @@ export class GraphifyIndexer {
     await this.syncWorkspaces({ normalizeStatuses: true });
     await sweepOrphanArtifacts(this.host);
 
-    for (const entry of Object.values(before?.workspaces ?? {})) {
+    const state = await this.host.readState();
+    for (const entry of Object.values(state?.workspaces ?? {})) {
       if (!entry.enabled || !isIndexableWorkspace(entry.workspaceId)) continue;
       if (await this.host.graphExists(entry.workspaceId)) {
-        this.enqueue({ workspaceId: entry.workspaceId, kind: 'update' });
+        if (entry.indexModeVersion === CURRENT_INDEX_MODE_VERSION) {
+          this.enqueue({ workspaceId: entry.workspaceId, kind: 'update' });
+        } else {
+          await this.setStatus(entry.workspaceId, 'needs-build', { progress: undefined });
+          if (entry.status !== 'needs-build') {
+            this.host.notify(notice('info', `${entry.name} needs one clean local rebuild to remove data from the previous indexing mode.`));
+          }
+        }
       } else {
         await this.setStatus(entry.workspaceId, 'needs-build', { progress: undefined });
       }
@@ -183,7 +191,10 @@ export class GraphifyIndexer {
     if (!(await this.host.readState())?.workspaces[workspaceId]) await this.syncWorkspaces();
 
     const hasGraph = await this.host.graphExists(workspaceId);
-    const needsBuild = options.rebuild || !hasGraph;
+    const state = await this.host.readState();
+    const currentEntry = state?.workspaces[workspaceId];
+    const needsBuild = options.rebuild || !hasGraph
+      || currentEntry?.indexModeVersion !== CURRENT_INDEX_MODE_VERSION;
     const foldsIntoActiveUpdate = needsBuild
       && this.activeJob?.workspaceId === workspaceId
       && this.activeJob.kind === 'update';
@@ -423,6 +434,9 @@ export class GraphifyIndexer {
             lastError: undefined,
             progress: undefined,
             failureCount: 0,
+            indexModeVersion: job.kind === 'build'
+              ? CURRENT_INDEX_MODE_VERSION
+              : entry.indexModeVersion,
           },
         },
       };

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -236,7 +236,11 @@ export class GraphifyIndexer {
         if (!request.workspaceId) break;
         const state = await this.host.readState();
         const entry = state?.workspaces[request.workspaceId];
-        if (entry?.enabled && await this.host.graphExists(request.workspaceId)) {
+        if (
+          entry?.enabled
+          && entry.indexModeVersion === CURRENT_INDEX_MODE_VERSION
+          && await this.host.graphExists(request.workspaceId)
+        ) {
           this.enqueue({ workspaceId: request.workspaceId, kind: 'update' });
         }
         break;
@@ -447,7 +451,11 @@ export class GraphifyIndexer {
   private async merge(): Promise<void> {
     const state = await this.host.readState();
     const ids = Object.values(state?.workspaces ?? {})
-      .filter((entry) => entry.enabled && entry.lastBuiltAt)
+      .filter((entry) => (
+        entry.enabled
+        && entry.lastBuiltAt
+        && entry.indexModeVersion === CURRENT_INDEX_MODE_VERSION
+      ))
       .map((entry) => entry.workspaceId);
 
     if (ids.length === 0) {

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -90,6 +90,8 @@ export class GraphifyIndexer {
     await sweepOrphanArtifacts(this.host);
 
     const state = await this.host.readState();
+    let profileNeedsMigration = false;
+    const profileWorkspaceIds = state?.profileGraph.workspaceIds;
     for (const entry of Object.values(state?.workspaces ?? {})) {
       if (!entry.enabled || !isIndexableWorkspace(entry.workspaceId)) continue;
       if (await this.host.graphExists(entry.workspaceId)) {
@@ -97,6 +99,9 @@ export class GraphifyIndexer {
           this.enqueue({ workspaceId: entry.workspaceId, kind: 'update' });
         } else {
           await this.setStatus(entry.workspaceId, 'needs-build', { progress: undefined });
+          if (!Array.isArray(profileWorkspaceIds) || profileWorkspaceIds.includes(entry.workspaceId)) {
+            profileNeedsMigration = true;
+          }
           if (entry.status !== 'needs-build') {
             this.host.notify(notice('info', `${entry.name} needs one clean local rebuild to remove data from the previous indexing mode.`));
           }
@@ -105,6 +110,7 @@ export class GraphifyIndexer {
         await this.setStatus(entry.workspaceId, 'needs-build', { progress: undefined });
       }
     }
+    if (profileNeedsMigration) await this.merge();
     this.kick();
   }
 

--- a/plugins/sero-graphify-plugin/shared/paths.test.ts
+++ b/plugins/sero-graphify-plugin/shared/paths.test.ts
@@ -19,6 +19,7 @@ describe('paths', () => {
     expect(p.home).toBe('/profile/apps/graphify');
     expect(p.stateFile).toBe('/profile/apps/graphify/state.json');
     expect(p.graphsDir).toBe('/profile/apps/graphify/graphs');
+    expect(p.rebuildsDir).toBe('/profile/apps/graphify/graph-rebuilds');
     expect(p.profileDir).toBe('/profile/apps/graphify/profile');
     expect(p.profileGraph).toBe('/profile/apps/graphify/profile/graph.json');
     // Tool installs are machine-shared (host.toolchains.sharedToolsDir),

--- a/plugins/sero-graphify-plugin/shared/paths.ts
+++ b/plugins/sero-graphify-plugin/shared/paths.ts
@@ -20,6 +20,7 @@ export interface GraphifyPaths {
   home: string;
   stateFile: string;
   graphsDir: string;
+  rebuildsDir: string;
   profileDir: string;
   profileGraph: string;
 }
@@ -29,6 +30,7 @@ export function graphifyPathsFromHome(home: string): GraphifyPaths {
     home,
     stateFile: path.join(home, 'state.json'),
     graphsDir: path.join(home, 'graphs'),
+    rebuildsDir: path.join(home, 'graph-rebuilds'),
     profileDir: path.join(home, 'profile'),
     profileGraph: path.join(home, 'profile', 'graph.json'),
   };

--- a/plugins/sero-graphify-plugin/shared/types.ts
+++ b/plugins/sero-graphify-plugin/shared/types.ts
@@ -44,7 +44,12 @@ export interface WorkspaceIndexEntry {
   progress?: string;
   lastAttemptAt?: string;
   failureCount?: number;
+  /** Version of Sero's extraction rules used to create this workspace graph. */
+  indexModeVersion?: number;
 }
+
+/** Increment when a graph needs a clean rebuild rather than an incremental refresh. */
+export const CURRENT_INDEX_MODE_VERSION = 1;
 
 export interface RemovedWorkspaceRecord {
   workspaceId: string;

--- a/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
+++ b/plugins/sero-graphify-plugin/ui/WorkspaceCard.tsx
@@ -1,6 +1,6 @@
 import { Badge, Button, Card, Switch } from '@sero-ai/ui';
 import { RefreshCw } from 'lucide-react';
-import type { WorkspaceIndexEntry } from '../shared/types';
+import { CURRENT_INDEX_MODE_VERSION, type WorkspaceIndexEntry } from '../shared/types';
 
 function statusBadge(entry: WorkspaceIndexEntry) {
   if (!entry.enabled) return <Badge variant="outline">off</Badge>;
@@ -8,10 +8,18 @@ function statusBadge(entry: WorkspaceIndexEntry) {
     case 'building': return <Badge>building…</Badge>;
     case 'updating': return <Badge>updating…</Badge>;
     case 'queued': return <Badge variant="secondary">queued</Badge>;
-    case 'needs-build': return <Badge variant="outline">not built</Badge>;
+    case 'needs-build': return (
+      <Badge variant="outline">
+        {needsCleanRebuild(entry) ? 'clean rebuild needed' : 'not built'}
+      </Badge>
+    );
     case 'error': return <Badge variant="destructive">error</Badge>;
     default: return <Badge variant="secondary">indexed</Badge>;
   }
+}
+
+function needsCleanRebuild(entry: WorkspaceIndexEntry): boolean {
+  return entry.lastBuiltAt !== undefined && entry.indexModeVersion !== CURRENT_INDEX_MODE_VERSION;
 }
 
 function statsLine(entry: WorkspaceIndexEntry): string | null {
@@ -32,6 +40,7 @@ interface Props {
 export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
   const stats = statsLine(entry);
   const building = entry.status === 'building' || entry.status === 'updating';
+  const needsMigration = entry.status === 'needs-build' && needsCleanRebuild(entry);
 
   return (
     <Card className="flex flex-row items-center justify-between border-border/40 p-3">
@@ -52,7 +61,7 @@ export function WorkspaceCard({ entry, blocked, onIndex }: Props) {
             here for another user action. Nothing retries on its own. */}
         {entry.enabled && (entry.status === 'needs-build' || entry.status === 'error') && (
           <Button size="sm" variant="outline" disabled={blocked} onClick={() => onIndex('rebuild')}>
-            {entry.status === 'error' ? 'Try again' : 'Build'}
+            {entry.status === 'error' ? 'Try again' : needsMigration ? 'Rebuild' : 'Build'}
           </Button>
         )}
         <Button


### PR DESCRIPTION
## Summary

- run explicit Graphify rebuilds with `--force --code-only --no-cluster`
- build in a temporary directory and replace the active graph only after extraction and clustering succeed
- mark older graphs for one clean local rebuild while keeping automatic refreshes incremental
- show the migration state in the workspace card and document the behavior

## Tests

- `pnpm --filter @sero-ai/plugin-graphify test`
- `pnpm typecheck`
- `pnpm --filter @sero-ai/plugin-graphify build`
- `bash scripts/build-plugin.sh plugins/sero-graphify-plugin`
- `npx react-doctor@latest --verbose --scope changed`

Closes #392