### PR TITLE
fix(memory): await transcript log writes

### DIFF
--- a/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
@@ -44,15 +44,14 @@ describe('memory logger', () => {
   });
 
   it('writes daily logs under ~/.sero-ui/debug/memory using the local day and offset timestamp', async () => {
-    info('daily_log_test', { ok: true });
-    await vi.waitFor(async () => {
-      const content = await readFile(getMemoryLogPath(), 'utf8');
-      expect(getMemoryLogDirPath()).toBe(path.join(seroHome, 'debug', 'memory'));
-      expect(path.basename(getMemoryLogPath())).toBe(`${getLocalDayStamp(new Date())}.log`);
-      expect(content).toContain('daily_log_test');
-      expect(content).toContain('{"ok":true}');
-      expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2} \[INFO\] daily_log_test/m);
-    });
+    await info('daily_log_test', { ok: true });
+
+    const content = await readFile(getMemoryLogPath(), 'utf8');
+    expect(getMemoryLogDirPath()).toBe(path.join(seroHome, 'debug', 'memory'));
+    expect(path.basename(getMemoryLogPath())).toBe(`${getLocalDayStamp(new Date())}.log`);
+    expect(content).toContain('daily_log_test');
+    expect(content).toContain('{"ok":true}');
+    expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2} \[INFO\] daily_log_test/m);
   });
 
   it('reads logging settings from agent/settings.json', async () => {
@@ -92,12 +91,11 @@ describe('memory logger', () => {
       },
     }, null, 2));
 
-    info('truncation_test', { payload: 'x'.repeat(400) });
-    await vi.waitFor(async () => {
-      const content = await readFile(getMemoryLogPath(), 'utf8');
-      expect(content).toContain('truncation_test');
-      expect(content).toContain('[truncated ');
-    });
+    await info('truncation_test', { payload: 'x'.repeat(400) });
+
+    const content = await readFile(getMemoryLogPath(), 'utf8');
+    expect(content).toContain('truncation_test');
+    expect(content).toContain('[truncated ');
   });
 
   it('rotates daily logs with a bounded backup count', async () => {
@@ -115,16 +113,16 @@ describe('memory logger', () => {
       },
     }, null, 2));
 
-    info('rotate_1', { payload: 'a'.repeat(80) });
-    info('rotate_2', { payload: 'b'.repeat(80) });
-    info('rotate_3', { payload: 'c'.repeat(80) });
+    await Promise.all([
+      info('rotate_1', { payload: 'a'.repeat(80) }),
+      info('rotate_2', { payload: 'b'.repeat(80) }),
+      info('rotate_3', { payload: 'c'.repeat(80) }),
+    ]);
 
-    await vi.waitFor(async () => {
-      const names = await readdir(getMemoryLogDirPath());
-      expect(names).toContain(path.basename(getMemoryLogPath()));
-      expect(names).toContain(`${path.basename(getMemoryLogPath())}.1`);
-      expect(names).toContain(`${path.basename(getMemoryLogPath())}.2`);
-    });
+    const names = await readdir(getMemoryLogDirPath());
+    expect(names).toContain(path.basename(getMemoryLogPath()));
+    expect(names).toContain(`${path.basename(getMemoryLogPath())}.1`);
+    expect(names).toContain(`${path.basename(getMemoryLogPath())}.2`);
   });
 
   it('prunes daily logs older than the retention window', async () => {
@@ -144,12 +142,11 @@ describe('memory logger', () => {
     await writeFile(path.join(logDir, '2000-01-01.log'), 'stale\n', 'utf8');
     await writeFile(path.join(logDir, '2000-01-01.log.1'), 'stale\n', 'utf8');
 
-    info('retention_test', { ok: true });
-    await vi.waitFor(async () => {
-      const names = await readdir(logDir);
-      expect(names).not.toContain('2000-01-01.log');
-      expect(names).not.toContain('2000-01-01.log.1');
-      expect(names).toContain(path.basename(getMemoryLogPath()));
-    });
+    await info('retention_test', { ok: true });
+
+    const names = await readdir(logDir);
+    expect(names).not.toContain('2000-01-01.log');
+    expect(names).not.toContain('2000-01-01.log.1');
+    expect(names).toContain(path.basename(getMemoryLogPath()));
   });
 });

