### PR TITLE
perf(ui): replace plugin barrel imports

### DIFF
--- a/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
+++ b/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { Plus, Settings2, Sparkles } from 'lucide-react';
 import { useMemo, useRef, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
@@ -1,4 +1,5 @@
-import { Button, Input } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import { Minus, Plus } from 'lucide-react';
 
 export interface CountStepperProps {

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -1,28 +1,17 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   Combobox,
   ComboboxContent,
   ComboboxEmpty,
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  Textarea,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/combobox';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@sero-ai/ui/components/ui/dialog';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@sero-ai/ui/components/ui/tabs';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { Sparkles } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/ItemCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemCard.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Check, Clock, ImageOff, Pencil, Star, TriangleAlert } from 'lucide-react';
 
 import type { ItemSummary } from '../../shared/types';

--- a/plugins/sero-design-library-plugin/ui/components/ItemInspector.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemInspector.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { TriangleAlert } from 'lucide-react';
 
 import type { LibrarianField } from '../../shared/librarian';

--- a/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
@@ -1,12 +1,12 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Input,
-  ScrollArea,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dropdown-menu';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Clock, Diamond, MoreHorizontal, Plus, Sparkles, Star, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -1,17 +1,19 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   Combobox,
   ComboboxContent,
   ComboboxEmpty,
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
+} from '@sero-ai/ui/components/ui/combobox';
+import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  SearchInput,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dropdown-menu';
+import { SearchInput } from '@sero-ai/ui/components/ui/search-input';
 import { ArrowDownUp } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
@@ -1,6 +1,6 @@
 import { useAppTools } from '@sero-ai/app-runtime';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   Combobox,
   ComboboxCollection,
   ComboboxContent,
@@ -10,11 +10,9 @@ import {
   ComboboxItem,
   ComboboxLabel,
   ComboboxList,
-  Label,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/combobox';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
 import { Info } from 'lucide-react';
 import { useEffect, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
@@ -1,5 +1,7 @@
 import { useAppTools } from '@sero-ai/app-runtime';
-import { Button, Input, TooltipProvider } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { TooltipProvider } from '@sero-ai/ui/components/ui/tooltip';
 import { useEffect, useState } from 'react';
 
 import type { CredentialStatus } from '../../shared/media';

--- a/plugins/sero-design-library-plugin/ui/components/PendingItemTile.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/PendingItemTile.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { AlertTriangle, Loader2 } from 'lucide-react';
 
 import type { PendingGeneration } from '../lib/pending-generations';

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
@@ -1,10 +1,10 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dropdown-menu';
 import { FolderPlus, RotateCw, Shuffle, Sparkles, Star, Trash2, X } from 'lucide-react';
 
 import { MAX_REFERENCES } from '../../shared/design';

--- a/plugins/sero-design-library-plugin/ui/components/design/BriefFields.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/BriefFields.tsx
@@ -1,15 +1,8 @@
-import {
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Slider,
-  Textarea,
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@sero-ai/ui';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
+import { Slider } from '@sero-ai/ui/components/ui/slider';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { ToggleGroup, ToggleGroupItem } from '@sero-ai/ui/components/ui/toggle-group';
 
 import type { DesignBrief } from '../../../shared/design';
 import { MAX_VARIANTS, MIN_VARIANTS } from '../../../shared/design';

--- a/plugins/sero-design-library-plugin/ui/components/design/CreateDesignDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/CreateDesignDialog.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@sero-ai/ui/components/ui/dialog';
 import { Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/design/DesignLoadingState.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/DesignLoadingState.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@sero-ai/ui';
+import { Spinner } from '@sero-ai/ui/components/ui/spinner';
 
 /** Visible progress over the design itself, including while revising a preview. */
 export function DesignLoadingState({ message }: { message: string }) {

--- a/plugins/sero-design-library-plugin/ui/components/design/FontPicker.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/FontPicker.tsx
@@ -1,4 +1,5 @@
-import { Button, Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { Check, ChevronDown } from 'lucide-react';
 
 import type { TweakOption, TweakValue } from '../../../shared/tweaks';

--- a/plugins/sero-design-library-plugin/ui/components/design/GuardrailChips.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/GuardrailChips.tsx
@@ -1,4 +1,5 @@
-import { Input, Label } from '@sero-ai/ui';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
 import { Check, Plus, X } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/design/PreviewControls.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/PreviewControls.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
   Maximize2,
   Monitor,

--- a/plugins/sero-design-library-plugin/ui/components/design/ReviseBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/ReviseBar.tsx
@@ -1,4 +1,6 @@
-import { Button, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
 import { Sparkles } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/design/SessionsRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/SessionsRail.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 import type { DesignSummary } from '../../../shared/types';

--- a/plugins/sero-design-library-plugin/ui/components/design/SynthesisRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/SynthesisRail.tsx
@@ -1,4 +1,5 @@
-import { Button, Spinner } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Spinner } from '@sero-ai/ui/components/ui/spinner';
 import { AlertTriangle, Check, Sparkles } from 'lucide-react';
 
 import type { ConflictResolution, GuardrailSynthesis } from '../../../shared/synthesis';

--- a/plugins/sero-design-library-plugin/ui/components/design/TweakControl.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/TweakControl.tsx
@@ -1,4 +1,6 @@
-import { Button, Slider, Switch } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Slider } from '@sero-ai/ui/components/ui/slider';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
 import { RotateCcw } from 'lucide-react';
 
 import type { TweakDefinition, TweakValue } from '../../../shared/tweaks';

--- a/plugins/sero-design-library-plugin/ui/components/design/TweaksPanel.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/TweaksPanel.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/design/VariantInspector.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/VariantInspector.tsx
@@ -1,4 +1,5 @@
-import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@sero-ai/ui/components/ui/tabs';
 import {
   FileCode,
   History,

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Copy, Library, RotateCw, Shuffle, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/DesignTab.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/DesignTab.tsx
@@ -1,4 +1,5 @@
-import { Badge, ScrollArea } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 
 import type { DesignReferenceView } from '../references';
 import { Block, Field } from './Field';

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/FilesTab.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/FilesTab.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { FolderOpen } from 'lucide-react';
 
 import type { DesignRevisionFile } from '../../../../shared/design';

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/HistoryTab.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/HistoryTab.tsx
@@ -1,4 +1,5 @@
-import { Button, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Check } from 'lucide-react';
 
 import type { DesignRevision } from '../../../../shared/design';

--- a/plugins/sero-design-library-plugin/ui/components/gallery/ExportNotifications.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/ExportNotifications.test.tsx
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
   canShowItemInFolder: vi.fn(),
 }));
 
-vi.mock('@sero-ai/ui', () => ({
+vi.mock('@sero-ai/ui/components/ui/sonner', () => ({
   Toaster: () => null,
 }));
 vi.mock('sonner', () => ({

--- a/plugins/sero-design-library-plugin/ui/components/gallery/ExportNotifications.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/ExportNotifications.tsx
@@ -1,5 +1,5 @@
 import { openSeroFile } from '@sero-ai/app-runtime';
-import { Toaster } from '@sero-ai/ui';
+import { Toaster } from '@sero-ai/ui/components/ui/sonner';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
@@ -1,15 +1,11 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dropdown-menu';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
 import { SquareArrowOutUpRight, Heart, ImageOff, MoreHorizontal } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 
 import type { GalleryFamilyRecord } from '../../../shared/gallery';
 import type { GalleryActions } from '../../hooks/useGallery';

--- a/plugins/sero-design-library-plugin/ui/components/inspector/EditableField.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/inspector/EditableField.tsx
@@ -1,4 +1,6 @@
-import { Button, Input, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { Pencil, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/components/inspector/FieldValue.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/inspector/FieldValue.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
 
 import type {
   LibrarianField,

--- a/plugins/sero-design-library-plugin/ui/components/inspector/InspectorHeader.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/inspector/InspectorHeader.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { RotateCw, Star, Trash2, X } from 'lucide-react';
 
 import type { ItemSummary } from '../../../shared/types';

--- a/plugins/sero-design-library-plugin/ui/pages/DesignPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/DesignPage.tsx
@@ -1,9 +1,5 @@
-import {
-  Button,
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@sero-ai/ui/components/ui/resizable';
 import { createDebouncedFn } from '@sero-ai/common';
 import { ArrowLeft, Images, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
@@ -1,4 +1,5 @@
-import { ScrollArea, SearchInput } from '@sero-ai/ui';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
+import { SearchInput } from '@sero-ai/ui/components/ui/search-input';
 import { Clock, Heart, Images, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/pages/ItemPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/ItemPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { ChevronRight, ImageOff } from 'lucide-react';
 
 import type { Collection } from '../../shared/records';

--- a/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
@@ -1,4 +1,6 @@
-import { Button, Progress, ScrollArea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Progress } from '@sero-ai/ui/components/ui/progress';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { ImagePlus, Sparkles, Upload } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 

--- a/plugins/sero-design-library-plugin/ui/pages/SettingsPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/SettingsPage.tsx
@@ -1,4 +1,9 @@
-import { Button, Input, Label, ScrollArea, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { useAppTools, useAvailableModels } from '@sero-ai/app-runtime';
 import { AvailableModelPicker } from '@sero-ai/ui/model-selection/available-model-picker';
 import { Plus, Trash2 } from 'lucide-react';

--- a/plugins/sero-design-library-plugin/ui/tsconfig.json
+++ b/plugins/sero-design-library-plugin/ui/tsconfig.json
@@ -8,7 +8,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
+    }
   },
   "include": ["./**/*", "../shared/**/*"],
   "exclude": [

--- a/plugins/sero-orchestrator-plugin/ui/components/AttemptHistory.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/AttemptHistory.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import { Badge, Button, Card } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { Send, Zap } from 'lucide-react';
 import type { LoopRunStatus, LoopRunSummary } from '../../shared/types';
 import { formatCost, formatDuration, formatTime, formatTokens } from '../lib/format';

--- a/plugins/sero-orchestrator-plugin/ui/components/AttentionLoopCards.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/AttentionLoopCards.tsx
@@ -6,7 +6,8 @@
  */
 
 import { useMemo, useState } from 'react';
-import { Button, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import type { LoopAttentionInput, LoopAttentionSuggestion, LoopSummary, OrchestratorAction } from '../../shared/types';
 import { allAnswered, buildAnswers, withChoice, withText, type AnswerDraft } from '../lib/answer-draft';
 import { EventCard, Pill } from './room-kit';

--- a/plugins/sero-orchestrator-plugin/ui/components/AttentionQueue.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/AttentionQueue.tsx
@@ -12,7 +12,7 @@
 
 import { useState } from 'react';
 import type { ReactNode } from 'react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { LoopSummary, OrchestratorAction } from '../../shared/types';
 import type { RoomSummary } from '../../shared/room-types';
 import { AttentionInputCard, AttentionSuggestionCard } from './AttentionLoopCards';

--- a/plugins/sero-orchestrator-plugin/ui/components/CatalogBrowser.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CatalogBrowser.tsx
@@ -7,17 +7,17 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Plus, RefreshCw, Search, X } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import {
-  Button,
-  Card,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dialog';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import type { CatalogRepoContents, CatalogRepoRef } from '../../shared/catalog-types';
 import type { LibraryIndex } from '../../shared/types';
 import { installState } from '../lib/catalog-summary';

--- a/plugins/sero-orchestrator-plugin/ui/components/CatalogEntryCard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CatalogEntryCard.tsx
@@ -7,7 +7,8 @@
 
 import { useState } from 'react';
 import { BadgeCheck, ChevronDown, ChevronRight, Download } from 'lucide-react';
-import { Button, Card } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import type { CatalogEntry } from '../../shared/catalog-types';
 import { entryChips, type CatalogInstallState } from '../lib/catalog-summary';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/CreateLoopForm.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CreateLoopForm.tsx
@@ -1,17 +1,11 @@
 import { useState } from 'react';
-import {
-  Button,
-  Card,
-  Input,
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Switch,
-  Textarea,
-} from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { Loader2 } from 'lucide-react';
 import type { DeliveryDestinationId, LoopDeliverySettings } from '../../shared/types';
 import { LOOP_DELIVERY_DESTINATIONS, deliveryDestinationInfo, isLoopDeliveryDestinationId } from '../../shared/delivery-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/CreateLoopWizard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CreateLoopWizard.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useState } from 'react';
-import { Button, Card } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { Sparkles } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import { useWatchedJson } from '../lib/use-watched-json';

--- a/plugins/sero-orchestrator-plugin/ui/components/HomeView.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/HomeView.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { Input } from '@sero-ai/ui';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import { Search } from 'lucide-react';
 import { WORKFLOW_LABEL, WORKFLOWS_LABEL } from '../../shared/labels';
 import type { LoopSummary, OrchestratorAction } from '../../shared/types';

--- a/plugins/sero-orchestrator-plugin/ui/components/InputRequestCard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/InputRequestCard.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useState } from 'react';
-import { Badge, Button, Card, Textarea } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { MessageCircleQuestion } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import { allAnswered as allAnsweredFn, buildAnswers, withChoice, withText, type AnswerDraft } from '../lib/answer-draft';

--- a/plugins/sero-orchestrator-plugin/ui/components/LibraryBrowser.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LibraryBrowser.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
-import { Button, Card, Input } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import { Download, History, Search } from 'lucide-react';
 import { DEFAULT_LIBRARY_INDEX } from '../../shared/defaults';
 import type { LibraryEntrySummary, LibraryIndex } from '../../shared/types';

--- a/plugins/sero-orchestrator-plugin/ui/components/LibraryLinkBadge.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LibraryLinkBadge.tsx
@@ -6,7 +6,7 @@
  * which only renders when there's something to do.
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { Bookmark, Link2Off } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import type { LibraryLinkStatus } from '../lib/use-library-link';

--- a/plugins/sero-orchestrator-plugin/ui/components/LibraryLinkSection.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LibraryLinkSection.tsx
@@ -6,7 +6,8 @@
  * simply-linked loop costs no body space. See specs/09-ui-redesign.md.
  */
 
-import { Button, Card } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { ArrowUpCircle, Sparkles } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import { readaptPrompt } from '../lib/catalog-summary';

--- a/plugins/sero-orchestrator-plugin/ui/components/LibrarySaveControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LibrarySaveControl.tsx
@@ -6,7 +6,18 @@
  */
 
 import { useState } from 'react';
-import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Input, Label, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@sero-ai/ui/components/ui/dialog';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { BookmarkPlus } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/LibraryView.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LibraryView.tsx
@@ -6,7 +6,7 @@
 
 import { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { LibraryIndex } from '../../shared/types';
 import { CatalogBrowser } from './CatalogBrowser';
 import { LibraryBrowser } from './LibraryBrowser';

--- a/plugins/sero-orchestrator-plugin/ui/components/LiveActivityStrip.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LiveActivityStrip.tsx
@@ -6,7 +6,7 @@
  * timer and no polling: elapsed reflects the moment of the last step update.
  */
 
-import { Card } from '@sero-ai/ui';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import type { Loop, RunIndex } from '../../shared/types';
 import { formatCost, formatDuration } from '../lib/format';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopContextControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopContextControl.tsx
@@ -9,7 +9,7 @@
 
 import { useState } from 'react';
 import { Settings2 } from 'lucide-react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { ContextPreset } from '@sero-ai/common';
 import { useSubagentContext, useContextPresets } from '@sero-ai/app-runtime';
 import { ContextEditor } from '@sero-ai/ui/components/context-editor/ContextEditor';

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopControls.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopControls.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import { Button, Checkbox, Label } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Checkbox } from '@sero-ai/ui/components/ui/checkbox';
+import { Label } from '@sero-ai/ui/components/ui/label';
 import { Power, PowerOff, RotateCcw, StepForward, Trash2, Zap } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDeliveryControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDeliveryControl.tsx
@@ -8,21 +8,17 @@
 
 import { useState } from 'react';
 import { Send } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dialog';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
 import type { DeliveryDestinationId, Loop, OrchestratorAction } from '../../shared/types';
 import { LOOP_DELIVERY_DESTINATIONS, deliveryDestinationInfo, effectiveDelivery } from '../../shared/delivery-types';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import { Button, Card } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { AlertTriangle, Sparkles } from 'lucide-react';
 import type {
   GithubSourceHealth,

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopList.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { Button, Input } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import { ArrowUpCircle, Plus, Search } from 'lucide-react';
 import { DEFAULT_LIBRARY_INDEX } from '../../shared/defaults';
 import type { LibraryIndex, LoopSummary } from '../../shared/types';

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopsOverview.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopsOverview.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { OrchestratorScheduleSummary } from '@sero-ai/common';
 import type { LoopStatus, LoopSummary } from '../../shared/types';
 import { formatCost, formatRelative } from '../lib/format';

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useId, useMemo, useState } from 'react';
-import { Badge, Button, Card } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import {
   Bot,
   Check,

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ToggleGroup, ToggleGroupItem } from '@sero-ai/ui';
+import { ToggleGroup, ToggleGroupItem } from '@sero-ai/ui/components/ui/toggle-group';
 import { Columns3, ListTree, Map, Rows3 } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import { PlanMap, type PlanMapOrientationSetting } from './PlanMap';

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanView.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanView.tsx
@@ -1,6 +1,6 @@
 import { useAvailableModels, useSubagentContext } from '@sero-ai/app-runtime';
 import type { Loop, LoopStepDefinition, OrchestratorAction } from '../../shared/types';
-import { Card } from '@sero-ai/ui';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { isStuckOnAttempts, RECOVERABLE_STEP_STATUSES } from '../../shared/recovery';
 import { fanOutView } from '../lib/fan-out-summary';
 import { groupStepsByLevel } from '../lib/plan-levels';

--- a/plugins/sero-orchestrator-plugin/ui/components/RefinePlan.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RefinePlan.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Button, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { Sparkles, Wand2 } from 'lucide-react';
 
 interface RefinePlanProps {

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomAdvancedSettings.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomAdvancedSettings.tsx
@@ -13,7 +13,8 @@
  */
 
 import { useState } from 'react';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, cn } from '@sero-ai/ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@sero-ai/ui/components/ui/select';
+import { cn } from '@sero-ai/ui/lib/utils';
 import type { BlueprintMember, RoomBlueprint } from '../../shared/room-blueprint-types';
 import { computeProposalSummary } from '../../shared/room-proposal';
 import { accessTile } from '../lib/access-tile';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomApprovalCard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomApprovalCard.tsx
@@ -7,7 +7,7 @@
  * another. Only the user answers it; no member can, not even the Conductor.
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { RoomAttentionApproval } from '../../shared/attention-types';
 import type { RoomSummary } from '../../shared/room-types';
 import { EventCard, Pill } from './room-kit';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomArtifactLink.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomArtifactLink.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { openSeroFile } from '@sero-ai/app-runtime';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@sero-ai/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
 import { cn } from '@sero-ai/ui/lib/utils';
 
 interface RoomArtifactLinkProps {

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomAttentionCards.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomAttentionCards.tsx
@@ -12,7 +12,8 @@
  */
 
 import { useState } from 'react';
-import { Button, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import type { RoomAttentionPause, RoomAttentionRequest } from '../../shared/attention-types';
 import type { RoomSummary } from '../../shared/room-types';
 import { EventCard, Pill } from './room-kit';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomBriefForm.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomBriefForm.tsx
@@ -9,7 +9,10 @@
  */
 
 import { useState } from 'react';
-import { Button, Select, SelectContent, SelectItem, SelectTrigger, Textarea, cn } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@sero-ai/ui/components/ui/select';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { cn } from '@sero-ai/ui/lib/utils';
 import { DELIVERY_DESTINATIONS, defaultDeliveryFor } from '../../shared/delivery-types';
 import type { DeliveryDestinationId } from '../../shared/delivery-types';
 import type { MemberPermissionLevel } from '../../shared/room-blueprint-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomDesktopLayout.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomDesktopLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@sero-ai/ui';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@sero-ai/ui/components/ui/resizable';
 import { useOrchestratorState } from '../lib/orchestrator-state';
 
 type LayoutMode = 'narrow' | 'roster' | 'rosterAndDetails';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomDetail.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomDetail.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useState } from 'react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { TERMINAL_ROOM_STATUSES, type RoomSummary } from '../../shared/room-types';
 import { useRoom } from '../lib/use-room-index';
 import { memberNames, useRoomMembers } from '../lib/use-room-members';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomDraftReview.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomDraftReview.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState } from 'react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import type { BlueprintClamp } from '../../shared/room-clamp';
 import type { HumanQuestion } from '../../shared/human-input-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomMemberFacts.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomMemberFacts.tsx
@@ -9,7 +9,7 @@
  */
 
 import { cn } from '@sero-ai/ui/lib/utils';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@sero-ai/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
 import type { PersistentSessionContextUsage } from '@sero-ai/common';
 import type { MemberLiveSnapshot } from '../../shared/room-live-types';
 import type { RoomMember } from '../../shared/room-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomMemberPanel.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomMemberPanel.tsx
@@ -13,7 +13,8 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { X } from 'lucide-react';
 import type { MemberLiveSnapshot } from '../../shared/room-live-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomMemberTranscript.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomMemberTranscript.tsx
@@ -8,7 +8,7 @@
  * green is reserved for the live state rather than historical message roles.
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { PersistentSessionHistoryEntry } from '@sero-ai/common';
 import type { LiveToolCall } from '../../shared/room-live-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomMessageDialog.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomMessageDialog.tsx
@@ -8,16 +8,16 @@
  */
 
 import { useState } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Textarea,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dialog';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 
 interface Addressee {
   id: string;

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomProposal.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomProposal.tsx
@@ -12,7 +12,8 @@
  */
 
 import { useState } from 'react';
-import { Button, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import type { RoomProposalSummary } from '../../shared/room-blueprint-types';
 import type { BlueprintClamp } from '../../shared/room-clamp';
 import { accessTile } from '../lib/access-tile';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomStopBanner.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomStopBanner.tsx
@@ -11,7 +11,7 @@
  * here.
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import type { RoomStopReason } from '../../shared/room-types';
 
 /** What each stop means to the user, in their terms. */

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomTopBar.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomTopBar.tsx
@@ -14,7 +14,7 @@
  * roster as its Team tab.
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { ArrowLeft, MessageSquare } from 'lucide-react';
 import { TERMINAL_ROOM_STATUSES, type PersistedRoom, type RoomStatus } from '../../shared/room-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomWatch.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomWatch.tsx
@@ -12,7 +12,7 @@
  * behaves identically (NFR-017).
  */
 
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { MemberLiveSnapshot } from '../../shared/room-live-types';
 import type { RoomMember } from '../../shared/room-types';

--- a/plugins/sero-orchestrator-plugin/ui/components/RoomsOverview.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/RoomsOverview.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useMemo, useState } from 'react';
-import { Button } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import { Users } from 'lucide-react';
 import type { RoomStatus, RoomSummary } from '../../shared/room-types';
 import { formatCost, formatElapsed, formatRelative } from '../lib/format';

--- a/plugins/sero-orchestrator-plugin/ui/components/ShellTopBar.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/ShellTopBar.tsx
@@ -10,14 +10,14 @@
  */
 
 import type { ComponentType, ReactNode } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
 import {
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  cn,
-} from '@sero-ai/ui';
+} from '@sero-ai/ui/components/ui/dropdown-menu';
+import { cn } from '@sero-ai/ui/lib/utils';
 import { BookOpen, Home, Library, MoreHorizontal, Plus, Users, Workflow } from 'lucide-react';
 import { WORKFLOWS_LABEL } from '../../shared/labels';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/SkillDraftControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/SkillDraftControl.tsx
@@ -12,7 +12,18 @@
  */
 
 import { useReducer } from 'react';
-import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Input, Label, Textarea } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@sero-ai/ui/components/ui/dialog';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { GraduationCap, LoaderCircle } from 'lucide-react';
 import type { Loop, SkillDraft } from '../../shared/types';
 import { useWatchedJson } from '../lib/use-watched-json';

--- a/plugins/sero-orchestrator-plugin/ui/components/StatusBadge.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/StatusBadge.tsx
@@ -4,7 +4,7 @@
  * the home inbox, the loop list, the detail header, and the plan.
  */
 
-import { Badge } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
 import type { LoopStatus, StepStatus } from '../../shared/types';
 import { LOOP_STATUS_STYLE, NEEDS_YOU_STYLE, STEP_STATUS_STYLE } from '../lib/status-style';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/StepCard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/StepCard.tsx
@@ -7,7 +7,9 @@
  */
 
 import { useState } from 'react';
-import { Badge, Button, Card } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
 import { ChevronDown, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import type { AppModelGroup } from '@sero-ai/app-runtime';
 import type { ContextAgentInfo, ContextToolInfo } from '@sero-ai/common';

--- a/plugins/sero-orchestrator-plugin/ui/components/StepToolsControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/StepToolsControl.tsx
@@ -1,6 +1,8 @@
 import { Lock, Wrench } from 'lucide-react';
 import type { ContextToolInfo } from '@sero-ai/common';
-import { Button, Checkbox, Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Checkbox } from '@sero-ai/ui/components/ui/checkbox';
+import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { LoopStepDefinition } from '../../shared/types';
 import { DEFAULT_TOOLS, isDefaultTool } from '../../shared/constants';

--- a/plugins/sero-orchestrator-plugin/ui/components/SuggestionsInbox.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/SuggestionsInbox.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
-import { Badge, Button, Card, Input } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
 import { Check, Lightbulb, X } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 

--- a/plugins/sero-orchestrator-plugin/ui/components/room-kit/chrome.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/room-kit/chrome.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { ReactNode } from 'react';
-import { Badge } from '@sero-ai/ui';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { cn } from '@sero-ai/ui/lib/utils';
 
 /** The kit's accent vocabulary, named for meaning, not colour (D1). */

--- a/plugins/sero-orchestrator-plugin/ui/widgets/AttentionWidget.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/widgets/AttentionWidget.tsx
@@ -8,17 +8,12 @@
  */
 
 import type { ComponentType } from 'react';
-import {
-  ActivityList,
-  ActivityListItem,
-  DataBoundary,
-  EmptyState,
-  Inline,
-  Stack,
-  Status,
-  WidgetContent,
-  type Tone,
-} from '@sero-ai/ui';
+import { ActivityList, ActivityListItem } from '@sero-ai/ui/components/dashboard/activity-list';
+import { DataBoundary } from '@sero-ai/ui/components/dashboard/data-boundary';
+import { EmptyState } from '@sero-ai/ui/components/dashboard/empty-state';
+import { Inline, Stack, WidgetContent } from '@sero-ai/ui/components/dashboard/layout';
+import { Status } from '@sero-ai/ui/components/dashboard/status';
+import { type Tone } from '@sero-ai/ui/components/dashboard/tone';
 import { CheckCircle2, MessageCircleQuestion, ShieldQuestion, Sparkles } from 'lucide-react';
 import type { LoopSummary } from '../../shared/types';
 import { useOrchestratorIndex } from '../lib/use-orchestrator-index';

--- a/plugins/sero-orchestrator-plugin/ui/widgets/LoopsWidget.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/widgets/LoopsWidget.tsx
@@ -8,19 +8,13 @@
  */
 
 import type { ReactNode } from 'react';
-import {
-  ActivityList,
-  ActivityListItem,
-  DataBoundary,
-  EmptyState,
-  Inline,
-  Metric,
-  MetricCard,
-  Stack,
-  Status,
-  WidgetContent,
-  type Tone,
-} from '@sero-ai/ui';
+import { ActivityList, ActivityListItem } from '@sero-ai/ui/components/dashboard/activity-list';
+import { DataBoundary } from '@sero-ai/ui/components/dashboard/data-boundary';
+import { EmptyState } from '@sero-ai/ui/components/dashboard/empty-state';
+import { Inline, Stack, WidgetContent } from '@sero-ai/ui/components/dashboard/layout';
+import { Metric, MetricCard } from '@sero-ai/ui/components/dashboard/metric';
+import { Status } from '@sero-ai/ui/components/dashboard/status';
+import { type Tone } from '@sero-ai/ui/components/dashboard/tone';
 import { Infinity as InfinityIcon, MessageCircleQuestion } from 'lucide-react';
 import type { LoopStatus, LoopSummary } from '../../shared/types';
 import { useOrchestratorIndex } from '../lib/use-orchestrator-index';

--- a/scripts/check-repository-layout.mjs
+++ b/scripts/check-repository-layout.mjs
@@ -5,8 +5,39 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const legacyDocsRoot = path.join(repoRoot, 'docs');
+const uiDeepImportRoots = [
+  'plugins/sero-design-library-plugin/ui',
+  'plugins/sero-orchestrator-plugin/ui',
+];
 
 if (fs.existsSync(legacyDocsRoot)) {
   console.error('Root docs/ is not allowed. Use apps/docs-site/docs, an owning README, or GitHub issues and PRs.');
+  process.exitCode = 1;
+}
+
+const bareUiImportPattern = /(['"])@sero-ai\/ui\1/;
+const bareUiImports = [];
+
+for (const relativeRoot of uiDeepImportRoots) {
+  const root = path.join(repoRoot, relativeRoot);
+  const directories = [root];
+
+  while (directories.length > 0) {
+    const directory = directories.pop();
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        directories.push(entryPath);
+      } else if (/\.[cm]?[jt]sx?$/.test(entry.name) && bareUiImportPattern.test(fs.readFileSync(entryPath, 'utf8'))) {
+        bareUiImports.push(path.relative(repoRoot, entryPath));
+      }
+    }
+  }
+}
+
+if (bareUiImports.length > 0) {
+  console.error(
+    `Bare @sero-ai/ui imports are not allowed in these plugin UIs. Use component subpaths:\n${bareUiImports.join('\n')}`,
+  );
   process.exitCode = 1;
 }


### PR DESCRIPTION
## Summary

- replace bare `@sero-ai/ui` imports in the Design Library and Orchestrator plugin UIs with component subpath imports
- update the Design Library test mock and TypeScript path mapping for the new imports
- reject new bare UI imports in these plugin UIs during the repository layout check
- reduce local Vitest import time from 92.46s to 34.20s for Design Library and from 34.63s to 23.80s for Orchestrator

Closes #404

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm build` in both changed plugins
- [x] `pnpm test` in both changed plugins
- [x] `node scripts/check-repository-layout.mjs`
- [x] `npx react-doctor@latest --verbose --scope changed`
- [x] docs checked; no user or plugin-author behavior changed

## Safety checklist

- [x] no secrets, tokens, credentials, or machine-specific private paths committed
- [x] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [x] touched source files remain under 500 LOC

## Screenshots / recordings

No visible UI change.

## Risk / rollout notes

- breaking changes: none; the root barrel remains available
- security or privacy impact: none
- follow-up work: remove unused heavy barrel exports in the next `@sero-ai/ui` major release
