### PR TITLE
perf(tests): remove real waiting and repeated setup from the slowest tests

### DIFF
--- a/apps/desktop/electron/__tests__/features/git/git-service/git-refresh.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/git-service/git-refresh.test.ts
@@ -4,8 +4,8 @@ import { refreshGitState } from '@electron/features/git/git-service/git-service'
 import {
   runGit,
   cleanupPaths,
-  commitAll,
   createGitRepo,
+  createSeededRepo,
   statePathFor,
   writeRepoFile,
 } from './git-test-helpers';
@@ -36,12 +36,10 @@ describe('refreshGitState', () => {
   });
 
   it('uses quick refresh mode when HEAD and branch are unchanged', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const statePath = statePathFor(repoPath);
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
 
       const initialState = await refreshGitState(repoPath, statePath, { scope: 'full' });
       await writeRepoFile(repoPath, 'notes.txt', 'dirty\n');
@@ -60,12 +58,10 @@ describe('refreshGitState', () => {
   });
 
   it('falls back to a full refresh when refs change without a HEAD update', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const statePath = statePathFor(repoPath);
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       await refreshGitState(repoPath, statePath, { scope: 'full' });
 
       runGit(['branch', 'feature'], repoPath);
@@ -78,12 +74,10 @@ describe('refreshGitState', () => {
   });
 
   it('excludes internal turn-undo refs from visible commit history and counts', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const statePath = statePathFor(repoPath);
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
 
       const headTree = runGit(['rev-parse', 'HEAD^{tree}'], repoPath);
       const hiddenCommit = runGit([

--- a/apps/desktop/electron/__tests__/features/git/git-service/git-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/git-service/git-service.test.ts
@@ -9,6 +9,7 @@ import {
   commitAll,
   createBareRemote,
   createGitRepo,
+  createSeededRepo,
   statePathFor,
   writeRepoFile,
 } from './git-test-helpers';
@@ -31,12 +32,10 @@ describe('runGitAction', () => {
   });
 
   it('blocks switching to branches checked out in another worktree', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const worktreePath = path.join(repoPath, 'feature-worktree');
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       runGit(['branch', 'feature'], repoPath);
       runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
 
@@ -55,12 +54,10 @@ describe('runGitAction', () => {
   });
 
   it('removes linked worktrees and supports force removal for dirty ones', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const worktreePath = path.join(repoPath, 'feature-worktree');
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       runGit(['branch', 'feature'], repoPath);
       runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
       await writeRepoFile(worktreePath, 'dirty.txt', 'dirty\n');
@@ -86,11 +83,9 @@ describe('runGitAction', () => {
   });
 
   it('blocks removing the main worktree', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
 
       const result = await runGitAction(
         { action: 'remove_worktree', worktreePath: repoPath },
@@ -106,12 +101,10 @@ describe('runGitAction', () => {
   });
 
   it('blocks deleting the default branch', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const remotePath = await createBareRemote();
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
 
       runGit(['remote', 'add', 'origin', remotePath], repoPath);
@@ -134,11 +127,9 @@ describe('runGitAction', () => {
   });
 
   it('blocks deleting the current branch', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       const currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
 
       const result = await runGitAction(
@@ -155,11 +146,9 @@ describe('runGitAction', () => {
   });
 
   it('supports force-deleting unmerged branches', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
 
       runGit(['switch', '-c', 'feature'], repoPath);
@@ -188,11 +177,9 @@ describe('runGitAction', () => {
   });
 
   it('applies a stash without dropping it', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'notes.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'notes.txt', 'base\n');
-      commitAll(repoPath, 'initial');
 
       await writeRepoFile(repoPath, 'notes.txt', 'base\nupdated\n');
       const stashResult = await runGitAction({ action: 'stash' }, repoPath, statePathFor(repoPath));
@@ -214,11 +201,9 @@ describe('runGitAction', () => {
   });
 
   it('can auto-stash before cherry-picking onto a dirty working tree', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'app.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'app.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
 
       runGit(['switch', '-c', 'feature'], repoPath);
@@ -252,11 +237,9 @@ describe('runGitAction', () => {
   });
 
   it('answers log from the repo even before a snapshot exists', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'notes.txt': 'base\n' });
 
     try {
-      await writeRepoFile(repoPath, 'notes.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       await writeRepoFile(repoPath, 'notes.txt', 'base\nsecond\n');
       commitAll(repoPath, 'second');
 
@@ -275,12 +258,10 @@ describe('runGitAction', () => {
   });
 
   it('answers branches from the repo after refs change outside the cached snapshot', async () => {
-    const repoPath = await createGitRepo();
+    const repoPath = await createSeededRepo({ 'a.txt': 'base\n' });
     const statePath = statePathFor(repoPath);
 
     try {
-      await writeRepoFile(repoPath, 'a.txt', 'base\n');
-      commitAll(repoPath, 'initial');
       await runGitAction({ action: 'refresh' }, repoPath, statePath);
       runGit(['branch', 'feature/e4-runtime'], repoPath);
 

--- a/apps/desktop/electron/__tests__/features/git/git-service/git-test-helpers.ts
+++ b/apps/desktop/electron/__tests__/features/git/git-service/git-test-helpers.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, cp } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -15,18 +16,89 @@ export function runGit(args: string[], cwd: string): string {
   }
 }
 
-export async function createGitRepo(prefix = 'sero-git-plugin-'): Promise<string> {
+/**
+ * `git init` plus commits costs several process spawns per test, and every
+ * test in these suites wants the same starting repository. Build each distinct
+ * starting point once per worker and copy it — a plain directory copy, no
+ * spawns. The copy is a real git repository, not a stand-in: the tests still
+ * run real git against it.
+ */
+const templates = new Map<string, Promise<string>>();
+const templateRoots: string[] = [];
+
+function template(key: string, build: (dir: string) => Promise<void>): Promise<string> {
+  const cached = templates.get(key);
+  if (cached) return cached;
+
+  const created = (async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sero-git-template-'));
+    templateRoots.push(dir);
+    await build(dir);
+    return dir;
+  })();
+  templates.set(key, created);
+  return created;
+}
+
+process.once('exit', () => {
+  for (const dir of templateRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+async function copyOfTemplate(templateDir: string, prefix: string): Promise<string> {
   const repoPath = await mkdtemp(path.join(os.tmpdir(), prefix));
-  runGit(['init'], repoPath);
-  runGit(['config', 'user.name', 'Sero Test'], repoPath);
-  runGit(['config', 'user.email', 'test@example.com'], repoPath);
+  await cp(templateDir, repoPath, { recursive: true });
   return repoPath;
 }
 
+async function initRepo(dir: string): Promise<void> {
+  runGit(['init'], dir);
+  runGit(['config', 'user.name', 'Sero Test'], dir);
+  runGit(['config', 'user.email', 'test@example.com'], dir);
+}
+
+export async function createGitRepo(prefix = 'sero-git-plugin-'): Promise<string> {
+  const templateDir = await template('empty', initRepo);
+  return copyOfTemplate(templateDir, prefix);
+}
+
+/**
+ * A copy of a directory built once per worker by `build`. `key` identifies the
+ * starting point: two calls with the same key share one build and get
+ * independent copies of it.
+ */
+export async function createRepoFromTemplate(
+  key: string,
+  build: (dir: string) => Promise<void>,
+  prefix = 'sero-git-plugin-',
+): Promise<string> {
+  const templateDir = await template(key, build);
+  return copyOfTemplate(templateDir, prefix);
+}
+
+/** A repo whose first commit already contains `files`. Equivalent to `createGitRepo` + `commitAll`. */
+export async function createSeededRepo(
+  files: Record<string, string>,
+  options: { message?: string; prefix?: string } = {},
+): Promise<string> {
+  const message = options.message ?? 'initial';
+  return createRepoFromTemplate(
+    JSON.stringify({ files, message }),
+    async (dir) => {
+      await initRepo(dir);
+      for (const [relativePath, content] of Object.entries(files)) {
+        await writeRepoFile(dir, relativePath, content);
+      }
+      commitAll(dir, message);
+    },
+    options.prefix ?? 'sero-git-plugin-',
+  );
+}
+
 export async function createBareRemote(prefix = 'sero-git-remote-'): Promise<string> {
-  const remotePath = await mkdtemp(path.join(os.tmpdir(), prefix));
-  runGit(['init', '--bare'], remotePath);
-  return remotePath;
+  const templateDir = await template('bare', async (dir) => {
+    runGit(['init', '--bare'], dir);
+  });
+  return copyOfTemplate(templateDir, prefix);
 }
 
 export async function writeRepoFile(repoPath: string, relativePath: string, content: string): Promise<void> {

--- a/apps/desktop/electron/__tests__/features/git/refresh-side-effects.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/refresh-side-effects.test.ts
@@ -11,30 +11,28 @@
  * itself a moment after appearing.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
-import { readFile, stat, writeFile, rm } from 'node:fs/promises';
+import { afterAll, describe, expect, it } from 'vitest';
+import { readFile, stat, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { refreshGitState } from '@electron/features/git/git-service/git-service';
 import { runGitAction } from '@electron/features/git/git-service/git-service';
 import { resolveStatePath } from '@electron/features/git/git-service/state-io';
-import { createGitRepo, runGit } from './git-service/git-test-helpers';
+import { createSeededRepo, runGit } from './git-service/git-test-helpers';
 
 const repos: string[] = [];
 
 async function repoWithACommit(): Promise<string> {
-  const repoPath = await createGitRepo('refresh-side-effects-');
+  const repoPath = await createSeededRepo(
+    { 'README.md': '# Project\n', 'src.ts': 'export const x = 1;\n' },
+    { message: 'initial commit', prefix: 'refresh-side-effects-' },
+  );
   repos.push(repoPath);
-
-  await writeFile(path.join(repoPath, 'README.md'), '# Project\n', 'utf8');
-  await writeFile(path.join(repoPath, 'src.ts'), 'export const x = 1;\n', 'utf8');
-  runGit(['add', '.'], repoPath);
-  runGit(['commit', '-m', 'initial commit'], repoPath);
-
   return repoPath;
 }
 
-afterEach(async () => {
+// Each test owns its own repository copy, so one cleanup at the end is enough.
+afterAll(async () => {
   await Promise.all(repos.splice(0).map((repoPath) => rm(repoPath, { recursive: true, force: true })));
 });
 

--- a/apps/desktop/electron/__tests__/features/git/sero-files-ignored.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/sero-files-ignored.test.ts
@@ -12,19 +12,19 @@
  * file that was never covered at all.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { refreshGitState } from '@electron/features/git/git-service/git-service';
 import { resolveStatePath } from '@electron/features/git/git-service/state-io';
-import { createGitRepo, runGit } from './git-service/git-test-helpers';
+import { createRepoFromTemplate, runGit } from './git-service/git-test-helpers';
 
-const repos: string[] = [];
-
-async function repoWithSeroFiles(): Promise<string> {
-  const repoPath = await createGitRepo('sero-ignore-');
-  repos.push(repoPath);
+/** The starting repository is identical for every test here, so build it once and copy it. */
+async function buildRepoWithSeroFiles(repoPath: string): Promise<void> {
+  runGit(['init'], repoPath);
+  runGit(['config', 'user.name', 'Sero Test'], repoPath);
+  runGit(['config', 'user.email', 'test@example.com'], repoPath);
 
   await writeFile(path.join(repoPath, 'README.md'), '# Project\n', 'utf8');
   runGit(['add', '.'], repoPath);
@@ -36,11 +36,18 @@ async function repoWithSeroFiles(): Promise<string> {
   await mkdir(path.join(repoPath, '.sero/apps/orchestrator'), { recursive: true });
   await writeFile(path.join(repoPath, '.sero/apps/git/state.json'), '{}\n', 'utf8');
   await writeFile(path.join(repoPath, '.sero/apps/orchestrator/state.json'), '{}\n', 'utf8');
+}
 
+const repos: string[] = [];
+
+async function repoWithSeroFiles(): Promise<string> {
+  const repoPath = await createRepoFromTemplate('sero-files', buildRepoWithSeroFiles, 'sero-ignore-');
+  repos.push(repoPath);
   return repoPath;
 }
 
-afterEach(async () => {
+// Each test owns its own repository copy, so one cleanup at the end is enough.
+afterAll(async () => {
   await Promise.all(repos.splice(0).map((repoPath) => rm(repoPath, { recursive: true, force: true })));
 });
 

--- a/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
@@ -7,13 +7,13 @@
  */
 
 import { execFile } from 'node:child_process';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import { WorktreeManager } from '@electron/features/git/worktree/manager';
+import { createRepoFromTemplate } from '../git-service/git-test-helpers';
 
 const execFileAsync = promisify(execFile);
 
@@ -31,23 +31,37 @@ async function initRepo(dir: string): Promise<void> {
   await git(dir, 'commit', '-m', 'init');
 }
 
+/**
+ * Every test starts from the same freshly committed workspace repo, so build
+ * it once per worker and hand each test its own copy — real git, no repeated
+ * `git init` and commit per test.
+ */
+const roots: string[] = [];
+
+async function newWorkspace(): Promise<{ root: string; workspace: string }> {
+  const root = await createRepoFromTemplate(
+    'worktree-workspace-root',
+    async (dir) => {
+      const workspace = path.join(dir, 'workspace');
+      await mkdir(workspace, { recursive: true });
+      await initRepo(workspace);
+    },
+    'wt-',
+  );
+  roots.push(root);
+  return { root, workspace: path.join(root, 'workspace') };
+}
+
+// Each test owns its own repository copy, so one cleanup at the end is enough.
+afterAll(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
 describe('WorktreeManager.create with existingBranch', () => {
-  let root: string;
-  let workspace: string;
   const manager = new WorktreeManager();
 
-  beforeEach(async () => {
-    root = await mkdtemp(path.join(tmpdir(), 'wt-existing-'));
-    workspace = path.join(root, 'workspace');
-    await execFileAsync('mkdir', ['-p', workspace]);
-    await initRepo(workspace);
-  });
-
-  afterEach(async () => {
-    await rm(root, { recursive: true, force: true });
-  });
-
   it('checks out a local branch as-is, minting nothing', async () => {
+    const { workspace } = await newWorkspace();
     await git(workspace, 'branch', 'feat/pr-branch');
     const result = await manager.create(workspace, 'loop-1', 'ignored title', { existingBranch: 'feat/pr-branch' });
 
@@ -59,9 +73,10 @@ describe('WorktreeManager.create with existingBranch', () => {
   });
 
   it('fetches and tracks a branch that only exists on origin', async () => {
+    const { root, workspace } = await newWorkspace();
     // A second repo plays "origin" holding the PR branch.
     const origin = path.join(root, 'origin');
-    await execFileAsync('mkdir', ['-p', origin]);
+    await mkdir(origin, { recursive: true });
     await initRepo(origin);
     await git(origin, 'checkout', '-b', 'feat/remote-only');
     await writeFile(path.join(origin, 'change.md'), 'remote work');
@@ -78,12 +93,14 @@ describe('WorktreeManager.create with existingBranch', () => {
   });
 
   it('errors clearly when the branch exists nowhere — never falls back to a fresh branch', async () => {
+    const { workspace } = await newWorkspace();
     await expect(manager.create(workspace, 'loop-3', 'ignored', { existingBranch: 'no/such-branch' })).rejects.toThrow(
       'exists neither locally nor on origin',
     );
   });
 
   it('refuses branch names git would refuse', async () => {
+    const { workspace } = await newWorkspace();
     await expect(manager.create(workspace, 'loop-4', 'ignored', { existingBranch: '--upload-pack=x' })).rejects.toThrow(
       'Invalid branch name',
     );
@@ -94,22 +111,10 @@ describe('WorktreeManager.create with existingBranch', () => {
 });
 
 describe('WorktreeManager merged-branch cleanup', () => {
-  let root: string;
-  let workspace: string;
   const manager = new WorktreeManager();
 
-  beforeEach(async () => {
-    root = await mkdtemp(path.join(tmpdir(), 'wt-cleanup-'));
-    workspace = path.join(root, 'workspace');
-    await execFileAsync('mkdir', ['-p', workspace]);
-    await initRepo(workspace);
-  });
-
-  afterEach(async () => {
-    await rm(root, { recursive: true, force: true });
-  });
-
   it('deletes a no-op branch that is fully merged', async () => {
+    const { workspace } = await newWorkspace();
     const worktree = await manager.create(workspace, 'loop-1-r1', 'Routine scan');
     await manager.remove(workspace, 'loop-1-r1', { force: true, deleteMergedBranch: true });
 
@@ -117,6 +122,7 @@ describe('WorktreeManager merged-branch cleanup', () => {
   });
 
   it('preserves a branch with unmerged work', async () => {
+    const { workspace } = await newWorkspace();
     const worktree = await manager.create(workspace, 'loop-1-r2', 'Implement change');
     await writeFile(path.join(worktree.worktreePath, 'change.md'), 'work in progress');
     await git(worktree.worktreePath, 'add', '.');

--- a/apps/desktop/electron/__tests__/features/plugins/dev-sessions/dev-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/dev-sessions/dev-server.test.ts
@@ -117,6 +117,8 @@ describe('ensurePluginDevServer', () => {
       declaredDevPort: port,
       command: buildHealthyServerCommand(port, toRemoteName(appId)),
       hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
       hasBuiltUi: false,
     });
 
@@ -139,6 +141,8 @@ describe('ensurePluginDevServer', () => {
       declaredDevPort: port,
       command: buildFailingCommand(),
       hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
       hasBuiltUi: true,
     });
 
@@ -186,6 +190,8 @@ describe('ensurePluginDevServer', () => {
       declaredDevPort: port,
       command: buildIdleCommand(),
       hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
       hasBuiltUi: false,
     });
 
@@ -211,6 +217,8 @@ describe('ensurePluginDevServer', () => {
         declaredDevPort: port,
         command: buildHealthyServerCommand(port, toRemoteName(appId)),
         hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
         hasBuiltUi: true,
       });
 
@@ -238,6 +246,8 @@ describe('ensurePluginDevServer', () => {
         declaredDevPort: port,
         command: buildHealthyServerCommand(port, toRemoteName('todo-plugin')),
         hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
         hasBuiltUi: true,
       });
 
@@ -262,6 +272,8 @@ describe('ensurePluginDevServer', () => {
       declaredDevPort: undefined,
       command: null,
       hasDeclaredUi: true,
+      // The real 500ms gap between health probes is not what these tests check.
+      healthPollIntervalMs: 1,
       hasBuiltUi: false,
     });
 

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
@@ -36,6 +36,9 @@ function createManager(options: {
     processAdapter: options.processAdapter ?? createProcessAdapter(),
     pollIntervalMs: 1,
     portDetectTimeoutMs: options.portDetectTimeoutMs ?? 10,
+    // The SIGTERM->SIGKILL grace defaults to 750ms of real waiting; the tests assert
+    // that both kill rounds happen, not how long the manager waits between them.
+    terminateGraceMs: 1,
   });
 }
 

--- a/apps/desktop/electron/features/plugins/dev-sessions/dev-server.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/dev-server.ts
@@ -40,6 +40,12 @@ export interface EnsurePluginDevServerOptions {
   command: string | null;
   hasDeclaredUi: boolean;
   hasBuiltUi?: boolean;
+  /**
+   * Gap between health probes while the dev server starts. Defaults to
+   * HEALTH_POLL_INTERVAL_MS; tests set it low so they do not wait out a real
+   * half-second for a server that is already listening.
+   */
+  healthPollIntervalMs?: number;
 }
 
 export interface PluginDevServerResult {
@@ -233,6 +239,7 @@ async function probeRemoteEntryCandidates(
 
 async function waitForRemoteEntry(
   remoteEntryOverrides: string[],
+  pollIntervalMs: number,
   entry?: ManagedPluginDevServer,
   expectedRemoteName?: string,
 ): Promise<{ remoteEntryOverride: string; probe: RemoteEntryProbeResult } | null> {
@@ -251,7 +258,7 @@ async function waitForRemoteEntry(
       return resolvedProbe;
     }
 
-    await sleep(HEALTH_POLL_INTERVAL_MS);
+    await sleep(pollIntervalMs);
     return poll();
   };
 
@@ -300,6 +307,7 @@ export async function ensurePluginDevServer(
   options: EnsurePluginDevServerOptions,
 ): Promise<PluginDevServerResult> {
   const sourcePath = normalizeSourcePath(options.sourcePath);
+  const pollIntervalMs = options.healthPollIntervalMs ?? HEALTH_POLL_INTERVAL_MS;
   const builtUiAvailable = options.hasBuiltUi ?? await hasBuiltPluginDevUi(sourcePath);
 
   if (!options.hasDeclaredUi) {
@@ -401,7 +409,7 @@ export async function ensurePluginDevServer(
     }
   }
 
-  const resolvedProbe = await waitForRemoteEntry(remoteEntryOverrides, entry, expectedRemoteName);
+  const resolvedProbe = await waitForRemoteEntry(remoteEntryOverrides, pollIntervalMs, entry, expectedRemoteName);
   if (resolvedProbe?.probe.status === 'ready') {
     return {
       remoteEntryOverride: resolvedProbe.remoteEntryOverride,
@@ -437,7 +445,7 @@ export async function ensurePluginDevServer(
         );
       }
 
-      const retryProbe = await waitForRemoteEntry(remoteEntryOverrides, entry, expectedRemoteName);
+      const retryProbe = await waitForRemoteEntry(remoteEntryOverrides, pollIntervalMs, entry, expectedRemoteName);
       if (retryProbe?.probe.status === 'ready') {
         return {
           remoteEntryOverride: retryProbe.remoteEntryOverride,

--- a/apps/desktop/src/components/layout/theme/theme-editor/useThemeEditorState.test.tsx
+++ b/apps/desktop/src/components/layout/theme/theme-editor/useThemeEditorState.test.tsx
@@ -23,8 +23,11 @@ import { useThemeEditorState } from './useThemeEditorState';
 const initialThemeState = useThemeStore.getState();
 const initialAppState = useAppStore.getState();
 
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+// Advances the faked clock so debounced auto-saves fire without real waiting.
+async function advanceTimers(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
 }
 
 function createPreset(overrides: Partial<ThemePreset> = {}): ThemePreset {
@@ -141,6 +144,7 @@ describe('useThemeEditorState', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (root) {
       await act(async () => {
         root?.unmount();
@@ -217,6 +221,7 @@ describe('useThemeEditorState', () => {
   });
 
   it('debounces auto-save draft changes and persists the latest draft', async () => {
+    vi.useFakeTimers();
     await act(async () => {
       root?.render(<Harness open={true} onOpenChange={onOpenChange} editPresetId="ocean-glow" />);
     });
@@ -233,9 +238,7 @@ describe('useThemeEditorState', () => {
 
     expect(saveCustomPresetSpy).not.toHaveBeenCalled();
 
-    await act(async () => {
-      await wait(450);
-    });
+    await advanceTimers(450);
 
     expect(saveCustomPresetSpy).toHaveBeenCalledTimes(1);
     expect(saveCustomPresetSpy).toHaveBeenCalledWith(
@@ -250,6 +253,7 @@ describe('useThemeEditorState', () => {
   });
 
   it('persists the auto-save preference to layout state', async () => {
+    vi.useFakeTimers();
     await act(async () => {
       root?.render(<Harness open={true} onOpenChange={onOpenChange} editPresetId="ocean-glow" />);
     });
@@ -258,9 +262,7 @@ describe('useThemeEditorState', () => {
       latestState?.setAutoSave(true);
     });
 
-    await act(async () => {
-      await wait(100);
-    });
+    await advanceTimers(100);
 
     expect(saveLayoutSpy).toHaveBeenCalledWith(
       expect.objectContaining({ themeEditorAutoSave: true }),
@@ -272,6 +274,7 @@ describe('useThemeEditorState', () => {
       .mockRejectedValueOnce(new Error('disk busy'))
       .mockResolvedValue(undefined);
 
+    vi.useFakeTimers();
     await act(async () => {
       root?.render(<Harness open={true} onOpenChange={onOpenChange} editPresetId="ocean-glow" />);
     });
@@ -284,9 +287,7 @@ describe('useThemeEditorState', () => {
       latestState?.handleColorChange('bgBase', '#456789');
     });
 
-    await act(async () => {
-      await wait(450);
-    });
+    await advanceTimers(450);
 
     expect(saveCustomPresetSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -294,9 +295,7 @@ describe('useThemeEditorState', () => {
       expect.any(Error),
     );
 
-    await act(async () => {
-      await wait(450);
-    });
+    await advanceTimers(450);
 
     expect(saveCustomPresetSpy).toHaveBeenCalledTimes(2);
     expect(saveCustomPresetSpy).toHaveBeenLastCalledWith(

--- a/plugins/sero-cron-plugin/extension/__tests__/state-watcher.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/state-watcher.test.ts
@@ -3,6 +3,12 @@
  *
  * Validates: start/stop lifecycle, debounced sync, own-write
  * suppression, and scheduler update propagation.
+ *
+ * The watcher uses a REAL fs.watch on a real temp directory, so every
+ * test still waits for a real OS filesystem event. Only the 500ms
+ * debounce runs on a fake clock: `fs.watch` is wrapped (call-through)
+ * so a test can await the watcher's own event instead of sleeping,
+ * then advance the debounce timer deterministically.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -19,7 +25,51 @@ vi.mock('../logger', () => ({
   error: vi.fn(),
 }));
 
+/** Records real fs.watch events so tests can wait on them, not on a clock. */
+const fsEvents = vi.hoisted(() => {
+  let received: Array<string | null> = [];
+  let waiters: Array<() => void> = [];
+  return {
+    get count() {
+      return received.length;
+    },
+    reset() {
+      received = [];
+      waiters = [];
+    },
+    notify(filename: string | null) {
+      received.push(filename);
+      const pending = waiters;
+      waiters = [];
+      for (const resolve of pending) resolve();
+    },
+    /** Resolves once the watcher has been handed a real event for `name`. */
+    async waitFor(name: string): Promise<void> {
+      const seen = () => received.some((f) => f === name || !!f?.startsWith(name + '.tmp'));
+      while (!seen()) {
+        await new Promise<void>((resolve) => waiters.push(resolve));
+      }
+    },
+  };
+});
+
+// Wrap node:fs.watch so the real watcher is still used; we only observe
+// when its listener actually fires.
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const watch = ((dir: string, opts: unknown, listener: (e: string, f: string | null) => void) =>
+    actual.watch(dir, opts as never, (event, filename) => {
+      listener(event, filename as string | null);
+      fsEvents.notify(filename as string | null);
+    })) as typeof actual.watch;
+  return { ...actual, watch, default: { ...actual, watch } };
+});
+
 import { StateWatcher } from '../state-watcher';
+import { info, warn } from '../logger';
+
+/** Matches DEBOUNCE_MS in state-watcher.ts. */
+const DEBOUNCE_MS = 500;
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -29,6 +79,41 @@ function makeScheduler() {
     updateJobs: vi.fn(),
     updateReminders: vi.fn(),
   } as any;
+}
+
+/** Yield to the event loop's poll phase with a real (tiny) I/O round trip. */
+async function yieldIo(): Promise<void> {
+  await fs.stat(process.cwd());
+}
+
+/** True once sync() has finished — it always logs one of these two. */
+function syncLogged(): boolean {
+  return (
+    vi.mocked(info).mock.calls.some(([tag]) => tag === 'state-watcher:sync') ||
+    vi.mocked(warn).mock.calls.some(([tag]) => tag === 'state-watcher:sync-failed')
+  );
+}
+
+/**
+ * Perform a write, wait for the watcher to receive the real fs event for the
+ * state file, then run the debounce window on the fake clock.
+ *
+ * `syncReadsFile: false` is for the paths where sync() returns synchronously
+ * (own write, scheduler missing or stopped) and never touches the file.
+ */
+async function writeAndSettle(
+  write: () => Promise<void>,
+  { syncReadsFile = true }: { syncReadsFile?: boolean } = {},
+): Promise<void> {
+  await write();
+  await fsEvents.waitFor('state.json');
+  // The watcher's own listener scheduled the debounce from that real event.
+  expect(vi.getTimerCount()).toBeGreaterThan(0);
+  await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  if (!syncReadsFile) return;
+  // sync() awaits a real readFile; wait for it to report its outcome.
+  for (let i = 0; i < 200 && !syncLogged(); i += 1) await yieldIo();
+  expect(syncLogged()).toBe(true);
 }
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -44,9 +129,15 @@ describe('StateWatcher', () => {
     scheduler = makeScheduler();
     // Write initial state file
     await fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8');
+    fsEvents.reset();
+    vi.mocked(info).mockClear();
+    vi.mocked(warn).mockClear();
+    // Only the debounce timer is faked; Date and file I/O stay real.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -77,11 +168,10 @@ describe('StateWatcher', () => {
       ...DEFAULT_CRON_STATE,
       jobs: [{ name: 'j1', schedule: '0 9 * * *', prompt: 'test', channel: 'cron', disabled: false }],
     };
-    await fs.writeFile(statePath, JSON.stringify(newState), 'utf8');
+    await writeAndSettle(() => fs.writeFile(statePath, JSON.stringify(newState), 'utf8'));
 
-    // Wait for debounce (500ms) + a buffer
-    await new Promise((r) => setTimeout(r, 900));
-
+    // The watcher saw a real filesystem event, not just a timer.
+    expect(fsEvents.count).toBeGreaterThan(0);
     expect(scheduler.updateJobs).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ name: 'j1' })]),
     );
@@ -95,12 +185,12 @@ describe('StateWatcher', () => {
 
     // Mark own write, then write the file
     watcher.markOwnWrite();
-    await fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8');
-
-    // Wait for debounce
-    await new Promise((r) => setTimeout(r, 900));
+    await writeAndSettle(() => fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8'), {
+      syncReadsFile: false,
+    });
 
     // Should NOT have synced because we marked our own write
+    expect(fsEvents.count).toBeGreaterThan(0);
     expect(scheduler.updateJobs).not.toHaveBeenCalled();
 
     watcher.stop();
@@ -111,9 +201,11 @@ describe('StateWatcher', () => {
     const watcher = new StateWatcher(statePath, () => scheduler);
     watcher.start();
 
-    await fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8');
-    await new Promise((r) => setTimeout(r, 900));
+    await writeAndSettle(() => fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8'), {
+      syncReadsFile: false,
+    });
 
+    expect(fsEvents.count).toBeGreaterThan(0);
     expect(scheduler.updateJobs).not.toHaveBeenCalled();
 
     watcher.stop();
@@ -123,10 +215,13 @@ describe('StateWatcher', () => {
     const watcher = new StateWatcher(statePath, () => null);
     watcher.start();
 
-    await fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8');
-    await new Promise((r) => setTimeout(r, 900));
+    await writeAndSettle(() => fs.writeFile(statePath, JSON.stringify(DEFAULT_CRON_STATE), 'utf8'), {
+      syncReadsFile: false,
+    });
 
     // No crash = pass (scheduler is null, so no update calls)
+    expect(fsEvents.count).toBeGreaterThan(0);
+
     watcher.stop();
   });
 
@@ -134,10 +229,10 @@ describe('StateWatcher', () => {
     const watcher = new StateWatcher(statePath, () => scheduler);
     watcher.start();
 
-    await fs.writeFile(statePath, 'not json!!!', 'utf8');
-    await new Promise((r) => setTimeout(r, 900));
+    await writeAndSettle(() => fs.writeFile(statePath, 'not json!!!', 'utf8'));
 
     // Should not crash, should not update scheduler
+    expect(fsEvents.count).toBeGreaterThan(0);
     expect(scheduler.updateJobs).not.toHaveBeenCalled();
 
     watcher.stop();
@@ -148,13 +243,15 @@ describe('StateWatcher', () => {
     watcher.start();
 
     // Write state without reminders field
-    await fs.writeFile(
-      statePath,
-      JSON.stringify({ jobs: [{ name: 'j1', schedule: '0 9 * * *', prompt: 'x', channel: 'cron', disabled: false }], schedulerActive: true, autostart: false, lastRunResults: [] }),
-      'utf8',
+    await writeAndSettle(() =>
+      fs.writeFile(
+        statePath,
+        JSON.stringify({ jobs: [{ name: 'j1', schedule: '0 9 * * *', prompt: 'x', channel: 'cron', disabled: false }], schedulerActive: true, autostart: false, lastRunResults: [] }),
+        'utf8',
+      ),
     );
-    await new Promise((r) => setTimeout(r, 900));
 
+    expect(fsEvents.count).toBeGreaterThan(0);
     expect(scheduler.updateReminders).toHaveBeenCalledWith([]);
 
     watcher.stop();

--- a/plugins/sero-design-library-plugin/extension/tools/item-files.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/item-files.test.ts
@@ -116,7 +116,12 @@ describe('the asset tool streams an original in slices', () => {
     }
 
     expect(total).toBe(CONTENT.byteLength);
-    expect(Buffer.concat(parts)).toEqual(CONTENT);
+    // Byte-for-byte, through `Buffer.equals` rather than `toEqual`: the deep
+    // comparator walks half a megabyte one element at a time and costs about
+    // half a second, while `equals` proves the same thing by memcmp.
+    const rebuilt = Buffer.concat(parts);
+    expect(rebuilt.byteLength).toBe(CONTENT.byteLength);
+    expect(rebuilt.equals(CONTENT)).toBe(true);
 
     // The identity is what stops slices being stitched across two files, and
     // it has to actually come back: the caller rejects a slice without one, so

--- a/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
@@ -45,6 +45,15 @@ export interface CoordinatorHarness {
   ): Coordinator;
 }
 
+/**
+ * Polling options for `vi.waitFor`. The work these tests wait on lands in well
+ * under a millisecond, so with the default 50ms interval nearly all the measured
+ * time is the gap between polls rather than the work. Only the interval changes;
+ * the timeout is left alone, so a run that never finishes still fails the same
+ * way it did before.
+ */
+export const FAST_POLL = { interval: 1 } as const;
+
 export const ANALYSIS_REPLY = JSON.stringify({
   title: 'Analysed title',
   primaryStyle: 'Technical monochrome',
@@ -287,7 +296,7 @@ export function useCoordinator(label: string, options: HarnessOptions = {}): Coo
       const itemId = state.items[state.items.length - 1]!.id;
       await vi.waitFor(async () => {
         expect((await readItem(paths, itemId))?.analysis.status).toBe('ready');
-      });
+      }, FAST_POLL);
       return itemId;
     },
     withErrors(failures) {

--- a/plugins/sero-design-library-plugin/runtime/coordinator-media.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-media.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { currentAttempt } from '../shared/media';
 import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 
-import { useCoordinator } from './coordinator-harness';
+import { FAST_POLL, useCoordinator } from './coordinator-harness';
 import { readDesign } from './design-store';
 import { listJobs, readItem } from './store';
 import { seedDesign } from './test-fixtures';
@@ -26,7 +26,7 @@ async function waitForAsset(designId: string, assetId: string) {
     const asset = design?.assets.find((entry) => entry.id === assetId);
     expect(asset?.attempts.length).toBeGreaterThan(0);
     return asset!;
-  });
+  }, FAST_POLL);
 }
 
 describe('generating an asset into a Design', () => {
@@ -95,7 +95,7 @@ describe('generating an asset into a Design', () => {
       const current = await readDesign(harness.paths, 'design-1');
       expect(current?.assets[0].attempts.length).toBe(2);
       return current!;
-    });
+    }, FAST_POLL);
     expect(design.assets).toHaveLength(1);
     expect(design.assets[0].reference).toBe(failed.reference);
     // The first failure is still on the record — a retry adds, never replaces.
@@ -209,13 +209,13 @@ describe('generating into the Library', () => {
       const generated = state.items.find((item) => item.sourceKind === 'generated');
       expect(generated).toBeDefined();
       return generated!.id;
-    });
+    }, FAST_POLL);
 
     // Generated items take the ordinary import route, so analysis starts by
     // itself exactly as it does for a file the user dropped in.
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.status).toBe('ready');
-    });
+    }, FAST_POLL);
     expect((await readItem(harness.paths, itemId))?.generation?.prompt).toBe(
       'brutalist poster grid',
     );
@@ -257,7 +257,7 @@ describe('generating into the Library', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.items.filter((item) => item.sourceKind === 'generated')).toHaveLength(1);
-    });
+    }, FAST_POLL);
   });
 });
 
@@ -276,7 +276,7 @@ describe('video confirmation', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'library')?.status).toBe('failed');
-    });
+    }, FAST_POLL);
     expect((await readStateWithIndexes(harness.paths)).items).toEqual([]);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
@@ -5,7 +5,7 @@ import { tombstoneFile } from '../shared/paths';
 import { appendRequest, readStateWithIndexes, updateState } from '../shared/state-io';
 import type { AppRuntimeSubagentRunParams } from '@sero-ai/common';
 
-import { ANALYSIS_REPLY, useCoordinator, viewReference } from './coordinator-harness';
+import { ANALYSIS_REPLY, FAST_POLL, useCoordinator, viewReference } from './coordinator-harness';
 import { markSucceeded } from './jobs';
 import { listJobs, mutateItem, readItem } from './store';
 
@@ -59,7 +59,7 @@ describe('applying requests', () => {
     await harness.coordinator.drain();
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.attempts).toBe(2);
-    });
+    }, FAST_POLL);
 
     const summary = (await readStateWithIndexes(harness.paths)).items.find((entry) => entry.id === itemId);
     expect(summary?.primaryStyle).toBe('My own style');
@@ -195,7 +195,7 @@ describe('reanalysis', () => {
 
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.status).toBe('ready');
-    });
+    }, FAST_POLL);
 
     const item = await readItem(harness.paths, itemId);
     const jobs = await listJobs(harness.paths);
@@ -338,7 +338,7 @@ describe('failure handling', () => {
     const itemId = (await readStateWithIndexes(harness.paths)).items[0].id;
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.status).toBe('failed');
-    });
+    }, FAST_POLL);
     expect((await readItem(harness.paths, itemId))?.analysis.error).toBe('provider exploded');
 
     // The reason has to reach the grid, or the UI can only say "it failed".
@@ -347,7 +347,7 @@ describe('failure handling', () => {
     await vi.waitFor(async () => {
       const summary = (await readStateWithIndexes(harness.paths)).items.find((entry) => entry.id === itemId);
       expect(summary?.analysisError).toBe('provider exploded');
-    });
+    }, FAST_POLL);
   });
 
   it('restarts an analysis left running by a process that is gone', async () => {
@@ -364,7 +364,7 @@ describe('failure handling', () => {
 
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.status).toBe('ready');
-    });
+    }, FAST_POLL);
   });
 
   it('keeps draining after one request fails', async () => {

--- a/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { revisionDir } from '../../shared/paths';
 import { appendRequest, readStateWithIndexes } from '../../shared/state-io';
 import { PREVIEW_CSP } from '../preview/harness';
 import {
+  FAST_POLL,
   STUB_PAGE,
   isGenerationRun,
   stubAnalysisRun,
@@ -55,7 +56,7 @@ async function settled(designId: string) {
   await vi.waitFor(async () => {
     const design = await readDesign(harness.paths, designId);
     expect(design?.variants.every((variant) => variant.status !== 'pending' && variant.status !== 'running')).toBe(true);
-  });
+  }, FAST_POLL);
   return (await readDesign(harness.paths, designId))!;
 }
 
@@ -285,7 +286,7 @@ describe('durability across restart and replay', () => {
     await vi.waitFor(async () => {
       const jobs = await listJobs(harness.paths);
       expect(jobs.every((job) => job.status !== 'running')).toBe(true);
-    });
+    }, FAST_POLL);
 
     const after = await readDesign(harness.paths, designId);
     expect(after?.variants[0]?.status).toBe('cancelled');
@@ -318,7 +319,7 @@ describe('cancelling a job that never started', () => {
     await vi.waitFor(async () => {
       const running = (await listJobs(harness.paths)).filter((job) => job.status === 'running');
       expect(running).toHaveLength(2);
-    });
+    }, FAST_POLL);
 
     // Chosen by the job, not the variant: the queue marks a job running a moment
     // before the variant catches up, so picking by variant status can hand back

--- a/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
@@ -12,6 +12,7 @@ import { appendRequest, readStateWithIndexes } from '../../shared/state-io';
 import { PREVIEW_CSP } from '../preview/harness';
 import {
   BASELINE_STYLE,
+  FAST_POLL,
   STUB_PAGE,
   isGenerationRun,
   nameDesign,
@@ -61,7 +62,7 @@ async function settled(designId: string, timeout = 5_000) {
   await vi.waitFor(async () => {
     const design = await readDesign(harness.paths, designId);
     expect(design?.variants.every((variant) => variant.status !== 'pending' && variant.status !== 'running')).toBe(true);
-  }, { timeout });
+  }, { ...FAST_POLL, timeout });
   return (await readDesign(harness.paths, designId))!;
 }
 
@@ -142,12 +143,12 @@ describe('generating a variant', () => {
         .find(isGenerationRun);
       expect(found).toBeDefined();
       return found!;
-    });
+    }, FAST_POLL);
     try {
       await vi.waitFor(async () => {
         const state = await readStateWithIndexes(harness.paths);
         expect(state.designs[0]?.variants[0]?.progress).toBe('Writing the design files…');
-      });
+      }, FAST_POLL);
     } finally {
       finish?.();
     }

--- a/plugins/sero-design-library-plugin/runtime/generation/revise.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/revise.test.ts
@@ -6,6 +6,7 @@ import type { DesignBrief, DesignRecord } from '../../shared/design';
 import { appendRequest } from '../../shared/state-io';
 import {
   BASELINE_STYLE,
+  FAST_POLL,
   STUB_PAGE,
   isGenerationRun,
   nameDesign,
@@ -58,7 +59,7 @@ async function settled(): Promise<DesignRecord> {
         (variant) => variant.status !== 'pending' && variant.status !== 'running',
       ),
     ).toBe(true);
-  }, { timeout: 5_000 });
+  }, { ...FAST_POLL, timeout: 5_000 });
   return (await readDesign(harness.paths, 'dsn-1'))!;
 }
 
@@ -262,7 +263,7 @@ describe('revising a variant', () => {
     await restarted.start();
     await vi.waitFor(async () => {
       expect((await readDesign(harness.paths, 'dsn-1'))?.variants[0]?.status).toBe('ready');
-    }, { timeout: 5_000 });
+    }, { ...FAST_POLL, timeout: 5_000 });
     await restarted.dispose();
 
     expect(tasks.at(-1)).toContain('Make the metrics tighter');

--- a/plugins/sero-design-library-plugin/runtime/media-faults.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media-faults.test.ts
@@ -5,7 +5,7 @@ import { assetIsPending, currentAttempt } from '../shared/media';
 import { designAssetDir } from '../shared/paths';
 import { assetTarget } from '../shared/records';
 import { appendRequest, readStateWithIndexes } from '../shared/state-io';
-import { useCoordinator } from './coordinator-harness';
+import { FAST_POLL, useCoordinator } from './coordinator-harness';
 import { readDesign } from './design-store';
 import { createJob, markRunning, reconcileJobs } from './jobs';
 import { reserveAsset } from './media/assets';
@@ -54,7 +54,7 @@ describe('a provider that fails', () => {
       const found = await assetOf(harness.paths, 'design-1', 'asset-1');
       expect(found.attempts.length).toBeGreaterThan(0);
       return found;
-    });
+    }, FAST_POLL);
 
     // The asset exists, holds the failure, and owns no job — which is exactly
     // what the tray turns into a placeholder with a retry.
@@ -78,7 +78,7 @@ describe('a provider that fails', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'asset')?.status).toBe('failed');
-    });
+    }, FAST_POLL);
     // The Design is untouched — a provider outage is not a reason to lose it.
     const design = await readDesign(harness.paths, 'design-1');
     expect(design?.variants.length).toBeGreaterThan(0);
@@ -128,7 +128,7 @@ describe('a run that died holding an asset', () => {
       expect(currentAttempt(await assetOf(harness.paths, 'design-1', 'asset-1'))?.outcome).toBe(
         'ready',
       );
-    });
+    }, FAST_POLL);
 
     await reconcileJobs(harness.paths);
 
@@ -155,7 +155,7 @@ describe('purging an asset', () => {
       expect(currentAttempt(await assetOf(harness.paths, 'design-1', 'asset-1'))?.outcome).toBe(
         'ready',
       );
-    });
+    }, FAST_POLL);
     const directory = designAssetDir(harness.paths, 'design-1', 'asset-1');
     expect(await exists(directory)).toBe(true);
 
@@ -194,7 +194,7 @@ describe('purging an asset', () => {
       expect((await assetOf(harness.paths, 'design-1', 'asset-2')).attempts.length).toBeGreaterThan(
         0,
       );
-    });
+    }, FAST_POLL);
   });
 });
 
@@ -214,7 +214,7 @@ describe('retrying after a failure', () => {
       const found = await assetOf(harness.paths, 'design-1', 'asset-1');
       expect(found.attempts.length).toBeGreaterThan(0);
       return found;
-    });
+    }, FAST_POLL);
     expect(currentAttempt(failed)?.outcome).toBe('failed');
     const reference = failed.reference;
 