--- a/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { parseMemoryEntries } from '../memory-format';
 import {
@@ -11,6 +11,7 @@ import {
   handleReplace,
   handleWrite,
 } from '../memory-tool';
+import * as logger from '../logger';
 import { getMemoryPath, getUserPath } from '../memory-manager';
 
 function getText(result: Awaited<ReturnType<typeof handleWrite>>): string {
@@ -35,6 +36,7 @@ describe('memory tool CRUD semantics', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     process.env.SERO_HOME = originalEnv.SERO_HOME;
     process.env.PI_CODING_AGENT_DIR = originalEnv.PI_CODING_AGENT_DIR;
     await rm(seroHome, { recursive: true, force: true });
@@ -72,6 +74,28 @@ describe('memory tool CRUD semantics', () => {
 
     const readWithIds = await handleRead(root, 'memory', undefined, true);
     expect(getText(readWithIds)).toContain(`<!-- id: ${firstEntry!.id} -->`);
+  });
+
+  it('waits for its log write before a read resolves', async () => {
+    await handleWrite(root, 'memory', 'Remember the release date.');
+
+    let finishLogWrite: () => void = () => undefined;
+    const logWrite = new Promise<void>((resolve) => {
+      finishLogWrite = resolve;
+    });
+    const infoSpy = vi.spyOn(logger, 'info').mockReturnValueOnce(logWrite);
+    let readCompleted = false;
+
+    const readPromise = handleRead(root, 'memory').then((result) => {
+      readCompleted = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(infoSpy).toHaveBeenCalledOnce());
+    expect(readCompleted).toBe(false);
+
+    finishLogWrite();
+    await expect(readPromise).resolves.toMatchObject({ content: expect.any(Array) });
   });
 
   it('enforces the MEMORY.md visible-capacity limit before writing', async () => {

--- a/plugins/sero-memory-plugin/extension/__tests__/session-transcripts.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/session-transcripts.test.ts
@@ -2,12 +2,13 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   exportTranscriptForSession,
   type SessionTranscriptExportResult,
 } from '../session-transcripts';
+import * as logger from '../logger';
 import { getSessionTranscriptPath } from '../memory-manager';
 
 type ExportSessionManager = Parameters<typeof exportTranscriptForSession>[0];
@@ -72,6 +73,7 @@ describe('session transcript export', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     process.env.SERO_HOME = originalEnv.SERO_HOME;
     process.env.PI_CODING_AGENT_DIR = originalEnv.PI_CODING_AGENT_DIR;
     await rm(seroHome, { recursive: true, force: true });
@@ -104,5 +106,31 @@ describe('session transcript export', () => {
     });
 
     await expect(readFile(transcriptPath, 'utf8')).resolves.toBe(transcript);
+    await expect(readFile(logger.getMemoryLogPath(), 'utf8')).resolves.toContain(
+      'session_transcript_skipped',
+    );
+  });
+
+  it('waits for its log write before the export resolves', async () => {
+    let finishLogWrite: () => void = () => undefined;
+    const logWrite = new Promise<void>((resolve) => {
+      finishLogWrite = resolve;
+    });
+    const infoSpy = vi.spyOn(logger, 'info').mockReturnValueOnce(logWrite);
+    let exportCompleted = false;
+
+    const exportPromise = exportTranscriptForSession(
+      createSessionManager(),
+      'session_start',
+    ).then((result) => {
+      exportCompleted = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(infoSpy).toHaveBeenCalledOnce());
+    expect(exportCompleted).toBe(false);
+
+    finishLogWrite();
+    await expect(exportPromise).resolves.toMatchObject({ changed: true });
   });
 });

--- a/plugins/sero-memory-plugin/extension/log-writer.ts
+++ b/plugins/sero-memory-plugin/extension/log-writer.ts
@@ -54,7 +54,7 @@ export function appendRotatingLogLine(options: {
   warningKey: string;
   warningMessage: string;
   beforeAppend?: () => Promise<void>;
-}): void {
+}): Promise<void> {
   const previous = writeQueues.get(options.filePath) ?? Promise.resolve();
   const next = previous
     .catch(() => undefined)
@@ -74,4 +74,5 @@ export function appendRotatingLogLine(options: {
   });
 
   writeQueues.set(options.filePath, tracked);
+  return tracked;
 }

--- a/plugins/sero-memory-plugin/extension/logger.ts
+++ b/plugins/sero-memory-plugin/extension/logger.ts
@@ -77,7 +77,11 @@ async function pruneOldDailyLogs(retentionDays: number): Promise<void> {
   }));
 }
 
