### PR TITLE
test(desktop): remove process grace wait from unit tests

### DIFF
--- a/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
@@ -29,6 +29,7 @@ function createManager(options: {
   processAdapter?: HostProcessAdapter;
   spawn?: (input: RuntimeProcessInput) => Promise<ReturnType<typeof createProcess>>;
   portDetectTimeoutMs?: number;
+  terminateGraceMs?: number;
 } = {}): HostDevServerManager {
   return new HostDevServerManager({
     workspaceId: 'workspace-a',
@@ -36,6 +37,7 @@ function createManager(options: {
     processAdapter: options.processAdapter ?? createProcessAdapter(),
     pollIntervalMs: 1,
     portDetectTimeoutMs: options.portDetectTimeoutMs ?? 10,
+    terminateGraceMs: options.terminateGraceMs ?? 0,
   });
 }
 


### PR DESCRIPTION
## Summary

This is the first package-specific Phase 4 change for #400. It changes only `@sero/desktop`.

The measured desktop test task was the largest package test task at 20.57 seconds. Within that package, `host-dev-server-manager.test.ts` was the slowest file at 4.52 seconds. Six tests used the production 750 ms termination grace period even though they did not test elapsed time.

The test helper now sets `terminateGraceMs` to zero. All 11 tests remain. They still check process TERM and KILL calls, descendant and listener cleanup, restart behavior, metadata, status events, port detection, and registered-process boundaries.

## Verdict

`REWRITE`

The tests protect real process lifecycle contracts. The wait was not part of an assertion. The manager already has a test seam for the grace period, so the rewrite does not change production code.

No test was deleted, merged, or moved across an environment boundary.

## Measurements

| Measure | Before | After |
| --- | ---: | ---: |
| Candidate file | 4.52s | 23ms |
| Candidate test body | about 4.5s | 15 to 17ms |
| Full desktop command | 20.28s | 20.09s |

The full-command values are single local runs and are close enough to normal run noise. They do not prove a 190 ms saving. The candidate-file reduction is deterministic because it removes six real 750 ms waits.

## Validation

- Focused test, three runs: 11 tests passed in 15 to 17 ms of test time.
- Desktop package suite: 385 files and 2,134 tests passed.
- Root `pnpm typecheck`: passed.
- TypeScript LSP: clean.
- Pi Lens: clean.
- `git diff --check`: passed.
- Touched file: 238 LOC.
- Luna-high read-only review: GREEN, no blocking findings.

## Documentation

I reviewed the docs-site scope. This test-only change does not change user or plugin-author behavior, so no documentation change is required.

Refs #400