@@ -229,7 +229,7 @@ describe('retrying after a failure', () => {
       const found = await assetOf(harness.paths, 'design-1', 'asset-1');
       expect(found.attempts).toHaveLength(2);
       return found;
-    });
+    }, FAST_POLL);
     // Attempts append, never replace: "preserves history" is only true if the
     // attempt that failed is still something you can look at.
     expect(retried.attempts[0]?.outcome).toBe('failed');
@@ -257,7 +257,7 @@ describe('two jobs racing for one asset', () => {
     await harness.coordinator.drain();
     await vi.waitFor(async () => {
       expect((await assetOf(harness.paths, 'design-1', 'asset-1')).attempts.length).toBe(1);
-    });
+    }, FAST_POLL);
 
     // The orphan is still `queued`, so the next start reconciles it as
     // resumable and routes it to the media queue — the real path it takes.
@@ -265,7 +265,7 @@ describe('two jobs racing for one asset', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.id === orphan.id)?.status).toBe('failed');
-    });
+    }, FAST_POLL);
 
     // One attempt, not two: the orphan does not own the asset, so it must not
     // generate — that would be two provider calls and two charges for one press.
@@ -289,7 +289,7 @@ describe('a video the user declines', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'asset')?.status).toBe('failed');
-    });
+    }, FAST_POLL);
 
     // The refusal wrote no attempt, so without an explicit release the asset
     // keeps pointing at a finished job — and `media.retry` reads a live jobId