-export function log(level: MemoryLogLevel, event: string, data?: Record<string, unknown>): void {
+export function log(
+  level: MemoryLogLevel,
+  event: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
   const now = new Date();
   const ts = formatLocalTimestamp(now);
   const settings = getMemoryLoggingSettingsSync();
@@ -92,7 +96,7 @@ export function log(level: MemoryLogLevel, event: string, data?: Record<string, 
     console.log(consoleLine);
   }
 
-  appendRotatingLogLine({
+  return appendRotatingLogLine({
     filePath: resolveLogPath(now),
     line: `${line}\n`,
     maxBytes: settings.maxBytesPerFile,

--- a/plugins/sero-memory-plugin/extension/memory-tool.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool.ts
@@ -95,7 +95,7 @@ function formatStructuredLinePreview(textValue: string): string {
 async function loadStructuredMemory(root: string): Promise<{ entries: ReturnType<typeof parseMemoryEntries>; content: string | null }> {
   const filePath = resolveTargetPath(root, 'memory')!.path;
   const content = await readFile(filePath);
-  info('memory_load_structured', {
+  await info('memory_load_structured', {
     filePath,
     exists: Boolean(content?.trim()),
     chars: content?.length ?? 0,
@@ -107,7 +107,7 @@ async function loadStructuredMemory(root: string): Promise<{ entries: ReturnType
     if (parsed.some((entry) => !entry.hasId)) {
       const nextContent = serializeMemoryEntries(parsed, nowTimestamp());
       await writeFile(filePath, nextContent);
-      info('memory_load_structured_rewrote_missing_ids', {
+      await info('memory_load_structured_rewrote_missing_ids', {
         filePath,
         parsedEntries: parsed.length,
       });
@@ -117,7 +117,7 @@ async function loadStructuredMemory(root: string): Promise<{ entries: ReturnType
   }
 
   const normalizedEntries = normalizeLegacyMemory(content);
-  info('memory_load_structured_legacy_detected', {
+  await info('memory_load_structured_legacy_detected', {
     filePath,
     normalizedEntries: normalizedEntries.length,
   });
@@ -125,7 +125,7 @@ async function loadStructuredMemory(root: string): Promise<{ entries: ReturnType
 
   const nextContent = serializeMemoryEntries(normalizedEntries, nowTimestamp());
   await writeFile(filePath, nextContent);
-  info('memory_load_structured_normalized', {
+  await info('memory_load_structured_normalized', {
     filePath,
     normalizedEntries: normalizedEntries.length,
   });
@@ -166,7 +166,7 @@ export async function handleRead(root: string, target?: string, date?: string, w
       ? await loadStructuredMemory(root)
       : { content: await readFile(resolved.path), entries: [] };
     if (!content) return text(`${resolved.displayName} not found or empty.`);
-    info('memory_read', {
+    await info('memory_read', {
       target,
       path: resolved.path,
       withIds: withIds === true,
@@ -396,7 +396,7 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
       const root = resolveMemoryRoot();
       await ensureDirectories(root);
       const p = params as MemoryParamsType;
-      info('memory_tool_execute', {
+      await info('memory_tool_execute', {
         action: p.action,
         target: p.target ?? null,
         withIds: p.with_ids ?? null,
@@ -438,7 +438,7 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
             return text(`Unknown action: ${p.action}`);
         }
       } catch (err) {
-        error('memory_tool_execute_failed', {
+        await error('memory_tool_execute_failed', {
           action: p.action,
           target: p.target ?? null,
           ...errorDetails(err),

--- a/plugins/sero-memory-plugin/extension/session-transcripts.ts
+++ b/plugins/sero-memory-plugin/extension/session-transcripts.ts
@@ -187,7 +187,7 @@ export async function exportTranscriptForSession(
     (entry: (typeof branch)[number]): entry is SessionMessageEntry => entry.type === 'message',
   );
   if (messageEntries.length === 0) {
-    info('session_transcript_skipped', { source, reason: 'no_messages' });
+    await info('session_transcript_skipped', { source, reason: 'no_messages' });
     return { changed: false, reason: 'no_messages' };
   }
 
@@ -197,7 +197,7 @@ export async function exportTranscriptForSession(
   const transcript = buildTranscriptMarkdown(messageEntries, sessionId, date);
   const existing = await readFile(transcriptPath);
   if (existing === transcript) {
-    info('session_transcript_skipped', {
+    await info('session_transcript_skipped', {
       source,
       sessionId,
       path: transcriptPath,
@@ -207,7 +207,7 @@ export async function exportTranscriptForSession(
   }
 
   await writeFile(transcriptPath, transcript);
-  info('session_transcript_exported', {
+  await info('session_transcript_exported', {
     source,
     sessionId,
     path: transcriptPath,
@@ -218,8 +218,8 @@ export async function exportTranscriptForSession(
 
 async function runBackfill(): Promise<{ exported: number; skipped: number }> {
   const sessionDir = getSessionStoreDir();
-  const sessionInfos = await SessionManager.list(os.homedir(), sessionDir).catch((err) => {
-    error('session_transcript_backfill_list_failed', errorDetails(err));
+  const sessionInfos = await SessionManager.list(os.homedir(), sessionDir).catch(async (err) => {
+    await error('session_transcript_backfill_list_failed', errorDetails(err));
     return [];
   });
 
@@ -232,7 +232,7 @@ async function runBackfill(): Promise<{ exported: number; skipped: number }> {
       if (result.changed) exported += 1;
       else skipped += 1;
     } catch (err) {
-      error('session_transcript_backfill_open_failed', {
+      await error('session_transcript_backfill_open_failed', {
         sessionPath: infoRecord.path,
         ...errorDetails(err),
       });
@@ -240,7 +240,7 @@ async function runBackfill(): Promise<{ exported: number; skipped: number }> {
   }
 
   backfillCompleted = true;
-  info('session_transcript_backfill_complete', { sessionDir, exported, skipped });
+  await info('session_transcript_backfill_complete', { sessionDir, exported, skipped });
   return { exported, skipped };
 }
 
@@ -250,8 +250,8 @@ async function runBackfill(): Promise<{ exported: number; skipped: number }> {
  */
 export function startBackfillInBackground(): void {
   if (backfillCompleted || backfillPromise) return;
-  backfillPromise = runBackfill().catch((err) => {
-    error('session_transcript_backfill_background_failed', errorDetails(err));
+  backfillPromise = runBackfill().catch(async (err) => {
+    await error('session_transcript_backfill_background_failed', errorDetails(err));
     backfillCompleted = true;
     return { exported: 0, skipped: 0 };
   });


### PR DESCRIPTION
## Summary

- Return the pending file-write promise from the memory logger.
- Wait for transcript, backfill, and memory tool log writes before each operation completes.
- Add deterministic tests for both cleanup race paths.
- Make logger tests wait for file writes directly.

## Tests

- `pnpm --filter @sero-ai/plugin-memory test`
- `pnpm --filter @sero-ai/plugin-memory typecheck`
- `pnpm typecheck`
- 10 repeated `pnpm turbo run test --force --filter=@sero-ai/plugin-memory` runs

Documentation does not need a change because this fix does not change user behavior.

Closes #423