@@ -306,6 +306,6 @@ describe('a video the user declines', () => {
     await vi.waitFor(async () => {
       const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.filter((job) => job.target.kind === 'asset')).toHaveLength(2);
-    });
+    }, FAST_POLL);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/media/contract.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/contract.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MEDIA_CAPABILITIES } from '../../shared/media';
 import type { MediaProvider, MediaSourceAsset } from './contract';
@@ -190,17 +190,21 @@ describe('fal adapter specifics', () => {
   ])(
     'maps HTTP $status to $code (retryable: $retryable)',
     async ({ status, code, retryable }) => {
-      const attempt = await runWith(createFalTransport({ failStatus: status }));
+      // A 429 is retried inside the fal client with backoff — four attempts,
+      // about seven seconds of real waiting. The retry is shipped behaviour and
+      // stays under test; only the waiting is faked, so the mapping is still
+      // read from the last real attempt.
+      vi.useFakeTimers();
+      const pending = runWith(createFalTransport({ failStatus: status }));
+      await vi.advanceTimersByTimeAsync(60_000);
+      const attempt = await pending;
+      vi.useRealTimers();
 
       expect(attempt.error?.code).toBe(code);
       // The tray offers a retry button on the strength of this flag, so a wrong
       // answer here turns one wasted call into as many as the user will click.
       expect(attempt.error?.retryable).toBe(retryable);
     },
-    // 429 and 5xx are retried inside the client with backoff before the error
-    // surfaces — four attempts, so the default 5s is not enough. The wait is the
-    // shipped behaviour, not a slow test.
-    20_000,
   );
 
   it('maps an aspect ratio onto the provider image size', async () => {

--- a/plugins/sero-design-library-plugin/runtime/tweaks.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/tweaks.test.ts
@@ -10,6 +10,7 @@ import { appendRequest } from '../shared/state-io';
 import { TWEAK_MANIFEST_FILE, normalizeTweakDocument } from '../shared/tweaks';
 import {
   BASELINE_CONTROLS,
+  FAST_POLL,
   STUB_TWEAKABLE_PAGE,
   declareTweaks,
   isGenerationRun,
@@ -91,7 +92,7 @@ async function createDesign(): Promise<{ designId: string; variantId: string; re
   await vi.waitFor(async () => {
     const design = await readDesign(harness.paths, 'dsn-1');
     expect(design?.variants[0]?.status).toBe('ready');
-  }, { timeout: 5_000 });
+  }, { ...FAST_POLL, timeout: 5_000 });
 
   const design = (await readDesign(harness.paths, 'dsn-1'))!;
   const variant = design.variants[0]!;

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -17,6 +17,11 @@ import { GenerateDialog, type GenerateDialogProps } from './GenerateDialog';
  * working from the picture.
  */
 
+// `userEvent`'s default inter-key delay is a real macrotask per keystroke, and
+// these tests type whole sentences. `delay: null` dispatches the same events
+// back-to-back instead of waiting between them.
+const user = userEvent.setup({ delay: null });
+
 function renderDialog(overrides: Partial<GenerateDialogProps> = {}) {
   const onGenerate = vi.fn();
   render(
@@ -33,7 +38,7 @@ function renderDialog(overrides: Partial<GenerateDialogProps> = {}) {
 }
 
 async function chooseOperation(label: string) {
-  await userEvent.click(screen.getByRole('tab', { name: label }));
+  await user.click(screen.getByRole('tab', { name: label }));
 }
 
 describe('fresh generation', () => {
@@ -63,20 +68,20 @@ describe('a video model that only makes long clips', () => {
   it('says why, and will not let the generation be started', async () => {
     const { onGenerate } = renderDialog({ modelOptions: longOnly });
     await chooseOperation('Video');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
+    await user.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.getByText(/shorter/)).toBeDefined();
     const generate = screen.getByRole('button', { name: /Generate/ });
     expect(generate.hasAttribute('disabled')).toBe(true);
 
-    await userEvent.click(generate);
+    await user.click(generate);
     expect(onGenerate).not.toHaveBeenCalled();
   });
 
   it('lets a model through as soon as one length fits', async () => {
     renderDialog({ modelOptions: { 'text-to-video': { durationsSeconds: [5, 20] } } });
     await chooseOperation('Video');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
+    await user.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.queryByText(/shorter/)).toBeNull();
     expect(screen.getByRole('button', { name: /Generate/ }).hasAttribute('disabled')).toBe(false);
@@ -99,8 +104,8 @@ describe('remixing a reference', () => {
     expect(screen.queryByText('Increase its resolution')).toBeNull();
 
     await chooseOperation('Video');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
-    await userEvent.click(screen.getByRole('button', { name: 'Generate video' }));
+    await user.type(screen.getByLabelText('Describe it'), 'animate this');
+    await user.click(screen.getByRole('button', { name: 'Generate video' }));
 
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -114,8 +119,8 @@ describe('remixing a reference', () => {
   it('creates a new image from the current reference', async () => {
     const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
     await chooseOperation('Image');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'a new coastal composition');
-    await userEvent.click(screen.getByRole('button', { name: 'Generate image' }));
+    await user.type(screen.getByLabelText('Describe it'), 'a new coastal composition');
+    await user.click(screen.getByRole('button', { name: 'Generate image' }));
 
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,8 +143,8 @@ describe('remixing a reference', () => {
   it('restyles the current reference', async () => {
     const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
     await chooseOperation('Restyle');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'use a paper collage style');
-    await userEvent.click(screen.getByRole('button', { name: 'Restyle' }));
+    await user.type(screen.getByLabelText('Describe it'), 'use a paper collage style');
+    await user.click(screen.getByRole('button', { name: 'Restyle' }));
 
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -156,10 +161,10 @@ describe('remixing a reference', () => {
       modelOptions: { 'image-to-video': { supportsAspectRatio: false } },
     });
     await chooseOperation('Video');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
+    await user.type(screen.getByLabelText('Describe it'), 'animate this');
 
     expect(screen.queryByLabelText('Aspect')).toBeNull();
-    await userEvent.click(screen.getByRole('button', { name: 'Generate video' }));
+    await user.click(screen.getByRole('button', { name: 'Generate video' }));
     expect(onGenerate).toHaveBeenCalledWith(
       expect.not.objectContaining({ aspectRatio: expect.anything() }),
     );
@@ -179,9 +184,9 @@ describe('remixing a reference', () => {
     const source = screen.getByLabelText('Work from');
     source.focus();
     fireEvent.change(source, { target: { value: 'Reference 999' } });
-    await userEvent.keyboard('{ArrowDown}{Enter}');
-    await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
-    await userEvent.click(screen.getByRole('button', { name: 'Restyle' }));
+    await user.keyboard('{ArrowDown}{Enter}');
+    await user.type(screen.getByLabelText('Describe it'), 'a colder composition');
+    await user.click(screen.getByRole('button', { name: 'Restyle' }));
 
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({ sourceId: 'item-999' }),
@@ -203,8 +208,8 @@ describe('remixing a reference', () => {
   it('clears the selected source when the combobox is cleared', async () => {
     const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
     const source = screen.getByLabelText('Work from');
-    await userEvent.clear(source);
-    await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
+    await user.clear(source);
+    await user.type(screen.getByLabelText('Describe it'), 'a colder composition');
 
     expect(screen.getByRole('button', { name: 'Restyle' }).hasAttribute('disabled')).toBe(
       true,

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -21,6 +21,11 @@ vi.mock('@sero-ai/app-runtime', () => ({ useAppTools: () => ({ run }) }));
 // eslint-disable-next-line import/first -- must follow the mock above
 import { MediaSettings } from './MediaSettings';
 
+// `userEvent`'s default inter-key delay is a real macrotask per keystroke.
+// `delay: null` dispatches the same events back-to-back instead of waiting
+// between them.
+const user = userEvent.setup({ delay: null });
+
 const MEDIA: MediaSettingsValue = {
   models: {
     'text-to-image': 'flux/dev',
@@ -88,8 +93,8 @@ describe('the provider key', () => {
     renderSettings();
     await waitFor(() => expect(callsFor('key-status')).toHaveLength(1));
 
-    await userEvent.type(screen.getByLabelText('Provider key'), 'secret-key');
-    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await user.type(screen.getByLabelText('Provider key'), 'secret-key');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(callsFor('store-key')[0]?.[1]).toMatchObject({ key: 'secret-key' });
     // Read back, because FAL_KEY in the environment still wins: saying "stored"
@@ -118,13 +123,13 @@ describe('media models', () => {
     renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
-    await userEvent.click(screen.getByLabelText('Image'));
+    await user.click(screen.getByLabelText('Image'));
     expect(screen.getByText('fal-ai')).toBeDefined();
     expect(screen.getByText('openai')).toBeDefined();
-    await userEvent.clear(screen.getByLabelText('Image'));
-    await userEvent.type(screen.getByLabelText('Image'), 'OpenAI');
+    await user.clear(screen.getByLabelText('Image'));
+    await user.type(screen.getByLabelText('Image'), 'OpenAI');
     expect(screen.getByText('openai/image').classList.contains('text-xs')).toBe(true);
-    await userEvent.click(screen.getByRole('option', { name: /OpenAI Image/ }));
+    await user.click(screen.getByRole('option', { name: /OpenAI Image/ }));
 
     expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({
       capability: 'text-to-image',
@@ -136,7 +141,7 @@ describe('media models', () => {
     renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
-    await userEvent.click(screen.getByLabelText('Image'));
+    await user.click(screen.getByLabelText('Image'));
     expect(screen.getByText('Saved choice')).toBeDefined();
     expect(screen.getByRole('option', { name: 'flux/dev' })).toBeDefined();
   });
@@ -152,16 +157,16 @@ describe('media models', () => {
 
     expect((await screen.findByRole('alert')).textContent).toContain('returned 429');
     const input = screen.getByLabelText('Image');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'private/image-model');
-    await userEvent.click(screen.getByRole('option', { name: 'private/image-model' }));
+    await user.clear(input);
+    await user.type(input, 'private/image-model');
+    await user.click(screen.getByRole('option', { name: 'private/image-model' }));
 
     expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({
       capability: 'text-to-image',
       mediaModel: 'private/image-model',
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(2));
     expect(callsFor('list-media-models')[1]?.[1]).toMatchObject({ refresh: true });
   });
@@ -189,7 +194,7 @@ describe('media models', () => {
     renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
-    await userEvent.click(screen.getByLabelText('Image'));
+    await user.click(screen.getByLabelText('Image'));
     expect(screen.getByText('openai')).toBeDefined();
   });
 
@@ -206,7 +211,7 @@ describe('media models', () => {
   it('explains where each model is used', async () => {
     renderSettings();
 
-    await userEvent.hover(screen.getByRole('button', { name: 'How Animate is used' }));
+    await user.hover(screen.getByRole('button', { name: 'How Animate is used' }));
     expect((await screen.findByRole('tooltip')).textContent).toContain(
       'Used when a Design animates an existing image.',
     );
@@ -216,7 +221,7 @@ describe('media models', () => {
 describe('the per-run cap', () => {
   it('uses the bounded stepper to update the cap', async () => {
     renderSettings();
-    await userEvent.click(screen.getByRole('button', { name: 'One more media call' }));
+    await user.click(screen.getByRole('button', { name: 'One more media call' }));
 
     const written = callsFor('set-media-cap').map(([, params]) => params?.callsPerRun);
     expect(written).toEqual([7]);

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/room-commands.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/room-commands.test.ts
@@ -14,7 +14,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { AppRuntimeContext } from '@sero-ai/common';
@@ -31,6 +31,7 @@ import { createRoomStore, type RoomStore } from '../rooms/room-store';
 import { createRoomWork } from '../rooms/room-work';
 import { createRoomWorkspaces } from '../rooms/room-workspace';
 import { createFakeHost, type FakeHost } from './fake-host';
+import { disposeHarness } from './room-harness';
 import { envelopeWith, MEMBERS } from './room-member-fixtures';
 
 let dir: string;
@@ -145,10 +146,7 @@ beforeEach(async () => {
   await makeRoom();
 });
 
-afterEach(async () => {
-  await new Promise((resolve) => setTimeout(resolve, 25));
-  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-});
+afterEach(() => disposeHarness(dir));
 
 describe('who is calling', () => {
   it('resolves the caller from its session file and marks it on the roster', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/room-harness.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/room-harness.ts
@@ -7,6 +7,7 @@
  * harness and each file stays inside the size limit.
  */
 
+import { afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -55,11 +56,21 @@ export function restartCoordinator(host: FakeHost, store: RoomStore): RoomCoordi
   return new RoomCoordinator(host, { store, sessions: createMemberSessionPool({ host, store }) });
 }
 
-export async function disposeHarness(dir: string): Promise<void> {
-  // Turns run outside the Room lock, so a test can finish while one last write
-  // is in flight. Let the queue drain before the directory goes.
-  await new Promise((resolve) => setTimeout(resolve, 25));
-  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+/**
+ * Turns run outside the Room lock, so a test can finish while one last write is
+ * in flight. Removing the directory once the file is done lets those writes
+ * land, instead of every test paying a fixed sleep to wait them out.
+ */
+const usedDirs: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(
+    usedDirs.splice(0).map((used) => rm(used, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 })),
+  );
+});
+
+export function disposeHarness(dir: string): void {
+  usedDirs.push(dir);
 }
 
 export function envelopeWith(overrides: Partial<OperatingEnvelope> = {}): OperatingEnvelope {
@@ -158,9 +169,15 @@ export async function memberIn(store: RoomStore, roomId: string, memberId: strin
 
 /** Turns are launched outside the Room lock, so tests wait on the store, not on a call. */
 export async function waitFor(predicate: () => boolean | Promise<boolean>, label = 'condition'): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
+  // What is being waited on is a queued turn or a store write, so the next
+  // event-loop tick is usually enough; only a genuinely slow wait falls back to
+  // sleeping, and the deadline keeps a stuck condition from hanging the file.
+  const deadline = Date.now() + 2_000;
+  for (let attempt = 0; ; attempt += 1) {
     if (await predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+    await (attempt < 100
+      ? new Promise((resolve) => setImmediate(resolve))
+      : new Promise((resolve) => setTimeout(resolve, 5)));
   }
-  throw new Error(`timed out waiting for ${label}`);
 }


### PR DESCRIPTION
Part of #400. Step 2 of the agreed plan: repair the slowest test files.

## What this does

Step 1 timed all 737 test files in both environments. Half of all test time sat
in 25 files. This pull request repairs the 29 files above the 1.00s threshold.

Almost none of the time removed was useful work. It was fixed sleeps, debounce
waits, vendor retry backoff, poll intervals, and repeated process spawning.

## Measured result

Local, medians. Three runs before, six runs after, on an idle machine.

| Measure | Before | After | Change |
| --- | ---: | ---: | ---: |
| Test work, whole suite | 106.0s | 86.7s | **-19.3s (-19%)** |
| The 29 target files | 60.5s | 37.2s | **-23.3s** |
| Suite wall time | 76s | 72.5s | -3.5s |

**Every test count is unchanged, file for file.** Forced full typecheck: 24 of
24 packages, zero errors.

Largest single files:

| File | Before | After |
| --- | ---: | ---: |
| `runtime/media/contract.test.ts` | 7.43s | 0.12s |
| `extension/__tests__/state-watcher.test.ts` | 5.44s | 0.08s |
| `host-dev-server-manager.test.ts` | 4.52s | 0.03s |
| `dev-server.test.ts` | 1.92s | 0.79s |

Wall time moves much less than test time because the suite is import-bound on a
12-core machine: removing test work leaves cores idle. CI has 4 cores, so the
same saving should convert better there. This pull request exists partly to
measure that.

## What changed, by cause

**Real waiting.** Only the timer being waited on is faked, never the whole
clock, and each case proves the code still runs the same path:

- the vendor fal client still makes 5 attempts on a 429, verified with real and
  fake timers side by side;
- the cron watcher still observes real `fs.watch` events on a real directory —
  `fs.watch` is wrapped call-through so a test can await the real event, and
  only the 500ms debounce runs on a fake clock. `Date` stays real, so the
  own-write suppression window is still exercised.

**Repeated setup.** The git tests built a real repository per test, five process
spawns each. They now build each distinct starting state once per worker and
give each test its own copy. Real `git` still runs; only the setup is cheap.
Measured: 11 repositories by spawning 489ms, by copying 117ms.

**Poll intervals.** `vi.waitFor` defaults to a 50ms poll for work that finishes
in under a millisecond. Shared harnesses now pass a 1ms interval. Timeouts are
untouched, so a run that never settles still fails exactly as before.

**One assertion.** Deep equality over a 513KB buffer cost 485ms. `Buffer.equals`
proves the same property by memcmp. Verified not vacuous by flipping one byte.

## One production change

`ensurePluginDevServer` takes an optional `healthPollIntervalMs`, mirroring the
`terminateGraceMs` option `HostDevServerManager` already exposes. It defaults to
the shipped 500ms, so behaviour is unchanged and both production callers compile
untouched. The tests set it low instead of waiting out two real poll intervals.

## Rules held

No test was deleted, skipped or weakened. No assertion was loosened. No mock
replaced real work. Value review of tests is Step 4 and is not in this pull
request.

`describe.concurrent` was added to the git suites during the work and has been
removed again: measured, it saves 0.71s only when cores are idle, and total test
work is the same either way, so it would buy nothing on a saturated 4-core CI
runner while adding flake risk.

## Known unrelated failure

`@sero-ai/plugin-memory` session transcript export fails intermittently with
`ENOTEMPTY` during temp-directory cleanup. Measured 2 failures in 13 full runs
on this branch and 1 in 10 on the untouched baseline, which proves it is
pre-existing. It needs its own issue.
