### PR TITLE
feat(apps): one lock for every app-state writer, an etag for the renderer

### DIFF
--- a/.agents/skills/sero-code-review/SKILL.md
+++ b/.agents/skills/sero-code-review/SKILL.md
@@ -42,12 +42,14 @@ things. Each round must move towards a verdict, never away from one.
 - Do the same for every fix on a re-review. A fix can leave the identical gap in the path beside it, and can add a new fault.
 - Re-read changed logic in full. A green test suite does not clear a concurrency or ordering change.
 
-## 3. One review, one comment
+## 3. Post each review round
 
 - Post to the PR yourself as part of the job. Do not ask first.
-- Keep **one** comment per PR. Update it with
-  `gh pr comment <pr> --edit-last --create-if-none --body-file <file>`.
-  Never stack a comment per round — the PR holds one current review, not a pile of rounds and corrections. `--edit-last` on its own fails when you have not commented on that PR yet, and it edits *your* last comment only, so a reply from someone else in between does not break it.
+- Post each completed review round as a new comment with
+  `gh pr comment <pr> --body-file <file>`. Separate comments preserve the review
+  history and notify agents that watch the PR.
+- Use `--edit-last` only to correct the comment for the current round. Do not
+  edit an earlier comment to publish a later review round.
 - A delta re-review opens with the status of every previous finding (fixed / not
   fixed / changed), then the new ones.
 - Lead with the verdict, then the blocking findings, then the non-blocking notes.

--- a/.agents/skills/sero-plugin/SKILL.md
+++ b/.agents/skills/sero-plugin/SKILL.md
@@ -154,6 +154,9 @@ Critical:
 - `@sero-ai/app-runtime` and `@sero-ai/ui` in `devDependencies`
 - `stateFile` is required even for global apps (Pi-CLI fallback)
 - `ui`, `component`, `devPort` only when the plugin ships a UI
+- Put extra federated components and host-rendered controls under
+  `sero.app.contributes`. Never generate legacy `widgets`, `search`,
+  `explorerView`, `titlebar`, or `workspaceCreation` fields for a new plugin.
 - `runtime` only when the plugin ships a runtime; add `runtime/tsconfig.json` to the `typecheck` script
 - Declare prompt templates in `pi.prompts` and plugin skills in `pi.skills`; folders alone are not auto-loaded
 - If you need a same-name slash shortcut for a bridged tool, use a prompt template in `pi.prompts` rather than `pi.registerCommand` with the same name
@@ -310,6 +313,7 @@ Verify:
 | Runtime never starts | Declare `sero.app.runtime` + `requiredHostCapabilities: ["appRuntime.background"]`; check `/tmp/sero-electron.log` |
 | Build fails because no HTML entry exists | Add `ui/index.html` |
 | "No UI module registered" | Set `sero.app.component` and `devPort` |
+| Contributed surface does not appear | Use a host-defined `extensionPoint` under `sero.app.contributes`, expose the named component, and check `minSeroVersion` |
 | "No workspace selected" | Pick one, or set `scope: "global"` |
 | State not syncing | Verify same `stateFile` path, use atomic writes |
 | Keyboard stealing input | Scope listeners to container, not `window` |

--- a/.agents/skills/sero-plugin/example/README.md
+++ b/.agents/skills/sero-plugin/example/README.md
@@ -15,7 +15,7 @@ plugin that exercises **every** surface a Sero plugin can ship.
 
 | Surface | File | What it demonstrates |
 |---------|------|----------------------|
-| Manifest | `sero-notes-plugin/package.json` | Full `pi` + `sero.app` + `sero.plugin` manifest, `bridgeTools`, `requiredHostCapabilities`, static widget, runtime entry |
+| Manifest | `sero-notes-plugin/package.json` | Full `pi` + `sero.app` + `sero.plugin` manifest, `bridgeTools`, `requiredHostCapabilities`, canonical static widget contribution, runtime entry |
 | Shared types | `sero-notes-plugin/shared/types.ts` | JSON-serialisable state + `DEFAULT_STATE` |
 | Pi extension | `sero-notes-plugin/extension/index.ts` | `pi.registerTool` with `StringEnum`, atomic state writes, custom TUI render, bridged CLI metadata (`cli`), `pi.registerCommand`, `session_start` warm fallback |
 | Background runtime | `sero-notes-plugin/runtime/index.ts` | `AppRuntime` implementation against `@sero-ai/common` — startup reconcile, `handleStateChange`, `dispose` |
@@ -35,7 +35,7 @@ plugin that exercises **every** surface a Sero plugin can ship.
    `devPort` (keep it unique — grep existing plugins first).
 3. Delete the surfaces you don't need:
    - No UI? Remove `vite.config.ts`, `ui/`, and the `sero.app.ui` /
-     `component` / `devPort` / `widgets` fields, and collapse
+     `component` / `devPort` / `contributes` fields, and collapse
      `scripts.typecheck` to just `extension/tsconfig.json`.
    - No background runtime? Remove `runtime/`, `sero.app.runtime`, the
      `appRuntime.background` capability, and the runtime tsconfig from

--- a/.agents/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
+++ b/.agents/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { Text } from '@earendil-works/pi-tui';
@@ -29,6 +30,20 @@ async function writeState(filePath: string, state: NotesState): Promise<void> {
   const tmp = `${filePath}.tmp.${Date.now()}`;
   await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
   await fs.rename(tmp, filePath);
+}
+
+// Locked read-modify-write. The Sero host writes this file for the UI under
+// the same `<stateFile>.lock` mutex, so a tool call cannot interleave with a
+// panel edit and revert it. Never write the state file without this.
+async function updateState(
+  filePath: string,
+  updater: (state: NotesState) => NotesState,
+): Promise<NotesState> {
+  return withStateLock(filePath, async () => {
+    const next = updater(await readState(filePath));
+    await writeState(filePath, next);
+    return next;
+  });
 }
 
 const Params = Type.Object({
@@ -103,15 +118,19 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const note: Note = {
-            id: state.nextId,
-            title: params.title,
-            done: false,
-            createdAt: new Date().toISOString(),
-          };
-          state.notes.push(note);
-          state.nextId++;
-          await writeState(statePath, state);
+          const title = params.title;
+          let note!: Note;
+          await updateState(statePath, (current) => {
+            note = {
+              id: current.nextId,
+              title,
+              done: false,
+              createdAt: new Date().toISOString(),
+            };
+            current.notes.push(note);
+            current.nextId++;
+            return current;
+          });
           return {
             content: [{ type: 'text', text: `Added #${note.id}: ${note.title}` }],
             details: {},
@@ -125,15 +144,18 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const note = state.notes.find((n) => n.id === params.id);
+          let note: Note | undefined;
+          await updateState(statePath, (current) => {
+            note = current.notes.find((n) => n.id === params.id);
+            if (note) note.done = !note.done;
+            return current;
+          });
           if (!note) {
             return {
               content: [{ type: 'text', text: `Error: no note #${params.id}` }],
               details: {},
             };
           }
-          note.done = !note.done;
-          await writeState(statePath, state);
           return {
             content: [
               { type: 'text', text: `Toggled #${note.id} -> ${note.done ? 'done' : 'open'}` },
@@ -149,15 +171,19 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const before = state.notes.length;
-          state.notes = state.notes.filter((n) => n.id !== params.id);
-          if (state.notes.length === before) {
+          let removed = false;
+          await updateState(statePath, (current) => {
+            const before = current.notes.length;
+            current.notes = current.notes.filter((n) => n.id !== params.id);
+            removed = current.notes.length < before;
+            return current;
+          });
+          if (!removed) {
             return {
               content: [{ type: 'text', text: `Error: no note #${params.id}` }],
               details: {},
             };
           }
-          await writeState(statePath, state);
           return {
             content: [{ type: 'text', text: `Removed #${params.id}` }],
             details: {},
@@ -213,36 +239,40 @@ export default function (pi: ExtensionAPI) {
         if (subcommand === 'add') {
           const title = rest.join(' ').trim();
           if (!title) return { output: 'Error: title is required', exitCode: 1 };
-          state.notes.push({
-            id: state.nextId,
-            title,
-            done: false,
-            createdAt: new Date().toISOString(),
+          let added!: Note;
+          await updateState(filePath, (current) => {
+            added = { id: current.nextId, title, done: false, createdAt: new Date().toISOString() };
+            current.notes.push(added);
+            current.nextId++;
+            return current;
           });
-          state.nextId++;
-          await writeState(filePath, state);
-          return { output: `Added #${state.nextId - 1}: ${title}`, exitCode: 0 };
+          return { output: `Added #${added.id}: ${title}`, exitCode: 0 };
         }
 
         if (subcommand === 'toggle') {
           const id = Number(rest[0]);
           if (!Number.isInteger(id)) return { output: 'Error: id is required', exitCode: 1 };
-          const note = state.notes.find((n) => n.id === id);
+          let note: Note | undefined;
+          await updateState(filePath, (current) => {
+            note = current.notes.find((n) => n.id === id);
+            if (note) note.done = !note.done;
+            return current;
+          });
           if (!note) return { output: `Error: no note #${id}`, exitCode: 1 };
-          note.done = !note.done;
-          await writeState(filePath, state);
           return { output: `Toggled #${id} -> ${note.done ? 'done' : 'open'}`, exitCode: 0 };
         }
 
         if (subcommand === 'remove') {
           const id = Number(rest[0]);
           if (!Number.isInteger(id)) return { output: 'Error: id is required', exitCode: 1 };
-          const before = state.notes.length;
-          state.notes = state.notes.filter((n) => n.id !== id);
-          if (state.notes.length === before) {
-            return { output: `Error: no note #${id}`, exitCode: 1 };
-          }
-          await writeState(filePath, state);
+          let removed = false;
+          await updateState(filePath, (current) => {
+            const before = current.notes.length;
+            current.notes = current.notes.filter((n) => n.id !== id);
+            removed = current.notes.length < before;
+            return current;
+          });
+          if (!removed) return { output: `Error: no note #${id}`, exitCode: 1 };
           return { output: `Removed #${id}`, exitCode: 0 };
         }
 

--- a/.agents/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/.agents/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@sero-ai/extension-runtime": "^0.2.2",
+    "@sero-ai/extension-runtime": "^0.2.4",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/.agents/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/.agents/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -22,23 +22,24 @@
       "component": "NotesApp",
       "runtime": "./runtime/index.ts",
       "devPort": 5199,
-      "widgets": [
-        {
+      "contributes": {
+        "components": [{
           "id": "notes-summary",
+          "extensionPoint": "ui.dashboard.widget",
           "name": "Notes Summary",
           "component": "NotesWidget",
           "description": "Quick overview of open notes",
           "defaultSize": { "w": 2, "h": 2 },
           "minSize": { "w": 1, "h": 1 },
           "maxSize": { "w": 4, "h": 3 }
-        }
-      ]
+        }]
+      }
     },
     "plugin": {
       "category": "productivity",
       "tags": ["notes", "example", "reference"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "requiredHostCapabilities": [
         "appAgent.invokeTool",
         "tool.cli",
@@ -48,6 +49,7 @@
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "^0.2.2",
     "typebox": "catalog:"
   },
   "peerDependencies": {
@@ -68,6 +70,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "lucide-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "tailwindcss": "catalog:",

--- a/.agents/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
+++ b/.agents/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
@@ -249,7 +249,7 @@ export function NotesApp() {
                 key={note.id}
                 className="group flex items-center gap-3 px-3 py-2 transition-colors hover:bg-secondary/40"
               >
-                <input aria-label="Checkbox input"
+                <input
                   type="checkbox"
                   checked={note.done}
                   onChange={() => toggleNote(note.id)}

--- a/.agents/skills/sero-plugin/example/sero-notes-plugin/ui/widgets/NotesWidget.tsx
+++ b/.agents/skills/sero-plugin/example/sero-notes-plugin/ui/widgets/NotesWidget.tsx
@@ -26,7 +26,7 @@ export function NotesWidget() {
   return (
     <WidgetContent>
       <Stack gap="sm" fill>
-        <Inline gap="xs" align="baseline">
+        <Inline gap="xs" align="center">
           <Text variant="numeric" className="text-lg">
             {open.length}
           </Text>

--- a/.agents/skills/sero-plugin/references/api-and-widgets.md
+++ b/.agents/skills/sero-plugin/references/api-and-widgets.md
@@ -194,23 +194,24 @@ Two registration methods: static (manifest) and dynamic (runtime hook).
 
 ### Static widgets (manifest)
 
-Declare in `sero.app.widgets` in package.json:
+Contribute a federated component to `ui.dashboard.widget` in package.json:
 
 ```json
 {
   "sero": {
     "app": {
-      "widgets": [
-        {
+      "contributes": {
+        "components": [{
           "id": "summary",
+          "extensionPoint": "ui.dashboard.widget",
           "name": "Summary",
           "component": "MyAppWidget",
           "description": "Quick overview of items",
           "defaultSize": { "w": 2, "h": 2 },
           "minSize": { "w": 1, "h": 1 },
           "maxSize": { "w": 4, "h": 3 }
-        }
-      ]
+        }]
+      }
     }
   }
 }
@@ -220,7 +221,8 @@ Widget manifest fields:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `id` | Yes | Unique within the app |
+| `id` | Yes | Unique among this app's dashboard widgets |
+| `extensionPoint` | Yes | Must be `ui.dashboard.widget` |
 | `name` | Yes | Display name in header and picker |
 | `component` | Yes | Exported component name from MF remote |
 | `description` | No | Shown in Add Widget picker |
@@ -380,7 +382,18 @@ Widget runtime API:
 | `component` | No | Exported component name. Required if `ui` is set. |
 | `devPort` | No | Vite dev server port. Required if `ui` is set. Must be unique. |
 | `styleIsolation` | For UI plugins | Set to `"scope"`. The matching Vite helper contains plugin CSS and host mounts provide scoped portal roots. |
-| `widgets` | No | Array of widget definitions |
+| `contributes` | No | Canonical component and host-control contributions. Static widgets use `contributes.components` with `ui.dashboard.widget`. |
+
+Supported component extension points are `ui.global-search.panel`,
+`ui.explorer.view`, `ui.titlebar.control`, and `ui.dashboard.widget`. The
+supported control extension point is `workspace.create.option`, with a
+`switch` control and app-local `tool` action. Contribution IDs are unique
+inside one extension point. Unknown points are ignored by the host, so set
+`minSeroVersion` if the plugin cannot work without a newer point.
+
+The old `search`, `explorerView`, `titlebar`, `widgets`, and
+`workspaceCreation` fields are compatibility syntax only. Do not generate them
+for a new plugin.
 
 ### sero.plugin fields
 
@@ -389,7 +402,7 @@ Widget runtime API:
 | `category` | Plugin category (e.g. `"productivity"`) |
 | `tags` | Array of searchable tags |
 | `minSeroVersion` | Minimum compatible Sero version |
-| `runtimeAbi` | Federated-UI ABI the plugin was built against. Required; must match the host (currently `2`). A plugin that omits it, or was built against a different Module Federation version, is refused with a "reinstall to update" message instead of crashing. |
+| `runtimeAbi` | Federated-UI ABI the plugin was built against. Required; must match the host (currently `3`). A plugin that omits it, or was built against a different Module Federation version, is refused with a "reinstall to update" message instead of crashing. |
 | `requiredHostCapabilities` | Explicit host seams the plugin depends on, such as `appAgent.invokeTool` or `tool.cli` |
 | `preBuilt` | Whether plugin ships pre-built |
 | `bundleExtensions` | Build-time hint for built-in release packaging. When `true`, Sero packages compiled JS `pi.extensions` instead of raw extension source. |

--- a/.agents/skills/sero-plugin/references/templates.md
+++ b/.agents/skills/sero-plugin/references/templates.md
@@ -60,16 +60,28 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
       "stateFile": ".sero/apps/myapp/state.json",
       "ui": "./dist/ui/remoteEntry.js",
       "component": "MyApp",
+      "contributes": {
+        "components": [
+          {
+            "id": "summary",
+            "extensionPoint": "ui.dashboard.widget",
+            "component": "MyAppWidget",
+            "name": "Summary",
+            "defaultSize": { "w": 2, "h": 2 }
+          }
+        ]
+      },
       "devPort": 5175
     },
     "plugin": {
       "category": "productivity",
       "tags": ["myapp", "example"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2
+      "runtimeAbi": 3
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "^0.2.2",
     "typebox": "catalog:"
   },
   "peerDependencies": {
@@ -96,17 +108,62 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
 
 **Key notes:**
 - `keywords: ["pi-package"]` keeps Pi CLI compatibility
-- Pi SDK packages in `peerDependencies` (runtime provides them)
+- Pi SDK packages in `peerDependencies` (runtime provides them); the current
+  peer minimum is `>=0.83.0`, with exact `0.83.0` development packages
 - `@sero-ai/app-runtime` in `devDependencies` (shared via MF singleton)
 - `@sero-ai/ui` in `devDependencies` (bundled at build time)
 - Use `@sero-ai/common` for renderer-safe contracts shared across multiple plugins or desktop packages; keep app-local types in `shared/`
 - Treat monorepo `packages/*` folders as shared package sources consumed by external plugins via published package names — do NOT point an external plugin at `../../packages/*` source paths, and do NOT move plugin-specific domain models into `packages/*`
 - `stateFile` remains required even for global apps — Sero ignores it there, but Pi CLI uses it as a fallback path
 - `ui`, `component`, and `devPort` are only needed when the plugin ships a web UI
+- `component` is the main app surface. Put extra components and standard host
+  controls under `contributes.components` and `contributes.controls`. Use only
+  host-defined extension points. Never generate a legacy contribution field
+  for a new plugin.
 - `runtime` is only needed when the plugin ships a background runtime; if present, add `runtime/tsconfig.json` to the package `typecheck` script
 - `pi.prompts` and `pi.skills` are optional, but when a plugin ships prompt templates or skills they must be declared there — folders alone are not discovered
 - For extension-only plugins, remove the Vite `dev` / `build` scripts and keep an extension-only `typecheck`
 - For built-in release packaging, `sero.plugin.bundleExtensions: true` ships compiled JS `pi.extensions` instead of raw source. Extension dependencies are bundled and pruned from `dist/plugin/package.json` unless listed in `sero.plugin.extensionExternals`.
+
+### Contribution templates
+
+Use only host-defined extension points. Component contributions name a Module
+Federation export. Control contributions contain host-rendered control data and
+an app-local tool action.
+
+```json
+"contributes": {
+  "components": [
+    {
+      "id": "explorer-view",
+      "extensionPoint": "ui.explorer.view",
+      "component": "MyExplorerView",
+      "label": "My view",
+      "icon": "box"
+    }
+  ],
+  "controls": [
+    {
+      "id": "workspace-setup",
+      "extensionPoint": "workspace.create.option",
+      "control": {
+        "type": "switch",
+        "label": "Set up My App",
+        "defaultValue": false
+      },
+      "action": {
+        "type": "tool",
+        "tool": "myapp_setup",
+        "params": { "mode": "default" }
+      }
+    }
+  ]
+}
+```
+
+Supported component points are `ui.global-search.panel`, `ui.explorer.view`,
+`ui.titlebar.control`, and `ui.dashboard.widget`. The supported control point
+is `workspace.create.option`.
 - `devPort` must be unique — check existing plugins first
 - Omit `bridgeTools` in `sero.plugin` to bridge all tools by default
 - Add `requiredHostCapabilities` only for seams the plugin actually needs:
@@ -331,6 +388,7 @@ export const DEFAULT_STATE: MyAppState = {
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Text } from '@earendil-works/pi-tui';
@@ -366,6 +424,20 @@ async function writeState(filePath: string, state: MyAppState): Promise<void> {
   const tmpPath = `${filePath}.tmp.${Date.now()}`;
   await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
   await fs.rename(tmpPath, filePath);
+}
+
+// Locked read-modify-write. The Sero host writes this file for the UI under
+// the same `<stateFile>.lock` mutex, so a tool call cannot interleave with a
+// panel edit and revert it. Never write the state file without this.
+async function updateState(
+  filePath: string,
+  updater: (state: MyAppState) => MyAppState,
+): Promise<MyAppState> {
+  return withStateLock(filePath, async () => {
+    const next = updater(await readState(filePath));
+    await writeState(filePath, next);
+    return next;
+  });
 }
 
 // -- Tool parameters --
@@ -421,14 +493,14 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const item: MyItem = {
-            id: state.nextId,
-            title: params.title,
-            createdAt: new Date().toISOString(),
-          };
-          state.items.push(item);
-          state.nextId++;
-          await writeState(statePath, state);
+          const title = params.title;
+          let item!: MyItem;
+          await updateState(statePath, (current) => {
+            item = { id: current.nextId, title, createdAt: new Date().toISOString() };
+            current.items.push(item);
+            current.nextId++;
+            return current;
+          });
           return {
             content: [{ type: 'text', text: `Added #${item.id}: ${item.title}` }],
             details: {},
@@ -442,8 +514,10 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          state.items = state.items.filter((i) => i.id !== params.id);
-          await writeState(statePath, state);
+          await updateState(statePath, (current) => ({
+            ...current,
+            items: current.items.filter((i) => i.id !== params.id),
+          }));
           return {
             content: [{ type: 'text', text: `Removed #${params.id}` }],
             details: {},
@@ -875,19 +949,8 @@ If you do this, declare:
 ```
 
 **Why needed:**
-- `@import "@sero-ai/ui/styles/plugin.css"` — imports Sero's shared Tailwind 4 theme bridge and scans shared primitives plus dashboard components
+- `@import "@sero-ai/ui/styles/plugin.css"` — imports Sero's shared Tailwind 4 theme bridge and scans shared UI components
 - `@source "./**/*.{ts,tsx}"` — keeps external remotes from silently missing plugin-local utility classes at runtime
-
-Add the matching source stylesheet immediately after `plugin.css` when the UI
-uses a specialized component family:
-
-```css
-@import "@sero-ai/ui/styles/ai-elements.css";
-@import "@sero-ai/ui/styles/model-selection.css";
-@import "@sero-ai/ui/styles/context-editor.css";
-```
-
-Only import the specialized stylesheets the plugin needs.
 
 ---
 
@@ -909,8 +972,6 @@ Only import the specialized stylesheets the plugin needs.
     "paths": {
       "@sero-ai/app-runtime": ["../../app-runtime/src/index.ts"],
       "@sero-ai/ui": ["../../ui/src/index.ts"],
-      "@sero-ai/ui/ai-elements/*": ["../../ui/src/components/ai-elements/*"],
-      "@sero-ai/ui/model-selection/*": ["../../ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../ui/src/*"]
     }
   },

--- a/.agents/skills/sero-plugin/references/templates.md
+++ b/.agents/skills/sero-plugin/references/templates.md
@@ -81,7 +81,7 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
     }
   },
   "dependencies": {
-    "@sero-ai/extension-runtime": "^0.2.2",
+    "@sero-ai/extension-runtime": "^0.2.4",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/.agents/skills/sero-subagent-orchestration/SKILL.md
+++ b/.agents/skills/sero-subagent-orchestration/SKILL.md
@@ -106,10 +106,10 @@ Reconcile all reports in the parent. If a real blocker remains, use one fix work
 
 ## 6. Report and update the PR
 
-Follow the `sero-code-review` skill. Give a green or red code verdict, list the status of every earlier finding, state exact validation, and separate non-code merge blockers. Update one existing PR review comment with:
+Follow the `sero-code-review` skill. Give a green or red code verdict, list the status of every earlier finding, state exact validation, and separate non-code merge blockers. Post the result as a new PR review comment with:
 
 ```bash
-gh pr comment <pr> --edit-last --create-if-none --body-file <file>
+gh pr comment <pr> --body-file <file>
 ```
 
-Push the validated integrated commits before posting so the PR head matches the reviewed SHA. Confirm the remote head, draft checks, and clean local status. Never stack review comments. Keep the PR a draft unless the user explicitly asks otherwise.
+Post a new comment for each review round so PR watchers receive the update and the review history stays visible. Use `--edit-last` only to correct the current round's comment. Push the validated integrated commits before posting so the PR head matches the reviewed SHA. Confirm the remote head, draft checks, and clean local status. Keep the PR a draft unless the user explicitly asks otherwise.

--- a/apps/desktop/e2e/vcs.workflow.spec.ts
+++ b/apps/desktop/e2e/vcs.workflow.spec.ts
@@ -163,7 +163,7 @@ test.describe('VCS - Repo State Subscription', () => {
       }
     }, testWorkspaceId);
 
-    expect(result.initial).toBeNull();
+    expect((result.initial as { data: unknown }).data).toBeNull();
     expect(result.changesAfterWrite).toBeGreaterThan(0);
     expect(result.changesAfterUnwatch).toBe(result.changesAfterWrite);
   });

--- a/apps/desktop/electron/__tests__/features/apps/app-state-locking.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-state-locking.test.ts
@@ -1,0 +1,147 @@
+/**
+ * AppStateManager cross-process locking + etag protocol (#428).
+ *
+ * Real filesystem in a tmpdir — the lock and the atomic writes are the unit
+ * under test, so nothing here mocks fs.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+import { AppStateManager } from '@electron/features/apps/state/manager';
+
+let dir: string;
+let manager: AppStateManager;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'sero-app-state-'));
+  manager = new AppStateManager();
+});
+
+afterEach(async () => {
+  manager.dispose();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('etag protocol', () => {
+  it('accepts a write that echoes the current etag and hands out the next one', async () => {
+    const file = path.join(dir, 'state.json');
+    await manager.write(file, { count: 1 });
+
+    const first = await manager.readWithEtag(file);
+    expect(first.data).toEqual({ count: 1 });
+    expect(first.etag).not.toBeNull();
+
+    const result = await manager.write(file, { count: 2 }, first.etag);
+    expect(result.ok).toBe(true);
+    const second = await manager.readWithEtag(file);
+    expect(second.data).toEqual({ count: 2 });
+    expect(second.etag).toBe(result.ok ? result.etag : null);
+  });
+
+  it('rejects a stale etag and returns the current content instead of clobbering it', async () => {
+    const file = path.join(dir, 'state.json');
+    await manager.write(file, { count: 1 });
+    const stale = (await manager.readWithEtag(file)).etag;
+
+    // Another writer landed in between.
+    await manager.write(file, { count: 2, fromRuntime: true });
+
+    const result = await manager.write(file, { count: 99 }, stale);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.data).toEqual({ count: 2, fromRuntime: true });
+      expect(result.etag).not.toBe(stale);
+    }
+    expect(await manager.read(file)).toEqual({ count: 2, fromRuntime: true });
+  });
+
+  it('treats `null` as the etag of an absent file', async () => {
+    const file = path.join(dir, 'state.json');
+    const created = await manager.write(file, { fresh: true }, null);
+    expect(created.ok).toBe(true);
+
+    // Now the file exists, so "expect absent" must be rejected.
+    const rejected = await manager.write(file, { fresh: false }, null);
+    expect(rejected.ok).toBe(false);
+  });
+
+  it('writes unconditionally when no etag is passed', async () => {
+    const file = path.join(dir, 'state.json');
+    await manager.write(file, { a: 1 });
+    const result = await manager.write(file, { a: 2 });
+    expect(result.ok).toBe(true);
+    expect(await manager.read(file)).toEqual({ a: 2 });
+  });
+});
+
+describe('cross-process lock', () => {
+  it('makes update() wait for an extension-side lock holder', async () => {
+    const file = path.join(dir, 'state.json');
+    await manager.write(file, { items: ['held'] });
+
+    let updated = false;
+    await withStateLock(file, async () => {
+      const update = manager
+        .update<{ items: string[] }>(file, (current) => ({ items: [...(current?.items ?? []), 'host'] }))
+        .then(() => { updated = true; });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(updated).toBe(false);
+      void update;
+    });
+
+    await expect.poll(() => updated).toBe(true);
+    expect(await manager.read(file)).toEqual({ items: ['held', 'host'] });
+  });
+
+  // The #428 defect: a host runtime and a plugin extension write one state
+  // file from different processes. Every child append and the parent's last
+  // status must survive; the unlocked version of this interleaving loses most
+  // of the appends.
+  it('loses no update between the host and an extension process', async () => {
+    const file = path.join(dir, 'state.json');
+    const count = 50;
+    await manager.write(file, { status: 'start', items: [] });
+
+    const worker = path.resolve(__dirname, 'fixtures/state-append-worker.mjs');
+    const child = spawn(process.execPath, [worker, file, String(count)], { stdio: ['ignore', 'inherit', 'inherit'] });
+    const childDone = new Promise<void>((resolve, reject) => {
+      child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`worker exited ${code}`))));
+      child.on('error', reject);
+    });
+
+    // Fail fast when the worker dies before it is ready.
+    await Promise.race([
+      childDone,
+      (async () => {
+        while (!existsSync(`${file}.ready`)) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      })(),
+    ]);
+    await writeFile(`${file}.go`, '', 'utf8');
+
+    type S = { status: string; items: number[] };
+    for (let i = 0; i < count; i += 1) {
+      await manager.update<S>(file, (current) => ({
+        status: `status-${i}`,
+        items: current?.items ?? [],
+      }));
+    }
+
+    await childDone;
+    const final = JSON.parse(await readFile(file, 'utf8')) as S;
+    expect(final.items).toEqual(Array.from({ length: count }, (_, i) => i));
+    expect(final.status).toBe(`status-${count - 1}`);
+  }, 30_000);
+});

--- a/apps/desktop/electron/__tests__/features/apps/app-state-locking.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-state-locking.test.ts
@@ -114,7 +114,9 @@ describe('cross-process lock', () => {
     await manager.write(file, { status: 'start', items: [] });
 
     const worker = path.resolve(__dirname, 'fixtures/state-append-worker.mjs');
-    const child = spawn(process.execPath, [worker, file, String(count)], { stdio: ['ignore', 'inherit', 'inherit'] });
+    const child = spawn(process.execPath, ['--import', 'tsx', worker, file, String(count)], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
     const childDone = new Promise<void>((resolve, reject) => {
       child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`worker exited ${code}`))));
       child.on('error', reject);

--- a/apps/desktop/electron/__tests__/features/apps/fixtures/state-append-worker.mjs
+++ b/apps/desktop/electron/__tests__/features/apps/fixtures/state-append-worker.mjs
@@ -1,0 +1,33 @@
+/**
+ * Child-process writer for the AppStateManager cross-process test.
+ *
+ * Plays the role of a plugin extension: appends 0..count-1 to `items` via
+ * read-modify-write under the shared `<stateFile>.lock` mutex, exactly the way
+ * an extension using @sero-ai/extension-runtime does. Signals readiness via
+ * `<stateFile>.ready` and waits for `<stateFile>.go` so both processes
+ * provably write concurrently.
+ *
+ * Plain .mjs (not .ts): Node runs it directly, and its `.ts`-extension import
+ * of the lock helper stays out of the electron typecheck.
+ */
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { withStateLock } from '../../../../../../../packages/extension-runtime/src/file-lock.ts';
+
+const [, , stateFile, countArg] = process.argv;
+if (!stateFile || !countArg) throw new Error('usage: state-append-worker.mjs <stateFile> <count>');
+const count = Number(countArg);
+
+await writeFile(`${stateFile}.ready`, '', 'utf8');
+while (!existsSync(`${stateFile}.go`)) {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+for (let i = 0; i < count; i += 1) {
+  await withStateLock(stateFile, async () => {
+    const current = JSON.parse(await readFile(stateFile, 'utf8'));
+    current.items.push(i);
+    await writeFile(stateFile, JSON.stringify(current), 'utf8');
+  });
+}

--- a/apps/desktop/electron/__tests__/features/apps/fixtures/state-append-worker.mjs
+++ b/apps/desktop/electron/__tests__/features/apps/fixtures/state-append-worker.mjs
@@ -7,8 +7,8 @@
  * `<stateFile>.ready` and waits for `<stateFile>.go` so both processes
  * provably write concurrently.
  *
- * Plain .mjs (not .ts): Node runs it directly, and its `.ts`-extension import
- * of the lock helper stays out of the electron typecheck.
+ * Plain .mjs keeps the fixture out of the electron typecheck. The parent loads
+ * tsx so the lock helper can use its extensionless TypeScript import.
  */
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';

--- a/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => {
       read: vi.fn(),
       readText: vi.fn(),
       remove: vi.fn(),
-      write: vi.fn(),
+      write: vi.fn().mockResolvedValue({ ok: true, etag: 'etag' }),
     },
   };
 

--- a/apps/desktop/electron/features/apps/git-app/manager.ts
+++ b/apps/desktop/electron/features/apps/git-app/manager.ts
@@ -170,9 +170,9 @@ export class GitWorkspaceStateManager {
       .then(() => {
         gitRefreshInvalidationCoordinator.markRefreshed(entry.stateFilePath);
       })
-      .catch((error) => {
+      .catch(async (error) => {
         console.error('[git-app] Failed to refresh git state:', error);
-        return appStateManager.write(entry.stateFilePath, {
+        await appStateManager.write(entry.stateFilePath, {
           repoPath: entry.workspacePath,
           repoName: path.basename(entry.workspacePath),
           currentBranch: '',

--- a/apps/desktop/electron/features/apps/state/manager.ts
+++ b/apps/desktop/electron/features/apps/state/manager.ts
@@ -6,15 +6,24 @@
  *   - Reading state from disk
  *   - Atomic writes (write to tmp, then fs.rename)
  *   - fs.watch() for change notifications (macOS uses FSEvents — reliable)
- *   - Serialised write queue to prevent concurrent writes
+ *   - Serialised write queue to prevent concurrent writes in this process
+ *   - A cross-process lock (`<stateFile>.lock`) around every mutation, shared
+ *     with plugin extensions via @sero-ai/extension-runtime — a writer in the
+ *     Pi agent process and a writer here must never interleave their
+ *     read-modify-write cycles
+ *   - An etag per file content, so a renderer holding state outside the lock
+ *     has its write rejected instead of silently clobbering newer content
  *
  * Used by both the IPC layer (renderer ↔ main) and the Pi extension
  * (which writes directly to the same file).
  */
 
+import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import { watch, type FSWatcher } from 'fs';
 import path from 'path';
+import { stateLockPath, withLock } from '@sero-ai/extension-runtime';
+import type { AppStateReadResult, AppStateWriteResult } from '@/types/ipc';
 import { IpcChannels } from '@/types/ipc-channels';
 import { broadcastToWindows } from '@electron/ipc/lib/window-broadcast';
 
@@ -38,6 +47,11 @@ interface WatcherEntry {
 
 type ChangeListener = (filePath: string, data: unknown) => void;
 
+/** Content etag: hash of the raw file text. `null` means the file is absent. */
+function computeEtag(raw: string): string {
+  return createHash('sha1').update(raw).digest('hex');
+}
+
 export class AppStateManager {
   private watchers = new Map<string, WatcherEntry>();
   private writeQueues = new Map<string, Promise<void>>();
@@ -55,11 +69,21 @@ export class AppStateManager {
   // ── Read ─────────────────────────────────────────────────
 
   async read(filePath: string): Promise<unknown> {
+    return (await this.readWithEtag(filePath)).data;
+  }
+
+  /** Read parsed content together with the etag a write must echo. */
+  async readWithEtag(filePath: string): Promise<AppStateReadResult> {
+    let raw: string;
     try {
-      const raw = await fs.readFile(filePath, 'utf8');
-      return JSON.parse(raw);
+      raw = await fs.readFile(filePath, 'utf8');
     } catch {
-      return null;
+      return { data: null, etag: null };
+    }
+    try {
+      return { data: JSON.parse(raw), etag: computeEtag(raw) };
+    } catch {
+      return { data: null, etag: computeEtag(raw) };
     }
   }
 
@@ -75,46 +99,71 @@ export class AppStateManager {
   // ── Remove ────────────────────────────────────────────────
 
   async remove(filePath: string): Promise<void> {
-    try {
-      await fs.unlink(filePath);
-    } catch {
-      /* file already gone — fine */
-    }
+    await this.enqueue(filePath, () =>
+      withLock(stateLockPath(filePath), async () => {
+        try {
+          await fs.unlink(filePath);
+        } catch {
+          /* file already gone — fine */
+        }
+      }),
+    );
   }
 
   // ── Write (atomic, serialised) ───────────────────────────
 
-  async write(filePath: string, data: unknown): Promise<void> {
-    // Chain writes per file to serialise them
-    const prev = this.writeQueues.get(filePath) ?? Promise.resolve();
-    const next = prev.then(() => this.atomicWrite(filePath, data));
-    this.writeQueues.set(filePath, next);
-    await next;
+  /**
+   * Write a file, atomically and under the cross-process lock.
+   *
+   * `expectedEtag` is the etag the caller's state is based on (from
+   * `readWithEtag`, `watch` or a change event); the write is rejected when the
+   * file has changed since, and the current content is returned so the caller
+   * can re-apply its change on top. Omitting it writes unconditionally — for
+   * whole-file owners like the CLI and the git-app manager, not for callers
+   * that hold state between read and write.
+   */
+  async write(filePath: string, data: unknown, expectedEtag?: string | null): Promise<AppStateWriteResult> {
+    return this.enqueue(filePath, () =>
+      withLock(stateLockPath(filePath), async () => {
+        if (expectedEtag !== undefined) {
+          const current = await this.readWithEtag(filePath);
+          if (current.etag !== expectedEtag) {
+            return { ok: false as const, data: current.data, etag: current.etag };
+          }
+        }
+        return { ok: true as const, etag: await this.atomicWrite(filePath, data) };
+      }),
+    );
   }
 
   /**
-   * Atomic read-modify-write: the updater callback runs inside the
-   * serialised write queue so no concurrent read can see stale data.
-   *
-   * Use this instead of separate read() + write() when multiple
-   * callers may update the same file concurrently (e.g. parallel
-   * subtask completion in the kanban orchestrator).
+   * Atomic read-modify-write: the updater runs inside the serialised write
+   * queue AND the cross-process lock, so no writer in any process can land
+   * between the read and the write.
    */
   async update<T = unknown>(
     filePath: string,
     updater: (current: T | null) => T,
   ): Promise<void> {
-    const prev = this.writeQueues.get(filePath) ?? Promise.resolve();
-    const next = prev.then(async () => {
-      const current = await this.read(filePath) as T | null;
-      const updated = updater(current);
-      await this.atomicWrite(filePath, updated);
-    });
-    this.writeQueues.set(filePath, next);
-    await next;
+    await this.enqueue(filePath, () =>
+      withLock(stateLockPath(filePath), async () => {
+        const current = await this.read(filePath) as T | null;
+        await this.atomicWrite(filePath, updater(current));
+      }),
+    );
   }
 
-  private async atomicWrite(filePath: string, data: unknown): Promise<void> {
+  /** Serialise mutations per file within this process. The chain survives a
+   * rejected entry; only the returned promise carries the error. */
+  private enqueue<T>(filePath: string, task: () => Promise<T>): Promise<T> {
+    const prev = this.writeQueues.get(filePath) ?? Promise.resolve();
+    const next = prev.then(task);
+    this.writeQueues.set(filePath, next.then(() => undefined, () => undefined));
+    return next;
+  }
+
+  /** Returns the etag of the content written. */
+  private async atomicWrite(filePath: string, data: unknown): Promise<string> {
     const dir = path.dirname(filePath);
     await fs.mkdir(dir, { recursive: true });
 
@@ -123,6 +172,7 @@ export class AppStateManager {
 
     await fs.writeFile(tmpPath, json, 'utf8');
     await fs.rename(tmpPath, filePath);
+    return computeEtag(json);
   }
 
   // ── Watch ────────────────────────────────────────────────
@@ -268,16 +318,16 @@ export class AppStateManager {
     entry.debounceTimer = setTimeout(async () => {
       entry.debounceTimer = null;
       try {
-        const data = await this.read(filePath);
-        this.pushChange(filePath, data);
+        const { data, etag } = await this.readWithEtag(filePath);
+        this.pushChange(filePath, data, etag);
       } catch (err) {
         console.error(`[AppStateManager] Error reading ${filePath}:`, err);
       }
     }, 50);
   }
 
-  private pushChange(filePath: string, data: unknown): void {
-    broadcastToWindows(IpcChannels.appState.change, filePath, data);
+  private pushChange(filePath: string, data: unknown, etag: string | null): void {
+    broadcastToWindows(IpcChannels.appState.change, filePath, data, etag);
     // Notify registered listeners (e.g. kanban orchestrator)
     for (const listener of this.changeListeners) {
       try {

--- a/apps/desktop/electron/ipc/apps/app-state.ts
+++ b/apps/desktop/electron/ipc/apps/app-state.ts
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import { ipcMain } from 'electron';
+import type { AppStateReadResult, AppStateWriteResult } from '@/types/ipc';
 import { IpcChannels } from '@/types/ipc-channels';
 import { appStateManager } from '@electron/features/apps/state/manager';
 import { SERO_HOME } from '@electron/platform/env';
@@ -124,26 +125,30 @@ export function registerAppStateHandlers(): void {
     },
   );
 
-  // Write state file (atomic + serialised)
+  // Write state file (atomic + serialised + cross-process locked).
+  // `expectedEtag` rejects a write based on state that is no longer current.
   ipcMain.handle(
     IpcChannels.appState.write,
-    async (_event, filePath: string, data: unknown): Promise<void> => {
-      await appStateManager.write(filePath, data);
-      // Immediate notification for IPC-originated writes (no file watcher delay)
-      notifyAppRuntimeManager(filePath, data);
-      await refreshRuntimeSettingsIfNeeded(filePath);
+    async (_event, filePath: string, data: unknown, expectedEtag?: string | null): Promise<AppStateWriteResult> => {
+      const result = await appStateManager.write(filePath, data, expectedEtag);
+      if (result.ok) {
+        // Immediate notification for IPC-originated writes (no file watcher delay)
+        notifyAppRuntimeManager(filePath, data);
+        await refreshRuntimeSettingsIfNeeded(filePath);
+      }
+      return result;
     },
   );
 
-  // Start watching a state file (returns current state)
+  // Start watching a state file (returns current state plus its etag)
   ipcMain.handle(
     IpcChannels.appState.watch,
-    async (_event, filePath: string): Promise<unknown> => {
+    async (_event, filePath: string): Promise<AppStateReadResult> => {
       appStateManager.watch(filePath);
       if (gitWorkspaceStateManager.isGitStateFile(filePath)) {
         gitWorkspaceStateManager.watchStateFile(filePath);
       }
-      return appStateManager.read(filePath);
+      return appStateManager.readWithEtag(filePath);
     },
   );
 

--- a/apps/desktop/electron/preload/apps/app-domain.ts
+++ b/apps/desktop/electron/preload/apps/app-domain.ts
@@ -2,6 +2,8 @@ import { ipcRenderer } from 'electron';
 
 import { IpcChannels } from '@/types/ipc-channels';
 import type {
+  AppStateReadResult,
+  AppStateWriteResult,
   SeroAppManifest,
   AuthProvidersResponse,
   OAuthEvent,
@@ -33,21 +35,21 @@ export const appStateBridge = {
   readText: (filePath: string): Promise<string | null> =>
     ipcRenderer.invoke(IpcChannels.appState.readText, filePath),
 
-  write: (filePath: string, data: unknown): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.appState.write, filePath, data),
+  write: (filePath: string, data: unknown, expectedEtag?: string | null): Promise<AppStateWriteResult> =>
+    ipcRenderer.invoke(IpcChannels.appState.write, filePath, data, expectedEtag),
 
   remove: (filePath: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.appState.remove, filePath),
 
-  watch: (filePath: string): Promise<unknown> =>
+  watch: (filePath: string): Promise<AppStateReadResult> =>
     ipcRenderer.invoke(IpcChannels.appState.watch, filePath),
 
   unwatch: (filePath: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.appState.unwatch, filePath),
 
-  onChange: (callback: (filePath: string, data: unknown) => void): (() => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, fp: string, data: unknown) => {
-      callback(fp, data);
+  onChange: (callback: (filePath: string, data: unknown, etag: string | null) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, fp: string, data: unknown, etag: string | null) => {
+      callback(fp, data, etag);
     };
     ipcRenderer.on(IpcChannels.appState.change, handler);
     return () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -116,6 +116,7 @@
     "react-grid-layout": "^2.2.4",
     "react-resizable-panels": "^4.12.2",
     "streamdown": "catalog:",
+    "tsx": "^4.23.12",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",

--- a/apps/desktop/src/lib/app-runtime.test.tsx
+++ b/apps/desktop/src/lib/app-runtime.test.tsx
@@ -72,11 +72,11 @@ describe('app-runtime shared seams', () => {
   it('reports when the initial app-state read is complete', async () => {
     let ready = false;
     let updateState: ((updater: (prev: { count: number }) => { count: number }) => void) | null = null;
-    let finishWatch: ((value: { count: number } | null) => void) | null = null;
+    let finishWatch: ((value: { data: { count: number } | null; etag: string | null }) => void) | null = null;
     const appState = {
       read: vi.fn(async () => null),
-      write: vi.fn(async () => undefined),
-      watch: vi.fn(() => new Promise<{ count: number } | null>((resolve) => {
+      write: vi.fn(async () => ({ ok: true as const, etag: 'e1' })),
+      watch: vi.fn(() => new Promise<{ data: { count: number } | null; etag: string | null }>((resolve) => {
         finishWatch = resolve;
       })),
       unwatch: vi.fn(async () => undefined),
@@ -101,13 +101,13 @@ describe('app-runtime shared seams', () => {
     expect(ready).toBe(false);
 
     await act(async () => {
-      finishWatch?.(null);
+      finishWatch?.({ data: null, etag: null });
       await Promise.resolve();
     });
     expect(ready).toBe(true);
 
     await act(async () => updateState?.((previous) => ({ count: previous.count + 1 })));
-    expect(appState.write).toHaveBeenCalledWith('/tmp/state.json', { count: 1 });
+    expect(appState.write).toHaveBeenCalledWith('/tmp/state.json', { count: 1 }, null);
   });
 
   it('reconciles optimistic app-state writes back to disk on write failure', async () => {
@@ -118,10 +118,10 @@ describe('app-runtime shared seams', () => {
 
     const appState = {
       read: vi.fn(async () => ({ count: 0 })),
-      write: vi.fn(() => new Promise<void>((_resolve, reject) => {
+      write: vi.fn(() => new Promise<never>((_resolve, reject) => {
         rejectWrite = reject;
       })),
-      watch: vi.fn(async () => ({ count: 0 })),
+      watch: vi.fn(async () => ({ data: { count: 0 }, etag: 'e0' })),
       unwatch: vi.fn(async () => undefined),
       onChange: vi.fn(() => () => undefined),
     };
@@ -154,7 +154,7 @@ describe('app-runtime shared seams', () => {
       updateState?.((prev) => ({ count: prev.count + 1 }));
     });
 
-    expect(appState.write).toHaveBeenCalledWith('/tmp/state.json', { count: 1 });
+    expect(appState.write).toHaveBeenCalledWith('/tmp/state.json', { count: 1 }, 'e0');
     expect(latestState).toBe(1);
 
     await act(async () => {
@@ -175,7 +175,7 @@ describe('app-runtime shared seams', () => {
     const appState = {
       read: vi.fn(async () => null),
       write: vi.fn(async () => undefined),
-      watch: vi.fn(async () => ({ display: 42, history: null, meta: {}, extra: 'kept' })),
+      watch: vi.fn(async () => ({ data: { display: 42, history: null, meta: {}, extra: 'kept' }, etag: 'e0' })),
       unwatch: vi.fn(async () => undefined),
       onChange: vi.fn(() => () => undefined),
     };

--- a/apps/desktop/src/stores/agent-board.ts
+++ b/apps/desktop/src/stores/agent-board.ts
@@ -94,7 +94,7 @@ export const useAgentBoardStore = create<AgentBoardState>((set, get) => {
     watchTargets.set(filePath, { workspaceId, kind });
     window.sero.appState
       .watch(filePath)
-      .then((data: unknown) => applyWatched(workspaceId, kind, data))
+      .then(({ data }: { data: unknown }) => applyWatched(workspaceId, kind, data))
       .catch(() => applyWatched(workspaceId, kind, null));
   }
 

--- a/apps/desktop/src/types/electron-apps.d.ts
+++ b/apps/desktop/src/types/electron-apps.d.ts
@@ -5,6 +5,8 @@
  */
 
 import type {
+  AppStateReadResult,
+  AppStateWriteResult,
   SeroAppManifest,
   AppControlEntry,
   AppInteractionParams,
@@ -24,16 +26,20 @@ interface SeroAppStateAPI {
   read(filePath: string): Promise<unknown>;
   /** Read a file as raw UTF-8 text (no JSON parsing). Returns null if missing. */
   readText(filePath: string): Promise<string | null>;
-  /** Write an app state JSON file (atomic + serialised). */
-  write(filePath: string, data: unknown): Promise<void>;
+  /**
+   * Write an app state JSON file (atomic, serialised, cross-process locked).
+   * Pass the etag the caller's state is based on to reject stale writes;
+   * omit it only for whole-file owners that never hold state between reads.
+   */
+  write(filePath: string, data: unknown, expectedEtag?: string | null): Promise<AppStateWriteResult>;
   /** Delete an app state / data file. */
   remove(filePath: string): Promise<void>;
-  /** Start watching a state file. Returns current state. */
-  watch(filePath: string): Promise<unknown>;
+  /** Start watching a state file. Returns current state plus its etag. */
+  watch(filePath: string): Promise<AppStateReadResult>;
   /** Stop watching a state file. */
   unwatch(filePath: string): Promise<void>;
   /** Subscribe to state file change events. Returns unsubscribe. */
-  onChange(callback: (filePath: string, data: unknown) => void): () => void;
+  onChange(callback: (filePath: string, data: unknown, etag: string | null) => void): () => void;
 }
 
 interface SeroAppsAPI {

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -448,3 +448,21 @@ export type {
 // ── Auto-update ────────────────────────────────────────────────
 
 export type { UpdaterStatusEvent } from './updater';
+
+// ── App state ──────────────────────────────────────────────────
+
+/** Parsed app-state content plus the etag a later write must echo. */
+export interface AppStateReadResult {
+  data: unknown;
+  /** Hash of the raw file text; `null` when the file is absent. */
+  etag: string | null;
+}
+
+/**
+ * Result of an app-state write. `ok: false` means the caller's etag no longer
+ * matches the file: nothing was written, and `data`/`etag` carry the current
+ * content so the caller can re-apply its change on top.
+ */
+export type AppStateWriteResult =
+  | { ok: true; etag: string }
+  | { ok: false; data: unknown; etag: string | null };

--- a/apps/docs-site/docs/plugins/catalog.md
+++ b/apps/docs-site/docs/plugins/catalog.md
@@ -42,8 +42,8 @@ Built-in plugins can appear in app discovery or favorites. External plugins do n
 | Spotify | `@sero-ai/plugin-spotify` | Deprecated; current runtime path unsupported | None recommended | [Docs](/plugins/spotify) | The repository marks it deprecated. Current stock Electron does not provide its former DRM path. |
 | ImageGen | `@sero-ai/plugin-imagegen` | External | `git:https://github.com/sero-labs/sero-imagegen-plugin.git` | [Docs](/plugins/imagegen) | Gemini credentials and network access. |
 | Loom | `@sero-ai/plugin-loom` | External | `git:https://github.com/sero-labs/sero-loom-plugin.git` | [Docs](/plugins/loom) | GLSL art studio and wallpaper capture. |
-| Starling Bank | `@sero-ai/plugin-starling` | External | `git:https://github.com/monobyte/sero-starling-plugin.git` | [Docs](/plugins/starling) | Sero 0.1.0+, runtime ABI 2, Sero desktop bridges, Starling token, and network access. |
-| Weight | `@sero-ai/plugin-weight-tracker` | External | `git:https://github.com/monobyte/sero-weight-tracker.git` | [Docs](/plugins/weight-tracker) | Sero 0.1.0+ and runtime ABI 2; stores health data as plain JSON. |
+| Starling Bank | `@sero-ai/plugin-starling` | External | `git:https://github.com/monobyte/sero-starling-plugin.git` | [Docs](/plugins/starling) | Sero 0.1.0+, runtime ABI 3, Sero desktop bridges, Starling token, and network access. |
+| Weight | `@sero-ai/plugin-weight-tracker` | External | `git:https://github.com/monobyte/sero-weight-tracker.git` | [Docs](/plugins/weight-tracker) | Sero 0.1.0+ and runtime ABI 3; stores health data as plain JSON. |
 
 ## External catalog-only plugins
 

--- a/apps/docs-site/docs/plugins/starling.md
+++ b/apps/docs-site/docs/plugins/starling.md
@@ -25,7 +25,7 @@ The PIN is an app lock. It is not an encryption key, and the source does not set
 
 ## Platform requirements
 
-The package manifest requires Sero 0.1.0 or later and runtime ABI 2. The safe-storage bridge and host network bridge require the Sero desktop app. The repository also documents Pi CLI installation, but its dashboard security and network behavior depend on Sero host bridges.
+The package manifest requires Sero 0.1.0 or later and runtime ABI 3. The safe-storage bridge and host network bridge require the Sero desktop app. The repository also documents Pi CLI installation, but its dashboard security and network behavior depend on Sero host bridges.
 
 Do not include tokens, account identifiers, balances, or transactions in screenshots and public support reports.
 

--- a/apps/docs-site/docs/plugins/weight-tracker.md
+++ b/apps/docs-site/docs/plugins/weight-tracker.md
@@ -24,7 +24,7 @@ Use made-up values in screenshots and public support reports. Weight records and
 
 ## Other runtimes
 
-The package manifest requires Sero 0.1.0 or later and runtime ABI 2. When the package runs in Pi CLI without Sero, it uses `workspace-root/.sero/apps/weight-tracker/state.json` instead of the global Sero path.
+The package manifest requires Sero 0.1.0 or later and runtime ABI 3. When the package runs in Pi CLI without Sero, it uses `workspace-root/.sero/apps/weight-tracker/state.json` instead of the global Sero path.
 
 ## Related docs
 

--- a/apps/docs-site/docs/reference/app-runtime.md
+++ b/apps/docs-site/docs/reference/app-runtime.md
@@ -35,6 +35,20 @@ Current public storage model:
 - global app state: `<SERO_HOME>/apps/<app-id>/state.json`
 - workspace app state: `<workspace>/.sero/apps/<app-id>/state.json`
 
+## Concurrent writers
+
+A state file can have three writers: the plugin UI, the plugin runtime, and the
+plugin extension. The host serialises them:
+
+- Every host-side mutation runs under a cross-process lock (`<stateFile>.lock`).
+- `useAppState` writes carry an etag. When another writer changed the file
+  first, the hook re-applies your updater on top of the new content and writes
+  again. Keep updaters pure functions of `prev` — an updater that closes over
+  older state re-applies stale values.
+- An extension that writes a state file directly must hold the same lock. Use
+  `withStateLock(stateFile, fn)` from `@sero-ai/extension-runtime` around each
+  read-modify-write.
+
 See [State and Folders](/reference/state-and-folders) for the broader storage map.
 
 ## Minimal example

--- a/apps/docs-site/docs/reference/plugin-end-to-end-example.md
+++ b/apps/docs-site/docs/reference/plugin-end-to-end-example.md
@@ -16,7 +16,7 @@ For an external repository, use the maintained
 | Task | File |
 | --- | --- |
 | Define the Pi, app, and plugin manifests | `package.json` |
-| Set runtime ABI 2 and required host capabilities | `package.json` |
+| Set runtime ABI 3 and required host capabilities | `package.json` |
 | Define JSON-serialisable state and defaults | `shared/types.ts` |
 | Register a tool, command, and CLI metadata | `extension/index.ts` |
 | Read and write state from the React UI | `ui/NotesApp.tsx` |

--- a/apps/docs-site/docs/reference/plugin-quickstart.md
+++ b/apps/docs-site/docs/reference/plugin-quickstart.md
@@ -40,7 +40,7 @@ recovery.
 
 If the plugin has a federated UI, keep these contracts:
 
-- set `sero.plugin.runtimeAbi` to `2`;
+- set `sero.plugin.runtimeAbi` to `3`;
 - set `sero.app.styleIsolation` to `"scope"`;
 - use `seroPluginCssScope({ pluginId: '<id>' })` from
   `@sero-ai/plugin-vite` after Tailwind;

--- a/apps/docs-site/docs/reference/plugins.md
+++ b/apps/docs-site/docs/reference/plugins.md
@@ -57,7 +57,7 @@ correct a failed session.
 
 Current UI plugins must:
 
-- declare `sero.plugin.runtimeAbi` as `2`;
+- declare `sero.plugin.runtimeAbi` as `3`;
 - declare `sero.app.styleIsolation` as `"scope"`;
 - use `seroPluginCssScope()` from `@sero-ai/plugin-vite`;
 - use `base: './'` for production;

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sero-ai/common": ">=0.3.1",
+    "@sero-ai/common": ">=0.11.0",
     "react": "^19.2.4"
   },
   "devDependencies": {

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/app-runtime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Hooks for Sero federated app modules — useAppState, useAppInfo, useAgentPrompt, useAppTools",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/app-runtime/src/sero-bridge.ts
+++ b/packages/app-runtime/src/sero-bridge.ts
@@ -17,12 +17,28 @@ import type {
   WebAppRequest,
 } from '@sero-ai/common';
 
+/** Parsed app-state content plus the etag a later write must echo. */
+export interface AppStateReadResult<TData = unknown> {
+  data: TData;
+  /** Hash of the raw file text; `null` when the file is absent. */
+  etag: string | null;
+}
+
+/**
+ * Result of an app-state write. `ok: false` means the caller's etag no longer
+ * matches the file: nothing was written, and `data`/`etag` carry the current
+ * content so the caller can re-apply its change on top.
+ */
+export type AppStateWriteResult =
+  | { ok: true; etag: string }
+  | { ok: false; data: unknown; etag: string | null };
+
 export interface SeroWindowAppStateBridge {
   read<TData = unknown>(filePath: string): Promise<TData>;
-  write<TData = unknown>(filePath: string, data: TData): Promise<void>;
-  watch<TData = unknown>(filePath: string): Promise<TData>;
+  write<TData = unknown>(filePath: string, data: TData, expectedEtag?: string | null): Promise<AppStateWriteResult>;
+  watch<TData = unknown>(filePath: string): Promise<AppStateReadResult<TData>>;
   unwatch(filePath: string): Promise<void>;
-  onChange<TData = unknown>(cb: (filePath: string, data: TData) => void): () => void;
+  onChange<TData = unknown>(cb: (filePath: string, data: TData, etag: string | null) => void): () => void;
 }
 
 export interface SeroAppAgentBridge {

--- a/packages/app-runtime/src/use-app-state.test.ts
+++ b/packages/app-runtime/src/use-app-state.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { applyDefaultState } from './use-app-state';
+import type { AppStateWriteResult } from './sero-bridge';
+import { applyDefaultState, writeStateWithRebase } from './use-app-state';
 
 interface DemoState {
   name: string;
@@ -52,5 +53,78 @@ describe('applyDefaultState', () => {
   it('leaves an absent optional field absent', () => {
     const withOptional: DemoState = { ...DEFAULT_STATE, optional: undefined };
     expect(applyDefaultState(withOptional, { name: 'repo' }).optional).toBeUndefined();
+  });
+});
+
+describe('writeStateWithRebase', () => {
+  type S = { status: string; count: number };
+  const rebase = (fileData: unknown) => applyDefaultState({ status: '', count: 0 }, fileData);
+
+  it('writes once when the etag still matches', async () => {
+    const write = vi.fn(async (): Promise<AppStateWriteResult> => ({ ok: true, etag: 'e1' }));
+
+    const result = await writeStateWithRebase<S>(
+      write,
+      (prev) => ({ ...prev, count: prev.count + 1 }),
+      { state: { status: 'a', count: 1 }, etag: 'e0' },
+      rebase,
+    );
+
+    expect(result).toEqual({ state: { status: 'a', count: 1 }, etag: 'e1' });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith({ status: 'a', count: 1 }, 'e0');
+  });
+
+  // The core #428 property: a write based on a stale snapshot must land ON TOP
+  // of the other writer's content, not replace it.
+  it('re-applies the updater on top of newer content when rejected', async () => {
+    const write = vi.fn()
+      .mockResolvedValueOnce({ ok: false, data: { status: 'runtime-wrote-this', count: 7 }, etag: 'e1' })
+      .mockResolvedValueOnce({ ok: true, etag: 'e2' });
+
+    const result = await writeStateWithRebase<S>(
+      write,
+      (prev) => ({ ...prev, count: prev.count + 1 }),
+      { state: { status: 'stale', count: 1 }, etag: 'e0' },
+      rebase,
+    );
+
+    expect(result).toEqual({ state: { status: 'runtime-wrote-this', count: 8 }, etag: 'e2' });
+    expect(write).toHaveBeenNthCalledWith(2, { status: 'runtime-wrote-this', count: 8 }, 'e1');
+  });
+
+  it('gives up after bounded attempts when the file keeps changing', async () => {
+    let round = 0;
+    const write = vi.fn(async (): Promise<AppStateWriteResult> => {
+      round += 1;
+      return { ok: false, data: { status: `round-${round}`, count: round }, etag: `e${round}` };
+    });
+
+    const result = await writeStateWithRebase<S>(
+      write,
+      (prev) => ({ ...prev, count: prev.count + 1 }),
+      { state: { status: 'a', count: 1 }, etag: 'e0' },
+      rebase,
+    );
+
+    expect(result).toBeNull();
+    expect(write).toHaveBeenCalledTimes(5);
+  });
+
+  it('stops without writing again when newer content already satisfies the update', async () => {
+    const write = vi.fn()
+      .mockResolvedValueOnce({ ok: false, data: { status: 'done', count: 3 }, etag: 'e1' });
+
+    const result = await writeStateWithRebase<S>(
+      write,
+      // Identity once the goal state is reached — models toggles that
+      // another writer already applied.
+      (prev) => (prev.status === 'done' ? prev : { ...prev, status: 'done' }),
+      { state: { status: 'done', count: 0 }, etag: 'e0' },
+      rebase,
+    );
+
+    expect(result).toEqual({ state: { status: 'done', count: 3 }, etag: 'e1' });
+    expect(write).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app-runtime/src/use-app-state.ts
+++ b/packages/app-runtime/src/use-app-state.ts
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useCallback, use, useRef } from 'react';
 import { AppContext } from './context';
-import { getSeroApi, type SeroWindowAppStateBridge } from './sero-bridge';
+import { getSeroApi, type AppStateWriteResult, type SeroWindowAppStateBridge } from './sero-bridge';
 
 /**
  * File-backed reactive state hook.
@@ -59,6 +59,43 @@ export function applyDefaultState<T>(defaultState: T, current: unknown): T {
   return normalizeStateValue(defaultState, current) as T;
 }
 
+/** How often a rejected write is re-applied before the update is dropped. */
+const MAX_WRITE_ATTEMPTS = 5;
+
+/**
+ * Write state, re-applying the updater on top of newer file content whenever
+ * the host rejects the etag. The caller's change lands on top of what another
+ * writer (extension, runtime) wrote instead of replacing it.
+ *
+ * Returns the state that reached disk, or `null` when the file kept changing
+ * for `MAX_WRITE_ATTEMPTS` rounds. Assumes the updater is a pure function of
+ * `prev` — an updater closing over values derived from an earlier `prev`
+ * re-applies those stale values.
+ *
+ * Exported for its tests, not from the package entry point.
+ */
+export async function writeStateWithRebase<T>(
+  write: (data: T, expectedEtag: string | null) => Promise<AppStateWriteResult>,
+  updater: (prev: T) => T,
+  first: { state: T; etag: string | null },
+  rebase: (fileData: unknown) => T,
+): Promise<{ state: T; etag: string | null } | null> {
+  let candidate = first.state;
+  let etag = first.etag;
+
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
+    const result = await write(candidate, etag);
+    if (result.ok) return { state: candidate, etag: result.etag };
+
+    const base = rebase(result.data);
+    etag = result.etag;
+    candidate = updater(base);
+    // The newer content already satisfies the update — nothing left to write.
+    if (Object.is(candidate, base)) return { state: base, etag };
+  }
+  return null;
+}
+
 export function useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) => void, boolean] {
   const ctx = use(AppContext);
   if (!ctx) {
@@ -75,6 +112,9 @@ export function useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) =
   const defaultStateRef = useRef<T>(defaultState);
   const stateRef = useRef<T>(defaultState);
   const latestWriteIdRef = useRef(0);
+  /** Etag of the last file content this hook observed; `null` before the
+   * first watch result, which makes any earlier write rebase onto disk. */
+  const etagRef = useRef<string | null>(null);
 
   defaultStateRef.current = defaultState;
   stateRef.current = state;
@@ -109,15 +149,18 @@ export function useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) =
       applyState(nextState);
     };
 
-    const unsubscribe = api.appState.onChange<T | null>((filePath, data) => {
-      if (!isActive || filePath !== stateFilePath || data == null) return;
+    const unsubscribe = api.appState.onChange<T | null>((filePath, data, etag) => {
+      if (!isActive || filePath !== stateFilePath) return;
+      etagRef.current = etag;
+      if (data == null) return;
       applyIfActive(applyDefaultState(defaultStateRef.current, data));
     });
 
     void api.appState.watch<T | null>(stateFilePath).then(
-      (current) => {
-        if (current != null) {
-          applyIfActive(applyDefaultState(defaultStateRef.current, current));
+      ({ data, etag }) => {
+        if (isActive) etagRef.current = etag;
+        if (data != null) {
+          applyIfActive(applyDefaultState(defaultStateRef.current, data));
         }
         if (isActive) setReadyPath(stateFilePath);
       },
@@ -143,7 +186,24 @@ export function useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) =
       applyState(next);
 
       const api = getSeroApi();
-      void api.appState.write(stateFilePath, next).catch((error: unknown) => {
+      void writeStateWithRebase(
+        (data, expectedEtag) => api.appState.write(stateFilePath, data, expectedEtag),
+        updater,
+        { state: next, etag: etagRef.current },
+        (fileData) => applyDefaultState(defaultStateRef.current, fileData),
+      ).then((result) => {
+        if (result === null) {
+          console.error(`[app-runtime] Dropped app state update for ${stateFilePath}: the file kept changing under this writer`);
+          void recoverFromWriteFailure(api.appState, writeId, previous);
+          return;
+        }
+        etagRef.current = result.etag;
+        // A rebase produced a different state than the optimistic one — show
+        // what actually reached disk, unless a newer update superseded this.
+        if (writeId === latestWriteIdRef.current && !Object.is(result.state, next)) {
+          applyState(result.state);
+        }
+      }, (error: unknown) => {
         if (writeId !== latestWriteIdRef.current) return;
         console.warn(`[app-runtime] Failed to persist app state for ${stateFilePath}`, error);
         void recoverFromWriteFailure(api.appState, writeId, previous);

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/common",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared types and utilities for Sero packages",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -65,8 +65,12 @@ export const SERO_HOST_CAPABILITIES = [
  *
  * - 1 — @module-federation/vite 1.11.x (runtime negotiation)
  * - 2 — @module-federation/vite 1.19.x (`__mf_module_cache__` share cache)
+ * - 3 — etag app-state protocol (#428): `watch` returns `{ data, etag }`,
+ *   change events carry an etag, and `useAppState` echoes it on write. A
+ *   bundle built on ABI 2 blind-writes whole state files from stale renderer
+ *   snapshots, which the host now rejects.
  */
-export const SERO_PLUGIN_RUNTIME_ABI = 2;
+export const SERO_PLUGIN_RUNTIME_ABI = 3;
 
 export type SeroHostCapability = (typeof SERO_HOST_CAPABILITIES)[number];
 

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@sero-ai/extension-runtime",
-  "version": "0.2.0",
-  "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, etc.)",
+  "version": "0.2.1",
+  "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./file-lock": "./src/file-lock.ts",
     "./package.json": "./package.json"
   },
   "files": [
@@ -20,9 +21,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@earendil-works/pi-agent-core": "catalog:peer",
-    "@earendil-works/pi-ai": "catalog:peer",
-    "@earendil-works/pi-coding-agent": "catalog:peer"
+    "@earendil-works/pi-agent-core": ">=0.83.0",
+    "@earendil-works/pi-ai": ">=0.83.0",
+    "@earendil-works/pi-coding-agent": ">=0.83.0"
   },
   "devDependencies": {
     "@earendil-works/pi-agent-core": "catalog:",
@@ -31,5 +32,16 @@
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-agent-core": {
+      "optional": true
+    },
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    }
   }
 }

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sero-ai/extension-runtime",
   "version": "0.2.3",
-  "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
+  "description": "Shared runtime helpers for isolated background agent work in Sero \u2014 plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -32,7 +32,8 @@
     "@earendil-works/pi-coding-agent": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "tsx": "^4.23.12"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-agent-core": {

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/extension-runtime",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/extension-runtime",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, etc.)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/extension-runtime",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Shared runtime helpers for isolated background agent work in Sero \u2014 plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/extension-runtime/package.json
+++ b/packages/extension-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/extension-runtime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Shared runtime helpers for isolated background agent work in Sero — plugin extensions and the desktop host (isolated model completions, file locks, etc.)",
   "type": "module",
   "main": "./src/index.ts",
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./file-lock": "./src/file-lock.ts",
+    "./state-lock-path": "./src/state-lock-path.ts",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/extension-runtime/src/__tests__/file-lock-publish-failure.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock-publish-failure.test.ts
@@ -1,0 +1,44 @@
+import type { PathLike } from 'node:fs';
+import type * as FsPromises from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const failLink = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>();
+  return {
+    ...actual,
+    link: async (existingPath: PathLike, newPath: PathLike) => {
+      if (failLink()) {
+        const error = new Error('hard links are not supported') as NodeJS.ErrnoException;
+        error.code = 'EPERM';
+        throw error;
+      }
+      return actual.link(existingPath, newPath);
+    },
+  };
+});
+
+import { acquireLock } from '../file-lock';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'sero-file-lock-publish-failure-'));
+  failLink.mockReturnValue(true);
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+it('removes its empty reservation when owner publication fails', async () => {
+  const lockDir = path.join(dir, 'state.json.lock');
+
+  await expect(acquireLock(lockDir)).rejects.toMatchObject({ code: 'EPERM' });
+  expect(existsSync(lockDir)).toBe(false);
+});

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -127,7 +127,9 @@ describe('cross-process exclusion', () => {
     await writeFile(stateFile, JSON.stringify({ status: 'start', items: [] }), 'utf8');
 
     const worker = fileURLToPath(new URL('./fixtures/append-worker.ts', import.meta.url));
-    const child = spawn(process.execPath, [worker, stateFile, String(count)], { stdio: ['ignore', 'inherit', 'inherit'] });
+    // --import tsx: the fixture and file-lock use extensionless TS imports,
+    // which plain Node type-stripping cannot resolve.
+    const child = spawn(process.execPath, ['--import', 'tsx', worker, stateFile, String(count)], { stdio: ['ignore', 'inherit', 'inherit'] });
     const childDone = new Promise<void>((resolve, reject) => {
       child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`worker exited ${code}`))));
       child.on('error', reject);
@@ -182,7 +184,7 @@ describe('cross-process exclusion', () => {
     const runs = [] as Promise<void>[];
     const start = (id: string, mode: 'normal' | 'crash') => {
       ids.push(id);
-      const child = spawn(process.execPath, [fixture, lockDir, logFile, id, String(sections), mode], { stdio: ['ignore', 'inherit', 'inherit'] });
+      const child = spawn(process.execPath, ['--import', 'tsx', fixture, lockDir, logFile, id, String(sections), mode], { stdio: ['ignore', 'inherit', 'inherit'] });
       runs.push(new Promise<void>((resolve, reject) => {
         child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`${id} exited ${code}`))));
         child.on('error', reject);

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -154,4 +154,52 @@ describe('cross-process exclusion', () => {
     expect(final.items).toEqual(Array.from({ length: count }, (_, i) => i));
     expect(final.status).toBe(`status-${count - 1}`);
   }, 30_000);
+
+  // The abandoned-lock races: many processes observe the same dead holder and
+  // reclaim concurrently, while more holders crash mid-storm. A reclaim that
+  // deletes from a stale observation admits two holders here — each worker
+  // proves exclusion with a marker file inside its critical section.
+  // LOCK_STRESS_WORKERS / LOCK_STRESS_SECTIONS scale it up for manual runs.
+  it('keeps exclusion while holders crash and many contenders reclaim at once', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const logFile = path.join(dir, 'stress.log');
+    await writeFile(logFile, '', 'utf8');
+
+    // Start from an already-crashed holder so every contender's first move is
+    // to reclaim the same dead lock.
+    const gonePid = await new Promise<number>((resolve, reject) => {
+      const dead = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+      dead.on('exit', () => resolve(dead.pid!));
+      dead.on('error', reject);
+    });
+    await mkdir(lockDir);
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: gonePid, acquiredAt: Date.now(), token: 'crashed' }), 'utf8');
+
+    const workers = Number(process.env.LOCK_STRESS_WORKERS ?? 8);
+    const sections = Number(process.env.LOCK_STRESS_SECTIONS ?? 5);
+    const fixture = fileURLToPath(new URL('./fixtures/contender-worker.ts', import.meta.url));
+    const ids: string[] = [];
+    const runs = [] as Promise<void>[];
+    const start = (id: string, mode: 'normal' | 'crash') => {
+      ids.push(id);
+      const child = spawn(process.execPath, [fixture, lockDir, logFile, id, String(sections), mode], { stdio: ['ignore', 'inherit', 'inherit'] });
+      runs.push(new Promise<void>((resolve, reject) => {
+        child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`${id} exited ${code}`))));
+        child.on('error', reject);
+      }));
+    };
+    for (let w = 0; w < workers; w += 1) start(`w${w}`, 'normal');
+    start('crash-a', 'crash');
+    start('crash-b', 'crash');
+
+    while (!ids.every((id) => existsSync(`${logFile}.ready-${id}`))) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    await writeFile(`${logFile}.go`, '', 'utf8');
+    await Promise.all(runs);
+
+    const log = await readFile(logFile, 'utf8');
+    expect(log).not.toContain('OVERLAP');
+    expect(log.split('\n').filter((line) => line.startsWith('OK ')).length).toBe(workers * sections);
+  }, 120_000);
 });

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -1,0 +1,128 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { acquireLock, stateLockPath, withLock, withStateLock } from '../file-lock';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'sero-file-lock-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('withLock', () => {
+  it('excludes a second holder until the first releases', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const order: string[] = [];
+
+    let releaseFirst!: () => void;
+    const firstHolds = new Promise<void>((resolve) => { releaseFirst = resolve; });
+
+    const first = withLock(lockDir, async () => {
+      order.push('first-in');
+      await firstHolds;
+      order.push('first-out');
+    });
+    // Give the first writer time to take the lock before the second tries.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const second = withLock(lockDir, async () => {
+      order.push('second-in');
+    });
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first-in', 'first-out', 'second-in']);
+  });
+
+  it('reclaims a lock whose owner is gone', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    await mkdir(lockDir);
+    // A pid from a process that has already exited.
+    const gonePid = await new Promise<number>((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+      child.on('exit', () => resolve(child.pid!));
+      child.on('error', reject);
+    });
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: gonePid, acquiredAt: Date.now() }), 'utf8');
+
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
+  });
+
+  it('reclaims a lock past its stale window even when the owner pid is alive', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    await mkdir(lockDir);
+    // Not our own pid (that is never reclaimed) — pid 1 is always alive.
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 1, acquiredAt: Date.now() - 60_000 }), 'utf8');
+
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000, staleMs: 30_000 })).resolves.toBe('ran');
+  });
+
+  it('throws on timeout while another holder is alive', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const release = await acquireLock(lockDir);
+    // The holder is this process, which is alive, so it is never reclaimed.
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 200 })).rejects.toThrow(/Timed out acquiring lock/);
+    await release();
+  });
+
+  it('releases the lock when the task throws', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    await expect(withLock(lockDir, async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
+  });
+});
+
+describe('stateLockPath', () => {
+  it('derives the shared lock directory from the state file path', () => {
+    expect(stateLockPath('/a/b/state.json')).toBe('/a/b/state.json.lock');
+  });
+});
+
+describe('cross-process exclusion', () => {
+  // Two writers in separate processes must not lose an update. The child
+  // appends items in a loop while this process rewrites status; every append
+  // and the last status must survive. This is the defect #428 exists for:
+  // without the shared lock, interleaved read-modify-write cycles routinely
+  // erase each other's writes.
+  it('loses no update between a parent and a child writer', async () => {
+    const stateFile = path.join(dir, 'state.json');
+    const count = 50;
+    await writeFile(stateFile, JSON.stringify({ status: 'start', items: [] }), 'utf8');
+
+    const worker = fileURLToPath(new URL('./fixtures/append-worker.ts', import.meta.url));
+    const child = spawn(process.execPath, [worker, stateFile, String(count)], { stdio: ['ignore', 'inherit', 'inherit'] });
+    const childDone = new Promise<void>((resolve, reject) => {
+      child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`worker exited ${code}`))));
+      child.on('error', reject);
+    });
+
+    // Start barrier: without it the parent finishes all its writes before the
+    // child process has even booted, and the test proves nothing. The unlocked
+    // version of this interleaving loses most of the 50 appends.
+    while (!existsSync(`${stateFile}.ready`)) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    await writeFile(`${stateFile}.go`, '', 'utf8');
+
+    for (let i = 0; i < count; i += 1) {
+      await withStateLock(stateFile, async () => {
+        const current = JSON.parse(await readFile(stateFile, 'utf8')) as { status: string; items: number[] };
+        current.status = `status-${i}`;
+        await writeFile(stateFile, JSON.stringify(current), 'utf8');
+      });
+    }
+
+    await childDone;
+    const final = JSON.parse(await readFile(stateFile, 'utf8')) as { status: string; items: number[] };
+    expect(final.items).toEqual(Array.from({ length: count }, (_, i) => i));
+    expect(final.status).toBe(`status-${count - 1}`);
+  }, 30_000);
+});

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -51,18 +51,47 @@ describe('withLock', () => {
       child.on('exit', () => resolve(child.pid!));
       child.on('error', reject);
     });
-    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: gonePid, acquiredAt: Date.now() }), 'utf8');
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: gonePid, acquiredAt: Date.now(), token: 'gone' }), 'utf8');
 
     await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
   });
 
-  it('reclaims a lock past its stale window even when the owner pid is alive', async () => {
+  // Evicting a live holder breaks mutual exclusion: the evicted holder would
+  // finish, then release a lock that belongs to its successor. A wedged but
+  // alive owner therefore surfaces as timeouts, never as a reclaim.
+  it('never reclaims an alive owner, however old the lock is', async () => {
     const lockDir = path.join(dir, 'state.json.lock');
     await mkdir(lockDir);
-    // Not our own pid (that is never reclaimed) — pid 1 is always alive.
-    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 1, acquiredAt: Date.now() - 60_000 }), 'utf8');
+    // Not our own pid — pid 1 is always alive.
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 1, acquiredAt: Date.now() - 60_000, token: 'held' }), 'utf8');
 
-    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000, staleMs: 30_000 })).resolves.toBe('ran');
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 300, staleMs: 100 })).rejects.toThrow(/Timed out/);
+  });
+
+  it('reclaims an ownerless lock directory after the stale window', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    // A crash between mkdir and the owner write leaves exactly this.
+    await mkdir(lockDir);
+
+    // Fresh ownerless dir: still treated as mid-acquisition.
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 200, staleMs: 60_000 })).rejects.toThrow(/Timed out/);
+    // Past the stale window (measured by directory age): reclaimed.
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000, staleMs: 100 })).resolves.toBe('ran');
+  });
+
+  it('does not release a lock it no longer owns', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const release = await acquireLock(lockDir);
+    // The holder dies and a successor legitimately reclaims and reacquires.
+    await rm(lockDir, { recursive: true, force: true });
+    await mkdir(lockDir);
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({ pid: 1, acquiredAt: Date.now(), token: 'successor' }), 'utf8');
+
+    // The stale release closure must leave the successor's lock alone.
+    await release();
+    const owner = JSON.parse(await readFile(path.join(lockDir, 'owner.json'), 'utf8')) as { token: string };
+    expect(owner.token).toBe('successor');
   });
 
   it('throws on timeout while another holder is alive', async () => {

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -84,6 +84,30 @@ describe('withLock', () => {
     await release();
   });
 
+  it('shares same-process ownership across bundled module copies', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const token = 'host-copy-token';
+    const heldTokensKey = Symbol.for('@sero-ai/extension-runtime/file-lock/held-tokens');
+    type FileLockGlobals = typeof globalThis & { [heldTokensKey]?: Set<string> };
+    const fileLockGlobals = globalThis as FileLockGlobals;
+    const bundledCopyTokens = fileLockGlobals[heldTokensKey] ??= new Set<string>();
+    bundledCopyTokens.add(token);
+
+    await mkdir(lockDir);
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      acquiredAt: Date.now(),
+      token,
+    }), 'utf8');
+
+    try {
+      await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 200 }))
+        .rejects.toThrow(/Timed out/);
+    } finally {
+      bundledCopyTokens.delete(token);
+    }
+  });
+
   it('never reclaims an ownerless legacy reservation', async () => {
     const lockDir = path.join(dir, 'state.json.lock');
     // A paused legacy publisher and a crashed one have the same empty shape.

--- a/packages/extension-runtime/src/__tests__/file-lock.test.ts
+++ b/packages/extension-runtime/src/__tests__/file-lock.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -68,16 +68,37 @@ describe('withLock', () => {
     await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 300, staleMs: 100 })).rejects.toThrow(/Timed out/);
   });
 
-  it('reclaims an ownerless lock directory after the stale window', async () => {
+  it('never reclaims a live tokenless legacy owner', async () => {
     const lockDir = path.join(dir, 'state.json.lock');
-    // A crash between mkdir and the owner write leaves exactly this.
+    await mkdir(lockDir);
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      acquiredAt: Date.now() - 60_000,
+    }), 'utf8');
+
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 300, staleMs: 100 })).rejects.toThrow(/Timed out/);
+
+    // Version 0.2.1 released unconditionally after its critical section.
+    await rm(lockDir, { recursive: true, force: true });
+    const release = await acquireLock(lockDir, { timeoutMs: 2000 });
+    await release();
+  });
+
+  it('never reclaims an ownerless legacy reservation', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    // A paused legacy publisher and a crashed one have the same empty shape.
     await mkdir(lockDir);
 
-    // Fresh ownerless dir: still treated as mid-acquisition.
-    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 200, staleMs: 60_000 })).rejects.toThrow(/Timed out/);
-    // Past the stale window (measured by directory age): reclaimed.
+    const contender = withLock(lockDir, async () => 'ran', { timeoutMs: 300, staleMs: 100 });
     await new Promise((resolve) => setTimeout(resolve, 120));
-    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000, staleMs: 100 })).resolves.toBe('ran');
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      acquiredAt: Date.now(),
+    }), 'utf8');
+    await expect(contender).rejects.toThrow(/Timed out/);
+
+    await rm(lockDir, { recursive: true, force: true });
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
   });
 
   it('does not release a lock it no longer owns', async () => {
@@ -92,6 +113,36 @@ describe('withLock', () => {
     await release();
     const owner = JSON.parse(await readFile(path.join(lockDir, 'owner.json'), 'utf8')) as { token: string };
     expect(owner.token).toBe('successor');
+  });
+
+  it('restores a live owner record left by an interrupted reclaim', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    const release = await acquireLock(lockDir);
+    const claim = path.join(lockDir, '.owner-claim-interrupted.json');
+    await rename(path.join(lockDir, 'owner.json'), claim);
+
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 200 })).rejects.toThrow(/Timed out/);
+    await expect(readFile(path.join(lockDir, 'owner.json'), 'utf8')).resolves.toContain(`"pid":${process.pid}`);
+
+    await release();
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
+  });
+
+  it('removes an interrupted reclaim whose owner is gone', async () => {
+    const lockDir = path.join(dir, 'state.json.lock');
+    await mkdir(lockDir);
+    const gonePid = await new Promise<number>((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+      child.on('exit', () => resolve(child.pid!));
+      child.on('error', reject);
+    });
+    await writeFile(path.join(lockDir, '.owner-claim-interrupted.json'), JSON.stringify({
+      pid: gonePid,
+      acquiredAt: Date.now(),
+      token: 'gone-claim',
+    }), 'utf8');
+
+    await expect(withLock(lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');
   });
 
   it('throws on timeout while another holder is alive', async () => {
@@ -157,10 +208,10 @@ describe('cross-process exclusion', () => {
     expect(final.status).toBe(`status-${count - 1}`);
   }, 30_000);
 
-  // The abandoned-lock races: many processes observe the same dead holder and
-  // reclaim concurrently, while more holders crash mid-storm. A reclaim that
-  // deletes from a stale observation admits two holders here — each worker
-  // proves exclusion with a marker file inside its critical section.
+  // The abandoned-lock races: current and legacy publishers contend while
+  // many processes observe the same dead holder and more holders crash
+  // mid-storm. Each worker proves exclusion with a marker file inside its
+  // critical section.
   // LOCK_STRESS_WORKERS / LOCK_STRESS_SECTIONS scale it up for manual runs.
   it('keeps exclusion while holders crash and many contenders reclaim at once', async () => {
     const lockDir = path.join(dir, 'state.json.lock');
@@ -182,7 +233,7 @@ describe('cross-process exclusion', () => {
     const fixture = fileURLToPath(new URL('./fixtures/contender-worker.ts', import.meta.url));
     const ids: string[] = [];
     const runs = [] as Promise<void>[];
-    const start = (id: string, mode: 'normal' | 'crash') => {
+    const start = (id: string, mode: 'normal' | 'legacy' | 'crash') => {
       ids.push(id);
       const child = spawn(process.execPath, ['--import', 'tsx', fixture, lockDir, logFile, id, String(sections), mode], { stdio: ['ignore', 'inherit', 'inherit'] });
       runs.push(new Promise<void>((resolve, reject) => {
@@ -191,6 +242,8 @@ describe('cross-process exclusion', () => {
       }));
     };
     for (let w = 0; w < workers; w += 1) start(`w${w}`, 'normal');
+    const legacyWorkers = 2;
+    for (let w = 0; w < legacyWorkers; w += 1) start(`legacy-${w}`, 'legacy');
     start('crash-a', 'crash');
     start('crash-b', 'crash');
 
@@ -202,6 +255,6 @@ describe('cross-process exclusion', () => {
 
     const log = await readFile(logFile, 'utf8');
     expect(log).not.toContain('OVERLAP');
-    expect(log.split('\n').filter((line) => line.startsWith('OK ')).length).toBe(workers * sections);
+    expect(log.split('\n').filter((line) => line.startsWith('OK ')).length).toBe((workers + legacyWorkers) * sections);
   }, 120_000);
 });

--- a/packages/extension-runtime/src/__tests__/fixtures/append-worker.ts
+++ b/packages/extension-runtime/src/__tests__/fixtures/append-worker.ts
@@ -1,0 +1,30 @@
+/**
+ * Child-process writer for the cross-process lock test.
+ *
+ * Usage: node append-worker.ts <stateFile> <count>
+ * Appends 0..count-1 to `items` via read-modify-write under the shared lock.
+ * Signals readiness via `<stateFile>.ready` and waits for `<stateFile>.go` so
+ * both processes provably write concurrently — without the barrier the parent
+ * can finish before the child boots and the test exercises nothing.
+ */
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { withStateLock } from '../../file-lock.ts';
+
+const [, , stateFile, countArg] = process.argv;
+if (!stateFile || !countArg) throw new Error('usage: append-worker.ts <stateFile> <count>');
+const count = Number(countArg);
+
+await writeFile(`${stateFile}.ready`, '', 'utf8');
+while (!existsSync(`${stateFile}.go`)) {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+for (let i = 0; i < count; i += 1) {
+  await withStateLock(stateFile, async () => {
+    const current = JSON.parse(await readFile(stateFile, 'utf8')) as { items: number[] };
+    current.items.push(i);
+    await writeFile(stateFile, JSON.stringify(current), 'utf8');
+  });
+}

--- a/packages/extension-runtime/src/__tests__/fixtures/contender-worker.ts
+++ b/packages/extension-runtime/src/__tests__/fixtures/contender-worker.ts
@@ -1,0 +1,46 @@
+/**
+ * Stress worker for the concurrent-reclaim exclusion test.
+ *
+ * Usage: node contender-worker.ts <lockDir> <logFile> <id> <sections> <mode>
+ * - mode `normal`: runs <sections> marker-verified critical sections and logs
+ *   `OVERLAP ...` whenever another holder is observed inside one.
+ * - mode `crash`: acquires once, then exits without releasing — a holder
+ *   crash for the other workers to reclaim while they contend.
+ * Signals readiness via `<logFile>.ready-<id>` and waits for `<logFile>.go`
+ * so every process provably contends at the same time.
+ */
+import { existsSync } from 'node:fs';
+import { appendFile, readFile, rm, writeFile } from 'node:fs/promises';
+
+import { acquireLock } from '../../file-lock.ts';
+
+const [, , lockDir, logFile, id, sectionsArg, mode] = process.argv;
+if (!lockDir || !logFile || !id || !sectionsArg || !mode) {
+  throw new Error('usage: contender-worker.ts <lockDir> <logFile> <id> <sections> <mode>');
+}
+const sections = Number(sectionsArg);
+const marker = `${logFile}.holder`;
+
+await writeFile(`${logFile}.ready-${id}`, '', 'utf8');
+while (!existsSync(`${logFile}.go`)) {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+if (mode === 'crash') {
+  await acquireLock(lockDir, { timeoutMs: 60_000, pollMs: 5 });
+  process.exit(0); // Dies holding the lock; never touches the marker.
+}
+
+for (let i = 0; i < sections; i += 1) {
+  const release = await acquireLock(lockDir, { timeoutMs: 60_000, pollMs: 5 });
+  const stamp = `${id}:${i}`;
+  const before = await readFile(marker, 'utf8').catch(() => null);
+  if (before !== null) await appendFile(logFile, `OVERLAP enter ${stamp} saw ${before}\n`);
+  await writeFile(marker, stamp, 'utf8');
+  await new Promise((resolve) => setTimeout(resolve, 2));
+  const after = await readFile(marker, 'utf8').catch(() => 'missing');
+  if (after !== stamp) await appendFile(logFile, `OVERLAP exit ${stamp} saw ${after}\n`);
+  await rm(marker, { force: true });
+  await appendFile(logFile, `OK ${stamp}\n`);
+  await release();
+}

--- a/packages/extension-runtime/src/__tests__/fixtures/contender-worker.ts
+++ b/packages/extension-runtime/src/__tests__/fixtures/contender-worker.ts
@@ -4,13 +4,16 @@
  * Usage: node contender-worker.ts <lockDir> <logFile> <id> <sections> <mode>
  * - mode `normal`: runs <sections> marker-verified critical sections and logs
  *   `OVERLAP ...` whenever another holder is observed inside one.
- * - mode `crash`: acquires once, then exits without releasing — a holder
- *   crash for the other workers to reclaim while they contend.
+ * - mode `legacy`: reserves with mkdir, pauses, then writes owner.json. This
+ *   widens the pre-0.2.2 publish window for mixed-version contention tests.
+ * - mode `crash`: acquires once, then exits without releasing. This gives the
+ *   other workers a holder to reclaim while they contend.
  * Signals readiness via `<logFile>.ready-<id>` and waits for `<logFile>.go`
  * so every process provably contends at the same time.
  */
 import { existsSync } from 'node:fs';
-import { appendFile, readFile, rm, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import { acquireLock } from '../../file-lock.ts';
 
@@ -20,6 +23,31 @@ if (!lockDir || !logFile || !id || !sectionsArg || !mode) {
 }
 const sections = Number(sectionsArg);
 const marker = `${logFile}.holder`;
+
+async function acquireLegacyLock(): Promise<() => Promise<void>> {
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      await mkdir(lockDir);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (Date.now() >= deadline) throw new Error('legacy acquire timed out');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  // A legacy client exposes an empty directory between mkdir and this write.
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+    pid: process.pid,
+    acquiredAt: Date.now(),
+  }), 'utf8');
+
+  return async () => {
+    await rm(lockDir, { recursive: true, force: true });
+  };
+}
 
 await writeFile(`${logFile}.ready-${id}`, '', 'utf8');
 while (!existsSync(`${logFile}.go`)) {
@@ -32,7 +60,9 @@ if (mode === 'crash') {
 }
 
 for (let i = 0; i < sections; i += 1) {
-  const release = await acquireLock(lockDir, { timeoutMs: 60_000, pollMs: 5 });
+  const release = mode === 'legacy'
+    ? await acquireLegacyLock()
+    : await acquireLock(lockDir, { timeoutMs: 60_000, pollMs: 5 });
   const stamp = `${id}:${i}`;
   const before = await readFile(marker, 'utf8').catch(() => null);
   if (before !== null) await appendFile(logFile, `OVERLAP enter ${stamp} saw ${before}\n`);

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { stateLockPath } from './state-lock-path.ts';
+import { stateLockPath } from './state-lock-path';
 
 /**
  * Cross-process exclusive lock for app state files.

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { link, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { link, mkdir, readdir, readFile, rename, rm, rmdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { stateLockPath } from './state-lock-path';
@@ -64,8 +64,12 @@ interface LockOwner {
   token?: string;
 }
 
-/** Tokens this process currently holds; distinguishes our live locks from our leftovers. */
-const heldTokens = new Set<string>();
+const HELD_TOKENS_KEY = Symbol.for('@sero-ai/extension-runtime/file-lock/held-tokens');
+type FileLockGlobals = typeof globalThis & { [HELD_TOKENS_KEY]?: Set<string> };
+const fileLockGlobals = globalThis as FileLockGlobals;
+
+/** Tokens this process currently holds, shared by every bundled copy of this module. */
+const heldTokens = fileLockGlobals[HELD_TOKENS_KEY] ??= new Set<string>();
 
 async function readOwnerFile(file: string): Promise<LockOwner | null> {
   const raw = await readFile(file, 'utf8').catch(() => null);
@@ -122,6 +126,15 @@ async function disposeLockDir(lockDir: string): Promise<void> {
     throw error;
   }
   await rm(disposal, { recursive: true, force: true });
+}
+
+async function removeEmptyLockDir(lockDir: string): Promise<void> {
+  try {
+    await rmdir(lockDir);
+  } catch (error) {
+    if (hasCode(error, 'ENOENT', 'ENOTDIR', 'ENOTEMPTY', 'EEXIST')) return;
+    throw error;
+  }
 }
 
 async function listSiblings(lockDir: string): Promise<string[]> {
@@ -192,6 +205,7 @@ async function tryPublish(lockDir: string, token: string): Promise<boolean> {
   } catch (error) {
     await rm(staging, { recursive: true, force: true });
     if (hasCode(error, 'ENOENT', 'EEXIST', 'ENOTDIR', 'EINVAL')) return false;
+    await removeEmptyLockDir(lockDir);
     throw error;
   }
 

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -2,16 +2,20 @@ import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 /**
- * Cross-process exclusive lock.
+ * Cross-process exclusive lock for app state files.
  *
- * Atomic file replacement is not sufficient concurrency control here: Pi tool
- * calls run in a different process from the host runtime, so two writers can
+ * Atomic file replacement is not sufficient concurrency control: a plugin
+ * extension runs in a different process from the host, so two writers can
  * each read, modify and rename without ever observing the other. `mkdir` is
  * atomic and fails if the directory exists, which gives us a mutex that works
  * across processes without a daemon.
  *
  * A holder that dies leaves the directory behind, so the lock records its pid
  * and acquisition time and is reclaimed once it is provably stale.
+ *
+ * Every writer of one file must use the same lock directory, or they hold two
+ * mutexes and exclude nothing. `stateLockPath` is that one name rule: the host
+ * (`AppStateManager`) locks `<stateFile>.lock`, and so must every extension.
  */
 
 export interface FileLockOptions {
@@ -24,6 +28,11 @@ export interface FileLockOptions {
 
 const DEFAULTS = { timeoutMs: 10_000, staleMs: 30_000, pollMs: 25 };
 
+/** The one shared lock-directory name for a state file: `<stateFile>.lock`. */
+export function stateLockPath(stateFile: string): string {
+  return `${stateFile}.lock`;
+}
+
 interface LockOwner {
   pid: number;
   acquiredAt: number;
@@ -32,7 +41,12 @@ interface LockOwner {
 async function readOwner(lockDir: string): Promise<LockOwner | null> {
   const raw = await readFile(path.join(lockDir, 'owner.json'), 'utf8').catch(() => null);
   if (raw === null) return null;
-  const parsed: unknown = JSON.parse(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
   if (typeof parsed !== 'object' || parsed === null) return null;
   const owner = parsed as Record<string, unknown>;
   if (typeof owner.pid !== 'number' || typeof owner.acquiredAt !== 'number') return null;
@@ -105,4 +119,13 @@ export async function withLock<T>(
   } finally {
     await release();
   }
+}
+
+/** Run `fn` while holding the shared cross-process lock for a state file. */
+export function withStateLock<T>(
+  stateFile: string,
+  fn: () => Promise<T>,
+  options: FileLockOptions = {},
+): Promise<T> {
+  return withLock(stateLockPath(stateFile), fn, options);
 }

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { link, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { stateLockPath } from './state-lock-path';
@@ -10,35 +10,35 @@ import { stateLockPath } from './state-lock-path';
  * Atomic file replacement is not sufficient concurrency control: a plugin
  * extension runs in a different process from the host, so two writers can
  * each read, modify and rename without ever observing the other. The lock is
- * a directory, because directory creation and rename are the atomic
- * primitives POSIX gives us without a daemon or native code.
+ * a directory, because directory creation, hard links and rename are the
+ * atomic primitives POSIX gives us without a daemon or native code.
  *
- * The protocol is built so that no step ever removes a lock based on a
- * possibly-stale observation:
+ * The protocol keeps the lock path present while it verifies ownership:
  *
- * - **Acquire** stages a directory that already contains `owner.json` and
- *   publishes it with one atomic `rename` onto the lock path. The lock can
- *   therefore never exist without its owner file, so there is no window in
- *   which a half-made lock can be reclaimed and then resurrected by a late
- *   owner write.
- * - **Reclaim** of an abandoned lock (owner process dead, or an ownerless
- *   legacy directory past `staleMs`) starts with an atomic `rename` of the
- *   lock to a unique grave path. Only one contender can win that rename. The
- *   winner then re-reads the grave: if it holds the incarnation that was
- *   judged abandoned it is removed; if a live successor was moved by mistake
- *   (the judgement was stale) it is renamed back, never deleted.
- * - **Acquirers verify after publishing**: if any grave holds a live owner, a
- *   displaced holder may still be inside its critical section, so the new
- *   acquirer withdraws and waits. Every waiter also restores live graves and
- *   clears dead ones, so a crashed reclaimer cannot strand the lock.
+ * - **Acquire** stages a complete owner record, reserves the shared path with
+ *   atomic `mkdir`, then hard-links the record into that directory without
+ *   replacement. Current and legacy clients therefore compete through the
+ *   same no-replace operation. A current publisher also leaves its staged
+ *   owner visible until publication completes, so current reclaimers do not
+ *   mistake its short ownerless phase for a crashed legacy client.
+ * - **Reclaim** first moves `owner.json` to a claim file inside the lock
+ *   directory. The lock path never disappears during verification, so a
+ *   contender cannot acquire it. The reclaimer removes the directory only if
+ *   the claimed token is the abandoned incarnation it observed. A stale
+ *   claim is restored without replacing a newer owner record.
+ * - **Waiters recover claims** left by a crashed reclaimer. A live owner is
+ *   restored, while a dead owner is removed with its lock directory.
+ * - An ownerless shared lock path is never reclaimed. A pre-0.2.2 publisher
+ *   can be paused between `mkdir` and its owner write, and that state has no
+ *   PID or token that can distinguish it from a crash. Waiting and timing out
+ *   preserves exclusion; deleting it could admit two live holders.
  * - An ALIVE owner is never reclaimed, however long it holds the lock — a
  *   wedged holder surfaces as acquire timeouts, which is the declared
  *   failure mode. The one exception is an owner record with our own pid
  *   whose token no code in this process holds: that is a leftover of a
  *   resolved steal, and only its own process can safely say so.
- * - **Release** verifies the ownership token before removing anything, and
- *   also looks for its own lock in a grave, so a holder that was briefly
- *   moved aside still cleans up after itself.
+ * - **Release** uses the same in-directory claim before removal, so it cannot
+ *   remove a successor from a stale token observation.
  *
  * Every writer of one file must use the same lock directory, or they hold
  * two mutexes and exclude nothing. `stateLockPath` is that one name rule:
@@ -49,7 +49,7 @@ import { stateLockPath } from './state-lock-path';
 export interface FileLockOptions {
   /** How long to keep trying before giving up. */
   timeoutMs?: number;
-  /** An ownerless lock directory older than this is treated as abandoned. */
+  /** Age threshold for corrupt staging and interrupted-claim cleanup. */
   staleMs?: number;
   pollMs?: number;
 }
@@ -61,14 +61,14 @@ export { stateLockPath };
 interface LockOwner {
   pid: number;
   acquiredAt: number;
-  token: string;
+  token?: string;
 }
 
 /** Tokens this process currently holds; distinguishes our live locks from our leftovers. */
 const heldTokens = new Set<string>();
 
-async function readOwner(dir: string): Promise<LockOwner | null> {
-  const raw = await readFile(path.join(dir, 'owner.json'), 'utf8').catch(() => null);
+async function readOwnerFile(file: string): Promise<LockOwner | null> {
+  const raw = await readFile(file, 'utf8').catch(() => null);
   if (raw === null) return null;
   let parsed: unknown;
   try {
@@ -78,8 +78,12 @@ async function readOwner(dir: string): Promise<LockOwner | null> {
   }
   if (typeof parsed !== 'object' || parsed === null) return null;
   const owner = parsed as Record<string, unknown>;
-  if (typeof owner.pid !== 'number' || typeof owner.token !== 'string') return null;
+  if (typeof owner.pid !== 'number' || (owner.token !== undefined && typeof owner.token !== 'string')) return null;
   return { pid: owner.pid, acquiredAt: typeof owner.acquiredAt === 'number' ? owner.acquiredAt : 0, token: owner.token };
+}
+
+function readOwner(dir: string): Promise<LockOwner | null> {
+  return readOwnerFile(path.join(dir, 'owner.json'));
 }
 
 /** True when the lock's owning process no longer exists. */
@@ -95,132 +99,185 @@ function processIsGone(pid: number): boolean {
 }
 
 function ownerIsAbandoned(owner: LockOwner): boolean {
-  if (owner.pid === process.pid) return !heldTokens.has(owner.token);
+  if (owner.pid === process.pid) return owner.token !== undefined && !heldTokens.has(owner.token);
   return processIsGone(owner.pid);
 }
 
-function isTakenCode(code: string | undefined): boolean {
-  // rename onto a non-empty directory: ENOTEMPTY on most platforms, EEXIST on some.
-  return code === 'ENOTEMPTY' || code === 'EEXIST';
+function sameOwner(left: LockOwner, right: LockOwner): boolean {
+  return left.pid === right.pid
+    && left.acquiredAt === right.acquiredAt
+    && left.token === right.token;
 }
 
-/**
- * Rename that refuses to replace an existing target. `rename` silently
- * replaces an EMPTY target directory, and the lock path can hold an empty
- * directory while a legacy (pre-0.2.2) client is between its `mkdir` and its
- * owner write — that incarnation must be waited out, not clobbered.
- */
-async function renameIfAbsent(src: string, dst: string): Promise<boolean> {
-  const existing = await stat(dst).catch(() => null);
-  if (existing) return false;
+function hasCode(error: unknown, ...codes: string[]): boolean {
+  return codes.includes((error as NodeJS.ErrnoException).code ?? '');
+}
+
+async function disposeLockDir(lockDir: string): Promise<void> {
+  const disposal = `${lockDir}.remove-${randomUUID()}`;
   try {
-    await rename(src, dst);
-    return true;
+    await rename(lockDir, disposal);
   } catch (error) {
-    // ENOENT: the source vanished under a concurrent resolver — equally "no".
-    const code = (error as NodeJS.ErrnoException).code;
-    if (isTakenCode(code) || code === 'ENOENT') return false;
+    if (hasCode(error, 'ENOENT', 'ENOTDIR')) return;
     throw error;
   }
+  await rm(disposal, { recursive: true, force: true });
 }
 
-/** Stage a fully-populated lock directory, then publish it atomically. */
-async function tryPublish(lockDir: string, token: string): Promise<boolean> {
-  const staging = `${lockDir}.tmp-${token}`;
-  await mkdir(path.dirname(lockDir), { recursive: true });
-  await mkdir(staging);
-  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now(), token };
-  await writeFile(path.join(staging, 'owner.json'), JSON.stringify(owner), 'utf8');
-  const published = await renameIfAbsent(staging, lockDir);
-  if (!published) await rm(staging, { recursive: true, force: true });
-  return published;
-}
-
-async function listSiblings(lockDir: string, kind: 'grave' | 'tmp'): Promise<string[]> {
+async function listSiblings(lockDir: string): Promise<string[]> {
   const parent = path.dirname(lockDir);
-  const prefix = `${path.basename(lockDir)}.${kind}-`;
+  const prefix = `${path.basename(lockDir)}.tmp-`;
   const entries = await readdir(parent).catch(() => [] as string[]);
-  return entries.filter((name) => name.startsWith(prefix)).map((name) => path.join(parent, name));
+  return entries.flatMap((name) => (name.startsWith(prefix) ? path.join(parent, name) : []));
+}
+
+async function listClaims(lockDir: string): Promise<string[]> {
+  const entries = await readdir(lockDir).catch(() => [] as string[]);
+  return entries.flatMap((name) => (
+    name.startsWith('.owner-claim-') ? path.join(lockDir, name) : []
+  ));
+}
+
+function claimProcessIsGone(claim: string): boolean {
+  const match = path.basename(claim).match(/^\.owner-claim-(\d+)-/);
+  return match ? processIsGone(Number(match[1])) : true;
 }
 
 /**
- * Restore or clear graves and abandoned staging dirs. Returns true while any
- * grave holds a live owner — an acquirer must not enter until it is restored.
+ * Remove dead staging directories and report whether a current publisher is
+ * still alive. A live publisher protects the brief ownerless interval after
+ * its successful mkdir.
  */
-async function resolveGraves(lockDir: string, staleMs: number): Promise<boolean> {
-  let liveGrave = false;
-  for (const grave of await listSiblings(lockDir, 'grave')) {
-    const owner = await readOwner(grave);
+async function resolveStaging(lockDir: string, staleMs: number): Promise<boolean> {
+  let livePublisher = false;
+  for (const staging of await listSiblings(lockDir)) {
+    const owner = await readOwner(staging);
     if (owner && !ownerIsAbandoned(owner)) {
-      liveGrave = true;
-      // A live holder was moved aside by a stale reclaim: put it back. The
-      // rename is atomic, so concurrent restorers cannot duplicate it, and a
-      // failure (lock path occupied) just leaves the grave for the next pass.
-      await renameIfAbsent(grave, lockDir);
+      livePublisher = true;
       continue;
     }
     if (owner === null) {
-      // Graves are created fully-populated, so an ownerless one is corrupt;
-      // give it the stale window before clearing it.
-      const stats = await stat(grave).catch(() => null);
-      if (stats && Date.now() - stats.mtimeMs < staleMs) continue;
+      const stats = await stat(staging).catch(() => null);
+      if (stats && Date.now() - stats.mtimeMs < staleMs) {
+        livePublisher = true;
+        continue;
+      }
     }
-    await rm(grave, { recursive: true, force: true });
+    await rm(staging, { recursive: true, force: true });
   }
-  for (const staging of await listSiblings(lockDir, 'tmp')) {
-    // A staging dir belongs to one live acquire attempt; clear it once its
-    // process is gone or, lacking an owner record, once it is stale.
-    const owner = await readOwner(staging);
-    const abandoned = owner
-      ? ownerIsAbandoned(owner)
-      : await stat(staging).then((s) => Date.now() - s.mtimeMs >= staleMs, () => false);
-    if (abandoned) await rm(staging, { recursive: true, force: true });
+  return livePublisher;
+}
+
+/** Stage a complete owner, reserve with mkdir, then publish without overwrite. */
+async function tryPublish(lockDir: string, token: string): Promise<boolean> {
+  const staging = `${lockDir}.tmp-${token}`;
+  const stagedOwner = path.join(staging, 'owner.json');
+  await mkdir(path.dirname(lockDir), { recursive: true });
+  await mkdir(staging);
+  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now(), token };
+  await writeFile(stagedOwner, JSON.stringify(owner), 'utf8');
+
+  try {
+    await mkdir(lockDir);
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true });
+    if (hasCode(error, 'EEXIST')) return false;
+    throw error;
   }
-  return liveGrave;
+
+  try {
+    // A hard link publishes the fully-written record and never replaces a
+    // successor's owner file if this reservation moved while we were paused.
+    await link(stagedOwner, path.join(lockDir, 'owner.json'));
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true });
+    if (hasCode(error, 'ENOENT', 'EEXIST', 'ENOTDIR', 'EINVAL')) return false;
+    throw error;
+  }
+
+  await rm(staging, { recursive: true, force: true });
+  return (await readOwner(lockDir))?.token === token;
+}
+
+async function restoreClaim(lockDir: string, claim: string): Promise<boolean> {
+  const raw = await readFile(claim, 'utf8').catch(() => null);
+  if (raw === null) return false;
+  try {
+    await writeFile(path.join(lockDir, 'owner.json'), raw, { encoding: 'utf8', flag: 'wx' });
+  } catch (error) {
+    if (!hasCode(error, 'EEXIST', 'ENOENT', 'ENOTDIR', 'EINVAL')) throw error;
+    const claimedOwner = await readOwnerFile(claim);
+    const currentOwner = await readOwner(lockDir);
+    if (!claimedOwner || !currentOwner || !sameOwner(claimedOwner, currentOwner)) return false;
+  }
+  await rm(claim, { force: true });
+  return true;
 }
 
 /**
- * Reclaim what was observed as an abandoned lock. The rename decides a single
- * winner; the verify afterwards guarantees a live successor moved by a stale
- * observation is restored, never deleted.
+ * Claim one owner record without removing the lock path. A matching claim can
+ * then remove the directory without touching a successor incarnation.
  */
-async function reclaimViaGrave(lockDir: string, observedToken: string | null): Promise<void> {
-  const grave = `${lockDir}.grave-${randomUUID()}`;
+async function removeIfOwned(lockDir: string, expectedOwner: LockOwner | string): Promise<boolean> {
+  const claim = path.join(lockDir, `.owner-claim-${process.pid}-${randomUUID()}.json`);
   try {
-    await rename(lockDir, grave);
-  } catch {
-    return; // Someone else already reclaimed this incarnation.
+    await rename(path.join(lockDir, 'owner.json'), claim);
+  } catch (error) {
+    if (hasCode(error, 'ENOENT', 'ENOTDIR')) return false;
+    throw error;
   }
-  const owner = await readOwner(grave);
-  const sameIncarnation = observedToken === null ? owner === null : owner?.token === observedToken;
-  if (sameIncarnation) {
-    await rm(grave, { recursive: true, force: true });
-    return;
+
+  const claimedOwner = await readOwnerFile(claim);
+  const matches = typeof expectedOwner === 'string'
+    ? claimedOwner?.token === expectedOwner
+    : claimedOwner !== null && sameOwner(claimedOwner, expectedOwner);
+  if (!matches) {
+    await restoreClaim(lockDir, claim);
+    return false;
   }
-  // The observation was stale and we moved a different incarnation. Restore
-  // it; if the lock path is already occupied again, resolveGraves finishes
-  // the restore on a later pass.
-  await renameIfAbsent(grave, lockDir);
+
+  await disposeLockDir(lockDir);
+  return true;
+}
+
+/** Restore live claims and remove locks whose claimant process has exited. */
+async function resolveClaims(lockDir: string, staleMs: number): Promise<boolean> {
+  for (const claim of await listClaims(lockDir)) {
+    // Only the process that moved owner.json can remove this incarnation.
+    // Wait while it is alive so a second resolver cannot later act on a
+    // successor through the same lock path.
+    if (!claimProcessIsGone(claim)) return true;
+    const owner = await readOwnerFile(claim);
+    const currentOwner = await readOwner(lockDir);
+    if (currentOwner) {
+      await rm(claim, { force: true });
+      continue;
+    }
+    if (owner && !ownerIsAbandoned(owner)) {
+      await restoreClaim(lockDir, claim);
+      return true;
+    }
+    if (owner === null) {
+      const stats = await stat(claim).catch(() => null);
+      if (stats && Date.now() - stats.mtimeMs < staleMs) return true;
+    }
+    await disposeLockDir(lockDir);
+    return false;
+  }
+  return false;
 }
 
 async function releaseByToken(lockDir: string, token: string, pollMs: number): Promise<void> {
   try {
-    // A steal-and-restore can move our lock through a grave while we release,
-    // so check both places and try again briefly if it is mid-flight.
     for (let attempt = 0; attempt < 40; attempt++) {
-      const owner = await readOwner(lockDir);
-      if (owner?.token === token) {
-        await rm(lockDir, { recursive: true, force: true });
-        return;
-      }
-      let foundOurs = false;
-      for (const grave of await listSiblings(lockDir, 'grave')) {
-        if ((await readOwner(grave))?.token === token) {
-          foundOurs = true;
-          await rm(grave, { recursive: true, force: true });
-        }
-      }
-      if (!foundOurs) return; // Nothing of ours anywhere: legitimately reclaimed.
+      if (await removeIfOwned(lockDir, token)) return;
+      const ownsClaim = await Promise.all(
+        (await listClaims(lockDir)).map(async (claim) => {
+          const owner = await readOwnerFile(claim);
+          return owner?.token === token;
+        }),
+      ).then((matches) => matches.some(Boolean));
+      if (!ownsClaim) return;
       await new Promise((resolve) => setTimeout(resolve, pollMs));
     }
   } finally {
@@ -233,8 +290,8 @@ export async function acquireLock(lockDir: string, options: FileLockOptions = {}
   const deadline = Date.now() + timeoutMs;
 
   for (;;) {
-    const liveGrave = await resolveGraves(lockDir, staleMs);
-    if (!liveGrave) {
+    const liveClaim = await resolveClaims(lockDir, staleMs);
+    if (!liveClaim) {
       const token = randomUUID();
       heldTokens.add(token);
       let published = false;
@@ -244,24 +301,15 @@ export async function acquireLock(lockDir: string, options: FileLockOptions = {}
         if (!published) heldTokens.delete(token);
       }
       if (published) {
-        // Verify: a displaced live holder may still be running inside a
-        // grave. Withdraw and wait for it to be restored.
-        if (!(await resolveGraves(lockDir, staleMs))) {
-          return () => releaseByToken(lockDir, token, pollMs);
-        }
-        await releaseByToken(lockDir, token, pollMs);
-      } else {
-        const owner = await readOwner(lockDir);
-        if (owner === null) {
-          // No owner record: either a rename is mid-flight or a legacy client
-          // crashed between mkdir and its owner write. Judge by age.
-          const stats = await stat(lockDir).catch(() => null);
-          if (stats && Date.now() - stats.mtimeMs >= staleMs) {
-            await reclaimViaGrave(lockDir, null);
-          }
-        } else if (ownerIsAbandoned(owner)) {
-          await reclaimViaGrave(lockDir, owner.token);
-        }
+        return () => releaseByToken(lockDir, token, pollMs);
+      }
+      const owner = await readOwner(lockDir);
+      if (owner === null) {
+        // Clean only identified staging artifacts. The shared path itself can
+        // be a paused legacy publisher and must remain until its owner appears.
+        await resolveStaging(lockDir, staleMs);
+      } else if (ownerIsAbandoned(owner)) {
+        await removeIfOwned(lockDir, owner);
       }
     }
     if (Date.now() >= deadline) {

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { stateLockPath } from './state-lock-path.ts';
+
 /**
  * Cross-process exclusive lock for app state files.
  *
@@ -54,10 +56,7 @@ export interface FileLockOptions {
 
 const DEFAULTS = { timeoutMs: 10_000, staleMs: 30_000, pollMs: 25 };
 
-/** The one shared lock-directory name for a state file: `<stateFile>.lock`. */
-export function stateLockPath(stateFile: string): string {
-  return `${stateFile}.lock`;
-}
+export { stateLockPath };
 
 interface LockOwner {
   pid: number;

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 /**
@@ -7,27 +7,41 @@ import path from 'node:path';
  *
  * Atomic file replacement is not sufficient concurrency control: a plugin
  * extension runs in a different process from the host, so two writers can
- * each read, modify and rename without ever observing the other. `mkdir` is
- * atomic and fails if the directory exists, which gives us a mutex that works
- * across processes without a daemon.
+ * each read, modify and rename without ever observing the other. The lock is
+ * a directory, because directory creation and rename are the atomic
+ * primitives POSIX gives us without a daemon or native code.
  *
- * Reclaim rules, in order of proof:
- * - An owner whose process has exited is reclaimed immediately.
- * - A directory that never got a readable owner file (a crash between mkdir
- *   and the owner write) is reclaimed once the directory is `staleMs` old.
- * - An ALIVE owner is never reclaimed, however long it holds the lock —
- *   evicting a live holder breaks mutual exclusion, because that holder will
- *   finish its write and then release a lock that now belongs to someone
- *   else. A wedged holder therefore surfaces as acquire timeouts, which is
- *   the declared failure mode.
+ * The protocol is built so that no step ever removes a lock based on a
+ * possibly-stale observation:
  *
- * Release verifies an ownership token before removing anything, so a release
- * arriving after a legitimate reclaim (owner died mid-hold and its release
- * closure still ran, e.g. in a finally) cannot remove a successor's lock.
+ * - **Acquire** stages a directory that already contains `owner.json` and
+ *   publishes it with one atomic `rename` onto the lock path. The lock can
+ *   therefore never exist without its owner file, so there is no window in
+ *   which a half-made lock can be reclaimed and then resurrected by a late
+ *   owner write.
+ * - **Reclaim** of an abandoned lock (owner process dead, or an ownerless
+ *   legacy directory past `staleMs`) starts with an atomic `rename` of the
+ *   lock to a unique grave path. Only one contender can win that rename. The
+ *   winner then re-reads the grave: if it holds the incarnation that was
+ *   judged abandoned it is removed; if a live successor was moved by mistake
+ *   (the judgement was stale) it is renamed back, never deleted.
+ * - **Acquirers verify after publishing**: if any grave holds a live owner, a
+ *   displaced holder may still be inside its critical section, so the new
+ *   acquirer withdraws and waits. Every waiter also restores live graves and
+ *   clears dead ones, so a crashed reclaimer cannot strand the lock.
+ * - An ALIVE owner is never reclaimed, however long it holds the lock — a
+ *   wedged holder surfaces as acquire timeouts, which is the declared
+ *   failure mode. The one exception is an owner record with our own pid
+ *   whose token no code in this process holds: that is a leftover of a
+ *   resolved steal, and only its own process can safely say so.
+ * - **Release** verifies the ownership token before removing anything, and
+ *   also looks for its own lock in a grave, so a holder that was briefly
+ *   moved aside still cleans up after itself.
  *
- * Every writer of one file must use the same lock directory, or they hold two
- * mutexes and exclude nothing. `stateLockPath` is that one name rule: the host
- * (`AppStateManager`) locks `<stateFile>.lock`, and so must every extension.
+ * Every writer of one file must use the same lock directory, or they hold
+ * two mutexes and exclude nothing. `stateLockPath` is that one name rule:
+ * the host (`AppStateManager`) locks `<stateFile>.lock`, and so must every
+ * extension.
  */
 
 export interface FileLockOptions {
@@ -51,8 +65,11 @@ interface LockOwner {
   token: string;
 }
 
-async function readOwner(lockDir: string): Promise<LockOwner | null> {
-  const raw = await readFile(path.join(lockDir, 'owner.json'), 'utf8').catch(() => null);
+/** Tokens this process currently holds; distinguishes our live locks from our leftovers. */
+const heldTokens = new Set<string>();
+
+async function readOwner(dir: string): Promise<LockOwner | null> {
+  const raw = await readFile(path.join(dir, 'owner.json'), 'utf8').catch(() => null);
   if (raw === null) return null;
   let parsed: unknown;
   try {
@@ -67,8 +84,7 @@ async function readOwner(lockDir: string): Promise<LockOwner | null> {
 }
 
 /** True when the lock's owning process no longer exists. */
-function ownerIsGone(pid: number): boolean {
-  if (pid === process.pid) return false;
+function processIsGone(pid: number): boolean {
   try {
     // Signal 0 performs the permission/existence check without delivering.
     process.kill(pid, 0);
@@ -79,43 +95,138 @@ function ownerIsGone(pid: number): boolean {
   }
 }
 
-/** Returns the ownership token on success, null when the lock is taken. */
-async function tryAcquire(lockDir: string): Promise<string | null> {
-  await mkdir(path.dirname(lockDir), { recursive: true });
-  const created = await mkdir(lockDir).then(
-    () => true,
-    (error: NodeJS.ErrnoException) => {
-      if (error.code === 'EEXIST') return false;
-      throw error;
-    },
-  );
-  if (!created) return null;
-  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now(), token: randomUUID() };
-  try {
-    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify(owner), 'utf8');
-  } catch (error) {
-    // The directory was reclaimed as ownerless between the mkdir and this
-    // write — the lock is not ours, go back to waiting.
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw error;
-  }
-  return owner.token;
+function ownerIsAbandoned(owner: LockOwner): boolean {
+  if (owner.pid === process.pid) return !heldTokens.has(owner.token);
+  return processIsGone(owner.pid);
 }
 
-async function reclaimIfAbandoned(lockDir: string, staleMs: number): Promise<void> {
-  const owner = await readOwner(lockDir);
-  if (owner) {
-    // An alive owner is never reclaimed; see the module comment.
-    if (!ownerIsGone(owner.pid)) return;
-    await rm(lockDir, { recursive: true, force: true });
+function isTakenCode(code: string | undefined): boolean {
+  // rename onto a non-empty directory: ENOTEMPTY on most platforms, EEXIST on some.
+  return code === 'ENOTEMPTY' || code === 'EEXIST';
+}
+
+/**
+ * Rename that refuses to replace an existing target. `rename` silently
+ * replaces an EMPTY target directory, and the lock path can hold an empty
+ * directory while a legacy (pre-0.2.2) client is between its `mkdir` and its
+ * owner write — that incarnation must be waited out, not clobbered.
+ */
+async function renameIfAbsent(src: string, dst: string): Promise<boolean> {
+  const existing = await stat(dst).catch(() => null);
+  if (existing) return false;
+  try {
+    await rename(src, dst);
+    return true;
+  } catch (error) {
+    // ENOENT: the source vanished under a concurrent resolver — equally "no".
+    const code = (error as NodeJS.ErrnoException).code;
+    if (isTakenCode(code) || code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+/** Stage a fully-populated lock directory, then publish it atomically. */
+async function tryPublish(lockDir: string, token: string): Promise<boolean> {
+  const staging = `${lockDir}.tmp-${token}`;
+  await mkdir(path.dirname(lockDir), { recursive: true });
+  await mkdir(staging);
+  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now(), token };
+  await writeFile(path.join(staging, 'owner.json'), JSON.stringify(owner), 'utf8');
+  const published = await renameIfAbsent(staging, lockDir);
+  if (!published) await rm(staging, { recursive: true, force: true });
+  return published;
+}
+
+async function listSiblings(lockDir: string, kind: 'grave' | 'tmp'): Promise<string[]> {
+  const parent = path.dirname(lockDir);
+  const prefix = `${path.basename(lockDir)}.${kind}-`;
+  const entries = await readdir(parent).catch(() => [] as string[]);
+  return entries.filter((name) => name.startsWith(prefix)).map((name) => path.join(parent, name));
+}
+
+/**
+ * Restore or clear graves and abandoned staging dirs. Returns true while any
+ * grave holds a live owner — an acquirer must not enter until it is restored.
+ */
+async function resolveGraves(lockDir: string, staleMs: number): Promise<boolean> {
+  let liveGrave = false;
+  for (const grave of await listSiblings(lockDir, 'grave')) {
+    const owner = await readOwner(grave);
+    if (owner && !ownerIsAbandoned(owner)) {
+      liveGrave = true;
+      // A live holder was moved aside by a stale reclaim: put it back. The
+      // rename is atomic, so concurrent restorers cannot duplicate it, and a
+      // failure (lock path occupied) just leaves the grave for the next pass.
+      await renameIfAbsent(grave, lockDir);
+      continue;
+    }
+    if (owner === null) {
+      // Graves are created fully-populated, so an ownerless one is corrupt;
+      // give it the stale window before clearing it.
+      const stats = await stat(grave).catch(() => null);
+      if (stats && Date.now() - stats.mtimeMs < staleMs) continue;
+    }
+    await rm(grave, { recursive: true, force: true });
+  }
+  for (const staging of await listSiblings(lockDir, 'tmp')) {
+    // A staging dir belongs to one live acquire attempt; clear it once its
+    // process is gone or, lacking an owner record, once it is stale.
+    const owner = await readOwner(staging);
+    const abandoned = owner
+      ? ownerIsAbandoned(owner)
+      : await stat(staging).then((s) => Date.now() - s.mtimeMs >= staleMs, () => false);
+    if (abandoned) await rm(staging, { recursive: true, force: true });
+  }
+  return liveGrave;
+}
+
+/**
+ * Reclaim what was observed as an abandoned lock. The rename decides a single
+ * winner; the verify afterwards guarantees a live successor moved by a stale
+ * observation is restored, never deleted.
+ */
+async function reclaimViaGrave(lockDir: string, observedToken: string | null): Promise<void> {
+  const grave = `${lockDir}.grave-${randomUUID()}`;
+  try {
+    await rename(lockDir, grave);
+  } catch {
+    return; // Someone else already reclaimed this incarnation.
+  }
+  const owner = await readOwner(grave);
+  const sameIncarnation = observedToken === null ? owner === null : owner?.token === observedToken;
+  if (sameIncarnation) {
+    await rm(grave, { recursive: true, force: true });
     return;
   }
-  // No readable owner: mid-acquisition, or a crash before the owner write.
-  // Judge by the directory's age and give it the full stale window.
-  const stats = await stat(lockDir).catch(() => null);
-  if (!stats) return;
-  if (Date.now() - stats.mtimeMs < staleMs) return;
-  await rm(lockDir, { recursive: true, force: true });
+  // The observation was stale and we moved a different incarnation. Restore
+  // it; if the lock path is already occupied again, resolveGraves finishes
+  // the restore on a later pass.
+  await renameIfAbsent(grave, lockDir);
+}
+
+async function releaseByToken(lockDir: string, token: string, pollMs: number): Promise<void> {
+  try {
+    // A steal-and-restore can move our lock through a grave while we release,
+    // so check both places and try again briefly if it is mid-flight.
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const owner = await readOwner(lockDir);
+      if (owner?.token === token) {
+        await rm(lockDir, { recursive: true, force: true });
+        return;
+      }
+      let foundOurs = false;
+      for (const grave of await listSiblings(lockDir, 'grave')) {
+        if ((await readOwner(grave))?.token === token) {
+          foundOurs = true;
+          await rm(grave, { recursive: true, force: true });
+        }
+      }
+      if (!foundOurs) return; // Nothing of ours anywhere: legitimately reclaimed.
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+  } finally {
+    heldTokens.delete(token);
+  }
 }
 
 export async function acquireLock(lockDir: string, options: FileLockOptions = {}): Promise<() => Promise<void>> {
@@ -123,17 +234,37 @@ export async function acquireLock(lockDir: string, options: FileLockOptions = {}
   const deadline = Date.now() + timeoutMs;
 
   for (;;) {
-    const token = await tryAcquire(lockDir);
-    if (token !== null) {
-      return async () => {
-        // Remove only what is still ours — releasing after a reclaim must
-        // not take a successor's lock with it.
+    const liveGrave = await resolveGraves(lockDir, staleMs);
+    if (!liveGrave) {
+      const token = randomUUID();
+      heldTokens.add(token);
+      let published = false;
+      try {
+        published = await tryPublish(lockDir, token);
+      } finally {
+        if (!published) heldTokens.delete(token);
+      }
+      if (published) {
+        // Verify: a displaced live holder may still be running inside a
+        // grave. Withdraw and wait for it to be restored.
+        if (!(await resolveGraves(lockDir, staleMs))) {
+          return () => releaseByToken(lockDir, token, pollMs);
+        }
+        await releaseByToken(lockDir, token, pollMs);
+      } else {
         const owner = await readOwner(lockDir);
-        if (owner?.token !== token) return;
-        await rm(lockDir, { recursive: true, force: true });
-      };
+        if (owner === null) {
+          // No owner record: either a rename is mid-flight or a legacy client
+          // crashed between mkdir and its owner write. Judge by age.
+          const stats = await stat(lockDir).catch(() => null);
+          if (stats && Date.now() - stats.mtimeMs >= staleMs) {
+            await reclaimViaGrave(lockDir, null);
+          }
+        } else if (ownerIsAbandoned(owner)) {
+          await reclaimViaGrave(lockDir, owner.token);
+        }
+      }
     }
-    await reclaimIfAbandoned(lockDir, staleMs);
     if (Date.now() >= deadline) {
       throw new Error(`Timed out acquiring lock at ${lockDir} after ${timeoutMs}ms`);
     }

--- a/packages/extension-runtime/src/file-lock.ts
+++ b/packages/extension-runtime/src/file-lock.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 /**
@@ -10,8 +11,19 @@ import path from 'node:path';
  * atomic and fails if the directory exists, which gives us a mutex that works
  * across processes without a daemon.
  *
- * A holder that dies leaves the directory behind, so the lock records its pid
- * and acquisition time and is reclaimed once it is provably stale.
+ * Reclaim rules, in order of proof:
+ * - An owner whose process has exited is reclaimed immediately.
+ * - A directory that never got a readable owner file (a crash between mkdir
+ *   and the owner write) is reclaimed once the directory is `staleMs` old.
+ * - An ALIVE owner is never reclaimed, however long it holds the lock —
+ *   evicting a live holder breaks mutual exclusion, because that holder will
+ *   finish its write and then release a lock that now belongs to someone
+ *   else. A wedged holder therefore surfaces as acquire timeouts, which is
+ *   the declared failure mode.
+ *
+ * Release verifies an ownership token before removing anything, so a release
+ * arriving after a legitimate reclaim (owner died mid-hold and its release
+ * closure still ran, e.g. in a finally) cannot remove a successor's lock.
  *
  * Every writer of one file must use the same lock directory, or they hold two
  * mutexes and exclude nothing. `stateLockPath` is that one name rule: the host
@@ -21,7 +33,7 @@ import path from 'node:path';
 export interface FileLockOptions {
   /** How long to keep trying before giving up. */
   timeoutMs?: number;
-  /** A lock older than this is treated as abandoned. */
+  /** An ownerless lock directory older than this is treated as abandoned. */
   staleMs?: number;
   pollMs?: number;
 }
@@ -36,6 +48,7 @@ export function stateLockPath(stateFile: string): string {
 interface LockOwner {
   pid: number;
   acquiredAt: number;
+  token: string;
 }
 
 async function readOwner(lockDir: string): Promise<LockOwner | null> {
@@ -49,8 +62,8 @@ async function readOwner(lockDir: string): Promise<LockOwner | null> {
   }
   if (typeof parsed !== 'object' || parsed === null) return null;
   const owner = parsed as Record<string, unknown>;
-  if (typeof owner.pid !== 'number' || typeof owner.acquiredAt !== 'number') return null;
-  return { pid: owner.pid, acquiredAt: owner.acquiredAt };
+  if (typeof owner.pid !== 'number' || typeof owner.token !== 'string') return null;
+  return { pid: owner.pid, acquiredAt: typeof owner.acquiredAt === 'number' ? owner.acquiredAt : 0, token: owner.token };
 }
 
 /** True when the lock's owning process no longer exists. */
@@ -66,7 +79,8 @@ function ownerIsGone(pid: number): boolean {
   }
 }
 
-async function tryAcquire(lockDir: string): Promise<boolean> {
+/** Returns the ownership token on success, null when the lock is taken. */
+async function tryAcquire(lockDir: string): Promise<string | null> {
   await mkdir(path.dirname(lockDir), { recursive: true });
   const created = await mkdir(lockDir).then(
     () => true,
@@ -75,18 +89,32 @@ async function tryAcquire(lockDir: string): Promise<boolean> {
       throw error;
     },
   );
-  if (!created) return false;
-  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now() };
-  await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify(owner), 'utf8');
-  return true;
+  if (!created) return null;
+  const owner: LockOwner = { pid: process.pid, acquiredAt: Date.now(), token: randomUUID() };
+  try {
+    await writeFile(path.join(lockDir, 'owner.json'), JSON.stringify(owner), 'utf8');
+  } catch (error) {
+    // The directory was reclaimed as ownerless between the mkdir and this
+    // write — the lock is not ours, go back to waiting.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  return owner.token;
 }
 
-async function reclaimIfStale(lockDir: string, staleMs: number): Promise<void> {
+async function reclaimIfAbandoned(lockDir: string, staleMs: number): Promise<void> {
   const owner = await readOwner(lockDir);
-  // A lock directory with no readable owner is either mid-acquisition or
-  // corrupt. Give it the full stale window before assuming the latter.
-  if (!owner) return;
-  if (Date.now() - owner.acquiredAt < staleMs && !ownerIsGone(owner.pid)) return;
+  if (owner) {
+    // An alive owner is never reclaimed; see the module comment.
+    if (!ownerIsGone(owner.pid)) return;
+    await rm(lockDir, { recursive: true, force: true });
+    return;
+  }
+  // No readable owner: mid-acquisition, or a crash before the owner write.
+  // Judge by the directory's age and give it the full stale window.
+  const stats = await stat(lockDir).catch(() => null);
+  if (!stats) return;
+  if (Date.now() - stats.mtimeMs < staleMs) return;
   await rm(lockDir, { recursive: true, force: true });
 }
 
@@ -95,12 +123,17 @@ export async function acquireLock(lockDir: string, options: FileLockOptions = {}
   const deadline = Date.now() + timeoutMs;
 
   for (;;) {
-    if (await tryAcquire(lockDir)) {
+    const token = await tryAcquire(lockDir);
+    if (token !== null) {
       return async () => {
+        // Remove only what is still ours — releasing after a reclaim must
+        // not take a successor's lock with it.
+        const owner = await readOwner(lockDir);
+        if (owner?.token !== token) return;
         await rm(lockDir, { recursive: true, force: true });
       };
     }
-    await reclaimIfStale(lockDir, staleMs);
+    await reclaimIfAbandoned(lockDir, staleMs);
     if (Date.now() >= deadline) {
       throw new Error(`Timed out acquiring lock at ${lockDir} after ${timeoutMs}ms`);
     }

--- a/packages/extension-runtime/src/index.ts
+++ b/packages/extension-runtime/src/index.ts
@@ -8,3 +8,5 @@ export type {
   IsolatedCompletionRequest,
   IsolatedCompletionService,
 } from './isolated-completion';
+export { acquireLock, stateLockPath, withLock, withStateLock } from './file-lock';
+export type { FileLockOptions } from './file-lock';

--- a/packages/extension-runtime/src/state-lock-path.ts
+++ b/packages/extension-runtime/src/state-lock-path.ts
@@ -1,0 +1,12 @@
+/**
+ * The one shared lock-directory name for a state file: `<stateFile>.lock`.
+ *
+ * Every writer of one state file must derive its lock from this rule — the
+ * host's `AppStateManager` and every plugin extension — or they hold two
+ * mutexes and exclude nothing. It lives in its own dependency-free module so
+ * browser bundles that only need the name (a plugin UI building its paths
+ * object) can import it without pulling Node-only code.
+ */
+export function stateLockPath(stateFile: string): string {
+  return `${stateFile}.lock`;
+}

--- a/packages/extension-runtime/tsconfig.json
+++ b/packages/extension-runtime/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "types": ["node"],
     "lib": ["ES2023"]
   },

--- a/packages/templates/skills/sero-plugin/SKILL.md
+++ b/packages/templates/skills/sero-plugin/SKILL.md
@@ -213,7 +213,7 @@ Required:
 - Import UI components from `@sero-ai/ui`
 - Import `./styles.css` from **every** exposed MF entry (main app, widgets, etc.)
 - Tailwind semantic colors (`bg-background`, `text-foreground`, etc.)
-- `ui/styles.css` should import `@sero-ai/ui/styles/plugin.css` and scan plugin-local files with `@source "./**/*.{ts,tsx}"`
+- `ui/styles.css` should import `@sero-ai/ui/styles/plugin.css` and scan plugin-local files with `@source "./**/*.{ts,tsx}"`. The base stylesheet scans only shared primitives and dashboard components; add `styles/ai-elements.css`, `styles/model-selection.css`, or `styles/context-editor.css` when the UI uses those families.
 - UI plugins must set `sero.app.styleIsolation` to `"scope"` and add `seroPluginCssScope({ pluginId: '<app-id>' })` after Tailwind in `vite.config.ts`.
 - Do not alias `@sero-ai/app-runtime`
 - Scope keyboard listeners to the container (`tabIndex={0}`), never `window`

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { Text } from '@earendil-works/pi-tui';
@@ -29,6 +30,20 @@ async function writeState(filePath: string, state: NotesState): Promise<void> {
   const tmp = `${filePath}.tmp.${Date.now()}`;
   await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
   await fs.rename(tmp, filePath);
+}
+
+// Locked read-modify-write. The Sero host writes this file for the UI under
+// the same `<stateFile>.lock` mutex, so a tool call cannot interleave with a
+// panel edit and revert it. Never write the state file without this.
+async function updateState(
+  filePath: string,
+  updater: (state: NotesState) => NotesState,
+): Promise<NotesState> {
+  return withStateLock(filePath, async () => {
+    const next = updater(await readState(filePath));
+    await writeState(filePath, next);
+    return next;
+  });
 }
 
 const Params = Type.Object({
@@ -103,15 +118,19 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const note: Note = {
-            id: state.nextId,
-            title: params.title,
-            done: false,
-            createdAt: new Date().toISOString(),
-          };
-          state.notes.push(note);
-          state.nextId++;
-          await writeState(statePath, state);
+          const title = params.title;
+          let note!: Note;
+          await updateState(statePath, (current) => {
+            note = {
+              id: current.nextId,
+              title,
+              done: false,
+              createdAt: new Date().toISOString(),
+            };
+            current.notes.push(note);
+            current.nextId++;
+            return current;
+          });
           return {
             content: [{ type: 'text', text: `Added #${note.id}: ${note.title}` }],
             details: {},
@@ -125,15 +144,18 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const note = state.notes.find((n) => n.id === params.id);
+          let note: Note | undefined;
+          await updateState(statePath, (current) => {
+            note = current.notes.find((n) => n.id === params.id);
+            if (note) note.done = !note.done;
+            return current;
+          });
           if (!note) {
             return {
               content: [{ type: 'text', text: `Error: no note #${params.id}` }],
               details: {},
             };
           }
-          note.done = !note.done;
-          await writeState(statePath, state);
           return {
             content: [
               { type: 'text', text: `Toggled #${note.id} -> ${note.done ? 'done' : 'open'}` },
@@ -149,15 +171,19 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const before = state.notes.length;
-          state.notes = state.notes.filter((n) => n.id !== params.id);
-          if (state.notes.length === before) {
+          let removed = false;
+          await updateState(statePath, (current) => {
+            const before = current.notes.length;
+            current.notes = current.notes.filter((n) => n.id !== params.id);
+            removed = current.notes.length < before;
+            return current;
+          });
+          if (!removed) {
             return {
               content: [{ type: 'text', text: `Error: no note #${params.id}` }],
               details: {},
             };
           }
-          await writeState(statePath, state);
           return {
             content: [{ type: 'text', text: `Removed #${params.id}` }],
             details: {},
@@ -213,36 +239,40 @@ export default function (pi: ExtensionAPI) {
         if (subcommand === 'add') {
           const title = rest.join(' ').trim();
           if (!title) return { output: 'Error: title is required', exitCode: 1 };
-          state.notes.push({
-            id: state.nextId,
-            title,
-            done: false,
-            createdAt: new Date().toISOString(),
+          let added!: Note;
+          await updateState(filePath, (current) => {
+            added = { id: current.nextId, title, done: false, createdAt: new Date().toISOString() };
+            current.notes.push(added);
+            current.nextId++;
+            return current;
           });
-          state.nextId++;
-          await writeState(filePath, state);
-          return { output: `Added #${state.nextId - 1}: ${title}`, exitCode: 0 };
+          return { output: `Added #${added.id}: ${title}`, exitCode: 0 };
         }
 
         if (subcommand === 'toggle') {
           const id = Number(rest[0]);
           if (!Number.isInteger(id)) return { output: 'Error: id is required', exitCode: 1 };
-          const note = state.notes.find((n) => n.id === id);
+          let note: Note | undefined;
+          await updateState(filePath, (current) => {
+            note = current.notes.find((n) => n.id === id);
+            if (note) note.done = !note.done;
+            return current;
+          });
           if (!note) return { output: `Error: no note #${id}`, exitCode: 1 };
-          note.done = !note.done;
-          await writeState(filePath, state);
           return { output: `Toggled #${id} -> ${note.done ? 'done' : 'open'}`, exitCode: 0 };
         }
 
         if (subcommand === 'remove') {
           const id = Number(rest[0]);
           if (!Number.isInteger(id)) return { output: 'Error: id is required', exitCode: 1 };
-          const before = state.notes.length;
-          state.notes = state.notes.filter((n) => n.id !== id);
-          if (state.notes.length === before) {
-            return { output: `Error: no note #${id}`, exitCode: 1 };
-          }
-          await writeState(filePath, state);
+          let removed = false;
+          await updateState(filePath, (current) => {
+            const before = current.notes.length;
+            current.notes = current.notes.filter((n) => n.id !== id);
+            removed = current.notes.length < before;
+            return current;
+          });
+          if (!removed) return { output: `Error: no note #${id}`, exitCode: 1 };
           return { output: `Removed #${id}`, exitCode: 0 };
         }
 

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -39,7 +39,7 @@
       "category": "productivity",
       "tags": ["notes", "example", "reference"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "requiredHostCapabilities": [
         "appAgent.invokeTool",
         "tool.cli",
@@ -49,6 +49,7 @@
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "^0.2.2",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@sero-ai/extension-runtime": "^0.2.2",
+    "@sero-ai/extension-runtime": "^0.2.4",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
@@ -249,7 +249,7 @@ export function NotesApp() {
                 key={note.id}
                 className="group flex items-center gap-3 px-3 py-2 transition-colors hover:bg-secondary/40"
               >
-                <input aria-label="Checkbox input"
+                <input
                   type="checkbox"
                   checked={note.done}
                   onChange={() => toggleNote(note.id)}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
@@ -249,7 +249,7 @@ export function NotesApp() {
                 key={note.id}
                 className="group flex items-center gap-3 px-3 py-2 transition-colors hover:bg-secondary/40"
               >
-                <input
+                <input aria-label="Checkbox input"
                   type="checkbox"
                   checked={note.done}
                   onChange={() => toggleNote(note.id)}

--- a/packages/templates/skills/sero-plugin/references/api-and-widgets.md
+++ b/packages/templates/skills/sero-plugin/references/api-and-widgets.md
@@ -402,7 +402,7 @@ for a new plugin.
 | `category` | Plugin category (e.g. `"productivity"`) |
 | `tags` | Array of searchable tags |
 | `minSeroVersion` | Minimum compatible Sero version |
-| `runtimeAbi` | Federated-UI ABI the plugin was built against. Required; must match the host (currently `2`). A plugin that omits it, or was built against a different Module Federation version, is refused with a "reinstall to update" message instead of crashing. |
+| `runtimeAbi` | Federated-UI ABI the plugin was built against. Required; must match the host (currently `3`). A plugin that omits it, or was built against a different Module Federation version, is refused with a "reinstall to update" message instead of crashing. |
 | `requiredHostCapabilities` | Explicit host seams the plugin depends on, such as `appAgent.invokeTool` or `tool.cli` |
 | `preBuilt` | Whether plugin ships pre-built |
 | `bundleExtensions` | Build-time hint for built-in release packaging. When `true`, Sero packages compiled JS `pi.extensions` instead of raw extension source. |

--- a/packages/templates/skills/sero-plugin/references/templates.md
+++ b/packages/templates/skills/sero-plugin/references/templates.md
@@ -81,7 +81,7 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
     }
   },
   "dependencies": {
-    "@sero-ai/extension-runtime": "^0.2.2",
+    "@sero-ai/extension-runtime": "^0.2.4",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/packages/templates/skills/sero-plugin/references/templates.md
+++ b/packages/templates/skills/sero-plugin/references/templates.md
@@ -77,10 +77,11 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
       "category": "productivity",
       "tags": ["myapp", "example"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2
+      "runtimeAbi": 3
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "^0.2.2",
     "typebox": "catalog:"
   },
   "peerDependencies": {
@@ -387,6 +388,7 @@ export const DEFAULT_STATE: MyAppState = {
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Text } from '@earendil-works/pi-tui';
@@ -422,6 +424,20 @@ async function writeState(filePath: string, state: MyAppState): Promise<void> {
   const tmpPath = `${filePath}.tmp.${Date.now()}`;
   await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
   await fs.rename(tmpPath, filePath);
+}
+
+// Locked read-modify-write. The Sero host writes this file for the UI under
+// the same `<stateFile>.lock` mutex, so a tool call cannot interleave with a
+// panel edit and revert it. Never write the state file without this.
+async function updateState(
+  filePath: string,
+  updater: (state: MyAppState) => MyAppState,
+): Promise<MyAppState> {
+  return withStateLock(filePath, async () => {
+    const next = updater(await readState(filePath));
+    await writeState(filePath, next);
+    return next;
+  });
 }
 
 // -- Tool parameters --
@@ -477,14 +493,14 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          const item: MyItem = {
-            id: state.nextId,
-            title: params.title,
-            createdAt: new Date().toISOString(),
-          };
-          state.items.push(item);
-          state.nextId++;
-          await writeState(statePath, state);
+          const title = params.title;
+          let item!: MyItem;
+          await updateState(statePath, (current) => {
+            item = { id: current.nextId, title, createdAt: new Date().toISOString() };
+            current.items.push(item);
+            current.nextId++;
+            return current;
+          });
           return {
             content: [{ type: 'text', text: `Added #${item.id}: ${item.title}` }],
             details: {},
@@ -498,8 +514,10 @@ export default function (pi: ExtensionAPI) {
               details: {},
             };
           }
-          state.items = state.items.filter((i) => i.id !== params.id);
-          await writeState(statePath, state);
+          await updateState(statePath, (current) => ({
+            ...current,
+            items: current.items.filter((i) => i.id !== params.id),
+          }));
           return {
             content: [{ type: 'text', text: `Removed #${params.id}` }],
             details: {},

--- a/plugins/sero-admin-plugin/package.json
+++ b/plugins/sero-admin-plugin/package.json
@@ -41,7 +41,7 @@
         "prompts"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false
     }
   },

--- a/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
@@ -92,6 +92,13 @@ const readStateMock = vi.fn(async (filePath: string) =>
 const writeStateMock = vi.fn(async (filePath: string, state: CronState) => {
   stateStore.set(filePath, cloneState(state));
 });
+let stateLockQueue: Promise<unknown> = Promise.resolve();
+
+function withStateLockMock<T>(_statePath: string, fn: () => Promise<T>): Promise<T> {
+  const run = stateLockQueue.then(fn, fn);
+  stateLockQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
 
 vi.mock('../scheduler', () => ({
   CronScheduler: MockCronScheduler,
@@ -99,7 +106,7 @@ vi.mock('../scheduler', () => ({
 
 vi.mock('../state-io', () => ({
   resolveStatePath: (cwd: string) => statePathFor(cwd),
-  withStateLock: async <T>(_statePath: string, fn: () => Promise<T>) => fn(),
+  withStateLock: withStateLockMock,
   readState: (filePath: string) => readStateMock(filePath),
   writeState: (filePath: string, state: CronState) => writeStateMock(filePath, state),
 }));
@@ -161,6 +168,7 @@ beforeEach(() => {
   stateStore.clear();
   readStateMock.mockClear();
   writeStateMock.mockClear();
+  stateLockQueue = Promise.resolve();
   delete process.env.SERO_HOME;
   delete process.env.SERO_CRON_SUBPROCESS;
 });
@@ -253,5 +261,31 @@ describe('cron extension lifecycle', () => {
 
     expect(notify).toHaveBeenCalledTimes(2);
     expect(notify.mock.calls.every(([message]) => message === '✓ Scheduler stopped')).toBe(true);
+  }, LIFECYCLE_TEST_TIMEOUT_MS);
+
+  it('starts only one scheduler when start commands overlap', async () => {
+    const cwd = '/workspace-a';
+    const notify = vi.fn();
+    stateStore.set(statePathFor(cwd), defaultState({ jobs: [makeJob()] }));
+
+    const registerExtension = await loadExtension();
+    const { pi, handlers, commands } = createFakePi();
+    registerExtension(pi as never);
+    await handlers.session_start({}, { cwd });
+
+    await Promise.all([
+      commands.get('cron')?.handler('on', { cwd, ui: { notify } }),
+      commands.get('cron')?.handler('on', { cwd, ui: { notify } }),
+    ]);
+
+    expect(schedulerInstances).toHaveLength(1);
+    expect(schedulerInstances[0].isRunning()).toBe(true);
+    expect(notify.mock.calls.map(([message]) => message)).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^✓ Scheduler started/),
+      'Scheduler is already running.',
+    ]));
+
+    await commands.get('cron')?.handler('off', { cwd, ui: { notify } });
+    expect(schedulerInstances[0].isRunning()).toBe(false);
   }, LIFECYCLE_TEST_TIMEOUT_MS);
 });

--- a/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
@@ -231,4 +231,27 @@ describe('cron extension lifecycle', () => {
     expect(schedulerInstances[1].start.mock.calls[0]?.[3]).toBeUndefined();
     expect(stateStore.get(statePathB)?.lastTickMinute).toBe('');
   }, LIFECYCLE_TEST_TIMEOUT_MS);
+
+  it('stops one scheduler safely when stop commands overlap', async () => {
+    const cwd = '/workspace-a';
+    const notify = vi.fn();
+    stateStore.set(statePathFor(cwd), defaultState({ jobs: [makeJob()] }));
+
+    const registerExtension = await loadExtension();
+    const { pi, handlers, commands } = createFakePi();
+    registerExtension(pi as never);
+
+    await handlers.session_start({}, { cwd });
+    await commands.get('cron')?.handler('on', { cwd, ui: { notify } });
+    expect(schedulerInstances).toHaveLength(1);
+
+    notify.mockClear();
+    await Promise.all([
+      commands.get('cron')?.handler('off', { cwd, ui: { notify } }),
+      commands.get('cron')?.handler('off', { cwd, ui: { notify } }),
+    ]);
+
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notify.mock.calls.every(([message]) => message === '✓ Scheduler stopped')).toBe(true);
+  }, LIFECYCLE_TEST_TIMEOUT_MS);
 });

--- a/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/index-lifecycle.test.ts
@@ -99,7 +99,7 @@ vi.mock('../scheduler', () => ({
 
 vi.mock('../state-io', () => ({
   resolveStatePath: (cwd: string) => statePathFor(cwd),
-  withStateLock: async <T>(fn: () => Promise<T>) => fn(),
+  withStateLock: async <T>(_statePath: string, fn: () => Promise<T>) => fn(),
   readState: (filePath: string) => readStateMock(filePath),
   writeState: (filePath: string, state: CronState) => writeStateMock(filePath, state),
 }));

--- a/plugins/sero-cron-plugin/extension/__tests__/state-io.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/state-io.test.ts
@@ -47,16 +47,19 @@ describe('resolveStatePath', () => {
 
 describe('withStateLock', () => {
   it('serialises concurrent operations', async () => {
+    const lockTarget = path.join(os.tmpdir(), `cron-lock-${process.pid}-${Date.now()}`);
     const order: number[] = [];
 
-    const op1 = withStateLock(async () => {
+    const op1 = withStateLock(lockTarget, async () => {
       order.push(1);
       await new Promise((r) => setTimeout(r, 50));
       order.push(2);
       return 'first';
     });
+    // Let op1 take the cross-process lock before op2 tries.
+    await new Promise((r) => setTimeout(r, 20));
 
-    const op2 = withStateLock(async () => {
+    const op2 = withStateLock(lockTarget, async () => {
       order.push(3);
       return 'second';
     });
@@ -69,13 +72,14 @@ describe('withStateLock', () => {
   });
 
   it('releases lock even if operation throws', async () => {
-    const failOp = withStateLock(async () => {
+    const lockTarget = path.join(os.tmpdir(), `cron-lock-throw-${process.pid}-${Date.now()}`);
+    const failOp = withStateLock(lockTarget, async () => {
       throw new Error('boom');
     });
     await expect(failOp).rejects.toThrow('boom');
 
     // Next operation should still proceed
-    const result = await withStateLock(async () => 'ok');
+    const result = await withStateLock(lockTarget, async () => 'ok');
     expect(result).toBe('ok');
   });
 });

--- a/plugins/sero-cron-plugin/extension/runtime-helpers.ts
+++ b/plugins/sero-cron-plugin/extension/runtime-helpers.ts
@@ -1,5 +1,8 @@
-import type { NotificationSettings } from '../shared/types';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
+import type { CronState, NotificationSettings } from '../shared/types';
+import type { ActionParams } from './actions';
+import type { ReminderParams } from './reminder-actions';
 import { readState } from './state-io';
 
 export function formatRuntimeError(error: unknown): string {
@@ -31,4 +34,46 @@ export async function readNotificationSettingsOrWarn(
     });
     return undefined;
   }
+}
+
+export interface CronCommandContext {
+  cwd?: string;
+  ui?: {
+    notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+  };
+}
+
+export interface CronToolContext {
+  cwd: string;
+}
+
+export interface ToolTextResult {
+  content: [{ type: 'text'; text: string }];
+  details: Record<string, never>;
+}
+
+export interface CronRuntime {
+  attachPi: (pi: ExtensionAPI) => void;
+  handleSessionStart: (pi: ExtensionAPI, ctx: { cwd: string }) => Promise<void>;
+  handleSessionSwitch: (ctx: { cwd: string }) => void;
+  handleSessionShutdown: () => Promise<void>;
+  handleCronCommand: (args?: string, ctx?: CronCommandContext) => Promise<void>;
+  executeCronTool: (params: ActionParams, ctx?: CronToolContext) => Promise<ToolTextResult>;
+  executeReminderTool: (
+    params: ReminderParams,
+    ctx?: CronToolContext,
+  ) => Promise<ToolTextResult>;
+}
+
+export function textToolResult(text: string): ToolTextResult {
+  return {
+    content: [{ type: 'text', text }],
+    details: {},
+  };
+}
+
+export function getSchedulerStartOpts(
+  state: CronState,
+): { lastTickMinute?: string } | undefined {
+  return state.lastTickMinute ? { lastTickMinute: state.lastTickMinute } : undefined;
 }

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -217,7 +217,8 @@ export function createCronRuntime(): CronRuntime {
   }
 
   async function stopScheduler(): Promise<string> {
-    if (!scheduler?.isRunning()) {
+    const activeScheduler = scheduler;
+    if (!activeScheduler?.isRunning()) {
       warn('scheduler:stop-skipped', { reason: 'not running' });
       return 'Scheduler is not running.';
     }
@@ -226,11 +227,11 @@ export function createCronRuntime(): CronRuntime {
     stateWatcher = null;
     await withStateLock(statePath, async () => {
       const state = await readState(statePath);
-      state.lastTickMinute = scheduler!.getLastTickMinute();
+      state.lastTickMinute = activeScheduler.getLastTickMinute();
       state.lastSchedulerShutdown = new Date().toISOString();
       state.schedulerActive = false;
-      scheduler!.stop();
-      scheduler = null;
+      activeScheduler.stop();
+      if (scheduler === activeScheduler) scheduler = null;
       await writeState(statePath, state);
     });
     return '✓ Scheduler stopped';
@@ -395,12 +396,13 @@ export function createCronRuntime(): CronRuntime {
 
     stateWatcher?.stop();
     stateWatcher = null;
-    if (scheduler?.isRunning()) {
+    const activeScheduler = scheduler;
+    if (activeScheduler?.isRunning()) {
       if (statePath) {
         try {
           await withStateLock(statePath, async () => {
             const state = await readState(statePath);
-            state.lastTickMinute = scheduler!.getLastTickMinute();
+            state.lastTickMinute = activeScheduler.getLastTickMinute();
             state.lastSchedulerShutdown = new Date().toISOString();
             await writeState(statePath, state);
           });
@@ -411,8 +413,8 @@ export function createCronRuntime(): CronRuntime {
           });
         }
       }
-      scheduler.stop();
-      scheduler = null;
+      activeScheduler.stop();
+      if (scheduler === activeScheduler) scheduler = null;
     }
     initialized = false;
   }

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -30,56 +30,17 @@ import {
   handleReminderToggle,
   handleReminderUpdate,
 } from './reminder-actions';
+import type { CronCommandContext, CronRuntime, CronToolContext, ToolTextResult } from './runtime-helpers';
 import {
   formatRuntimeError,
+  getSchedulerStartOpts,
   readNotificationSettingsOrWarn,
+  textToolResult,
   toolError,
 } from './runtime-helpers';
 import { CronScheduler } from './scheduler';
 import { resolveStatePath, withStateLock, readState, writeState } from './state-io';
 import { StateWatcher } from './state-watcher';
-
-export interface CronCommandContext {
-  cwd?: string;
-  ui?: {
-    notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
-  };
-}
-
-export interface CronToolContext {
-  cwd: string;
-}
-
-export interface ToolTextResult {
-  content: [{ type: 'text'; text: string }];
-  details: Record<string, never>;
-}
-
-export interface CronRuntime {
-  attachPi: (pi: ExtensionAPI) => void;
-  handleSessionStart: (pi: ExtensionAPI, ctx: { cwd: string }) => Promise<void>;
-  handleSessionSwitch: (ctx: { cwd: string }) => void;
-  handleSessionShutdown: () => Promise<void>;
-  handleCronCommand: (args?: string, ctx?: CronCommandContext) => Promise<void>;
-  executeCronTool: (params: ActionParams, ctx?: CronToolContext) => Promise<ToolTextResult>;
-  executeReminderTool: (
-    params: ReminderParams,
-    ctx?: CronToolContext,
-  ) => Promise<ToolTextResult>;
-}
-
-function textToolResult(text: string): ToolTextResult {
-  return {
-    content: [{ type: 'text', text }],
-    details: {},
-  };
-}
-
-function getSchedulerStartOpts(
-  state: CronState,
-): { lastTickMinute?: string } | undefined {
-  return state.lastTickMinute ? { lastTickMinute: state.lastTickMinute } : undefined;
-}
 
 export function createCronRuntime(): CronRuntime {
   let statePath = '';

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -111,7 +111,7 @@ export function createCronRuntime(): CronRuntime {
 
   async function appendRunResult(result: CronRunResult): Promise<void> {
     if (!statePath) return;
-    await withStateLock(async () => {
+    await withStateLock(statePath, async () => {
       const state = await readState(statePath);
       state.lastRunResults.unshift(result);
       if (state.lastRunResults.length > MAX_RUN_RESULTS) {
@@ -124,7 +124,7 @@ export function createCronRuntime(): CronRuntime {
 
   async function persistReminderUpdate(updated: Reminder): Promise<void> {
     if (!statePath) return;
-    await withStateLock(async () => {
+    await withStateLock(statePath, async () => {
       const state = await readState(statePath);
       const index = state.reminders.findIndex((entry) => entry.id === updated.id);
       if (index >= 0) {
@@ -278,7 +278,7 @@ export function createCronRuntime(): CronRuntime {
       const resolvedPath = ctx?.cwd ? resolveStatePath(ctx.cwd) : statePath;
       if (!resolvedPath) return toolError('no state path');
 
-      const result = await withStateLock(async () => {
+      const result = await withStateLock(resolvedPath, async () => {
         const state = await readState(resolvedPath);
         const deps: ActionDeps = {
           state,
@@ -324,7 +324,7 @@ export function createCronRuntime(): CronRuntime {
       const resolvedPath = ctx?.cwd ? resolveStatePath(ctx.cwd) : statePath;
       if (!resolvedPath) return toolError('no state path');
 
-      const result = await withStateLock(async () => {
+      const result = await withStateLock(resolvedPath, async () => {
         const state = await readState(resolvedPath);
         const deps: ReminderActionDeps = {
           state,

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -199,11 +199,16 @@ export function createCronRuntime(): CronRuntime {
     }
 
     const state = await withStateLock(statePath, async () => {
+      if (scheduler?.isRunning()) return null;
       const started = createAndStartScheduler(await readState(statePath));
       started.schedulerActive = true;
       await writeState(statePath, started);
       return started;
     });
+    if (!state) {
+      warn('scheduler:start-skipped', { reason: 'already running' });
+      return 'Scheduler is already running.';
+    }
     startStateWatcher();
 
     const activeReminders = state.reminders.filter(

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -202,27 +202,29 @@ export function createCronRuntime(): CronRuntime {
       return;
     }
 
-    const initialState = await readState(statePath);
-    const hasWork =
-      initialState.jobs.length > 0 || (initialState.reminders?.length ?? 0) > 0;
+    await withStateLock(statePath, async () => {
+      const initialState = await readState(statePath);
+      const hasWork =
+        initialState.jobs.length > 0 || (initialState.reminders?.length ?? 0) > 0;
 
-    if (initialState.autostart && hasWork) {
-      info('scheduler:autostart', {
-        jobs: initialState.jobs.length,
-        reminders: initialState.reminders.length,
-      });
-      const state = createAndStartScheduler(initialState);
-      state.schedulerActive = true;
-      await writeState(statePath, state);
-      startStateWatcher();
-      return;
-    }
+      if (initialState.autostart && hasWork) {
+        info('scheduler:autostart', {
+          jobs: initialState.jobs.length,
+          reminders: initialState.reminders.length,
+        });
+        const state = createAndStartScheduler(initialState);
+        state.schedulerActive = true;
+        await writeState(statePath, state);
+        startStateWatcher();
+        return;
+      }
 
-    if (initialState.schedulerActive) {
-      info('scheduler:reset-stale-flag');
-      initialState.schedulerActive = false;
-      await writeState(statePath, initialState);
-    }
+      if (initialState.schedulerActive) {
+        info('scheduler:reset-stale-flag');
+        initialState.schedulerActive = false;
+        await writeState(statePath, initialState);
+      }
+    });
   }
 
   async function startScheduler(): Promise<string> {
@@ -235,10 +237,12 @@ export function createCronRuntime(): CronRuntime {
       return 'Error: no state path resolved.';
     }
 
-    const initialState = await readState(statePath);
-    const state = createAndStartScheduler(initialState);
-    state.schedulerActive = true;
-    await writeState(statePath, state);
+    const state = await withStateLock(statePath, async () => {
+      const started = createAndStartScheduler(await readState(statePath));
+      started.schedulerActive = true;
+      await writeState(statePath, started);
+      return started;
+    });
     startStateWatcher();
 
     const activeReminders = state.reminders.filter(
@@ -259,13 +263,15 @@ export function createCronRuntime(): CronRuntime {
 
     stateWatcher?.stop();
     stateWatcher = null;
-    const state = await readState(statePath);
-    state.lastTickMinute = scheduler.getLastTickMinute();
-    state.lastSchedulerShutdown = new Date().toISOString();
-    state.schedulerActive = false;
-    scheduler.stop();
-    scheduler = null;
-    await writeState(statePath, state);
+    await withStateLock(statePath, async () => {
+      const state = await readState(statePath);
+      state.lastTickMinute = scheduler!.getLastTickMinute();
+      state.lastSchedulerShutdown = new Date().toISOString();
+      state.schedulerActive = false;
+      scheduler!.stop();
+      scheduler = null;
+      await writeState(statePath, state);
+    });
     return '✓ Scheduler stopped';
   }
 
@@ -431,10 +437,12 @@ export function createCronRuntime(): CronRuntime {
     if (scheduler?.isRunning()) {
       if (statePath) {
         try {
-          const state = await readState(statePath);
-          state.lastTickMinute = scheduler.getLastTickMinute();
-          state.lastSchedulerShutdown = new Date().toISOString();
-          await writeState(statePath, state);
+          await withStateLock(statePath, async () => {
+            const state = await readState(statePath);
+            state.lastTickMinute = scheduler!.getLastTickMinute();
+            state.lastSchedulerShutdown = new Date().toISOString();
+            await writeState(statePath, state);
+          });
         } catch (error) {
           warn('scheduler:shutdown-state-write-skipped', {
             path: statePath,

--- a/plugins/sero-cron-plugin/extension/state-io.ts
+++ b/plugins/sero-cron-plugin/extension/state-io.ts
@@ -7,6 +7,7 @@
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { withStateLock as withSharedStateLock } from '@sero-ai/extension-runtime';
 import type { CronState } from '../shared/types';
 import { DEFAULT_CRON_STATE } from '../shared/types';
 
@@ -22,13 +23,14 @@ export function resolveStatePath(cwd: string): string {
 
 // ── Mutex ──────────────────────────────────────────────────────
 
-let stateMutexQueue: Promise<void> = Promise.resolve();
-
-export function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
-  const prev = stateMutexQueue;
-  let resolve: () => void;
-  stateMutexQueue = new Promise<void>((r) => { resolve = r; });
-  return prev.then(fn).finally(() => resolve!());
+/**
+ * Cross-process lock on `<statePath>.lock`, shared with the Sero host's
+ * AppStateManager. An in-process queue is not enough: the UI writes this file
+ * through the host in another process, and an unshared mutex excludes
+ * nothing (#428). Also serialises writers inside this process.
+ */
+export function withStateLock<T>(statePath: string, fn: () => Promise<T>): Promise<T> {
+  return withSharedStateLock(statePath, fn);
 }
 
 // ── Read / Write ───────────────────────────────────────────────

--- a/plugins/sero-cron-plugin/extension/tools.ts
+++ b/plugins/sero-cron-plugin/extension/tools.ts
@@ -4,7 +4,7 @@ import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { ActionParams } from './actions';
-import type { CronRuntime } from './runtime';
+import type { CronRuntime } from './runtime-helpers';
 import type { ReminderParams } from './reminder-actions';
 
 const CronParams = Type.Object({

--- a/plugins/sero-cron-plugin/package.json
+++ b/plugins/sero-cron-plugin/package.json
@@ -59,7 +59,7 @@
         "jobs"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false
     }
   },

--- a/plugins/sero-cron-plugin/ui/lib/use-watched-json.ts
+++ b/plugins/sero-cron-plugin/ui/lib/use-watched-json.ts
@@ -24,7 +24,7 @@ export function useWatchedJson<T>(filePath: string | null, fallback: T): T {
       if (!active || changedPath !== filePath) return;
       setData(value == null ? fallbackRef.current : value);
     });
-    void api.watch<T | null>(filePath).then((current) => {
+    void api.watch<T | null>(filePath).then(({ data: current }) => {
       if (active) setData(current == null ? fallbackRef.current : current);
     });
 

--- a/plugins/sero-design-library-plugin/package.json
+++ b/plugins/sero-design-library-plugin/package.json
@@ -42,7 +42,7 @@
         "generation"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false,
       "requiredHostCapabilities": [
         "appAgent.invokeTool",
@@ -61,6 +61,7 @@
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "workspace:*",
     "@fal-ai/client": "^1.10.1",
     "@fontsource-variable/geist": "^5.3.0",
     "@fontsource-variable/ibm-plex-sans": "^5.3.0",

--- a/plugins/sero-design-library-plugin/runtime/full-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/full-repair.ts
@@ -49,11 +49,16 @@ export async function runRequestedFullRepair(
   const attempted = { ...request, attempts: request.attempts + 1 };
   await writeJsonFile(paths.repairRequestFile, attempted);
   try {
-    const unreadable = (await Promise.all([
+    // allSettled: a fast failure must not leave the other scans running in
+    // the background while the failure handling below rewrites the request.
+    const scans = await Promise.allSettled([
       reindex(paths, false),
       reindexGallery(paths, false),
       reindexExports(paths, false),
-    ])).flat();
+    ]);
+    const failed = scans.find((scan) => scan.status === 'rejected');
+    if (failed) throw failed.reason;
+    const unreadable = scans.flatMap((scan) => (scan as PromiseFulfilledResult<string[]>).value);
     await bumpControlRevision(paths);
     await rm(paths.repairRequestFile, { force: true });
     return unreadable;

--- a/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
@@ -179,8 +179,12 @@ describe('generating a variant', () => {
       expect(await readFile(path.join(directory, 'index.html'), 'utf8')).toBe(STUB_PAGE);
     }
 
-    const summary = (await readStateWithIndexes(harness.paths)).designs.find((entry) => entry.id === designId);
-    expect(summary?.variants.every((variant) => variant.previewPath !== undefined)).toBe(true);
+    await vi.waitFor(async () => {
+      const summary = (await readStateWithIndexes(harness.paths)).designs.find(
+        (entry) => entry.id === designId,
+      );
+      expect(summary?.variants.every((variant) => variant.previewPath !== undefined)).toBe(true);
+    }, FAST_POLL);
   });
 
   it('gives the run no platform tools and keeps imported reference pixels out', async () => {

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -1,6 +1,5 @@
 import os from 'node:os';
 import path from 'node:path';
-import { stateLockPath } from '@sero-ai/extension-runtime';
 
 import { isSafeId } from './safe-id';
 export { isSafeId } from './safe-id';
@@ -60,8 +59,11 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     stateFile: path.join(home, 'state.json'),
     // The host's AppStateManager locks `<stateFile>.lock` around every state
     // mutation; this runtime's own updateState must hold the SAME mutex, or
-    // the two writers exclude nothing (#428).
-    lockDir: stateLockPath(path.join(home, 'state.json')),
+    // the two writers exclude nothing (#428). The name rule is inlined —
+    // importing `stateLockPath` here would pull the Node-only
+    // extension-runtime package into the browser UI bundle; state-io.test.ts
+    // pins this string to the real helper.
+    lockDir: `${path.join(home, 'state.json')}.lock`,
     recordLocksDir: path.join(home, '.record-locks'),
     indexRepairsDir: path.join(home, '.index-repairs'),
     repairRequestFile: path.join(home, '.repair-indexes.json'),

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
+import { stateLockPath } from '@sero-ai/extension-runtime';
 
 import { isSafeId } from './safe-id';
 export { isSafeId } from './safe-id';
@@ -57,7 +58,10 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
   return {
     home,
     stateFile: path.join(home, 'state.json'),
-    lockDir: path.join(home, '.state.lock'),
+    // The host's AppStateManager locks `<stateFile>.lock` around every state
+    // mutation; this runtime's own updateState must hold the SAME mutex, or
+    // the two writers exclude nothing (#428).
+    lockDir: stateLockPath(path.join(home, 'state.json')),
     recordLocksDir: path.join(home, '.record-locks'),
     indexRepairsDir: path.join(home, '.index-repairs'),
     repairRequestFile: path.join(home, '.repair-indexes.json'),

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -1,5 +1,8 @@
 import os from 'node:os';
 import path from 'node:path';
+// The dependency-free subpath: the full package pulls Node-only code that
+// cannot enter the browser UI bundle this file is part of.
+import { stateLockPath } from '@sero-ai/extension-runtime/state-lock-path';
 
 import { isSafeId } from './safe-id';
 export { isSafeId } from './safe-id';
@@ -59,11 +62,8 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     stateFile: path.join(home, 'state.json'),
     // The host's AppStateManager locks `<stateFile>.lock` around every state
     // mutation; this runtime's own updateState must hold the SAME mutex, or
-    // the two writers exclude nothing (#428). The name rule is inlined —
-    // importing `stateLockPath` here would pull the Node-only
-    // extension-runtime package into the browser UI bundle; state-io.test.ts
-    // pins this string to the real helper.
-    lockDir: `${path.join(home, 'state.json')}.lock`,
+    // the two writers exclude nothing (#428).
+    lockDir: stateLockPath(path.join(home, 'state.json')),
     recordLocksDir: path.join(home, '.record-locks'),
     indexRepairsDir: path.join(home, '.index-repairs'),
     repairRequestFile: path.join(home, '.repair-indexes.json'),

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { withLock } from './file-lock';
+import { withLock } from '@sero-ai/extension-runtime';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from './paths';
 import {
   StaleStateError,

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { withLock } from '@sero-ai/extension-runtime';
+import { stateLockPath, withLock } from '@sero-ai/extension-runtime';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from './paths';
 import {
   StaleStateError,
@@ -134,6 +134,13 @@ describe('requests', () => {
 });
 
 describe('withLock', () => {
+  // paths.ts inlines the `<stateFile>.lock` name (the UI bundle cannot import
+  // the Node-only extension-runtime package); this pins it to the one rule
+  // the host and every extension share.
+  it('locks the same directory as the shared stateLockPath rule', () => {
+    expect(paths.lockDir).toBe(stateLockPath(paths.stateFile));
+  });
+
   it('excludes a second holder until the first releases', async () => {
     const order: string[] = [];
     const first = withLock(paths.lockDir, async () => {

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { stateLockPath, withLock } from '@sero-ai/extension-runtime';
+import { withLock } from '@sero-ai/extension-runtime';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from './paths';
 import {
   StaleStateError,
@@ -134,13 +134,6 @@ describe('requests', () => {
 });
 
 describe('withLock', () => {
-  // paths.ts inlines the `<stateFile>.lock` name (the UI bundle cannot import
-  // the Node-only extension-runtime package); this pins it to the one rule
-  // the host and every extension share.
-  it('locks the same directory as the shared stateLockPath rule', () => {
-    expect(paths.lockDir).toBe(stateLockPath(paths.stateFile));
-  });
-
   it('excludes a second holder until the first releases', async () => {
     const order: string[] = [];
     const first = withLock(paths.lockDir, async () => {

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -156,7 +156,7 @@ describe('withLock', () => {
     // pid 1 exists but is not us; use an implausible pid that is certainly free.
     await writeFile(
       path.join(paths.lockDir, 'owner.json'),
-      JSON.stringify({ pid: 0x7ffffff, acquiredAt: Date.now() }),
+      JSON.stringify({ pid: 0x7ffffff, acquiredAt: Date.now(), token: 'gone' }),
       'utf8',
     );
     await expect(withLock(paths.lockDir, async () => 'ran', { timeoutMs: 2000 })).resolves.toBe('ran');

--- a/plugins/sero-design-library-plugin/shared/state-io.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { withLock, type FileLockOptions } from './file-lock';
+import { withLock, type FileLockOptions } from '@sero-ai/extension-runtime';
 import {
   normalizeDesignIndex,
   normalizeExportIndex,

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
@@ -9,7 +9,7 @@ const bridge = vi.hoisted(() => {
   const listeners = new Set<(filePath: string, value: unknown) => void>();
   return {
     listeners,
-    watch: vi.fn<(filePath: string) => Promise<unknown>>(),
+    watch: vi.fn<(filePath: string) => Promise<{ data: unknown; etag: string }>>(),
     unwatch: vi.fn<(filePath: string) => Promise<void>>(),
     onChange: vi.fn((listener: (filePath: string, value: unknown) => void) => {
       listeners.add(listener);
@@ -47,7 +47,7 @@ function Probe({ relativePath = 'items/index.json' }: { relativePath?: string })
 
 beforeEach(() => {
   bridge.listeners.clear();
-  bridge.watch.mockReset().mockResolvedValue([{ id: 'initial' }]);
+  bridge.watch.mockReset().mockResolvedValue({ data: [{ id: 'initial' }], etag: 'initial-etag' });
   bridge.unwatch.mockReset().mockResolvedValue(undefined);
   bridge.onChange.mockClear();
 });
@@ -69,7 +69,7 @@ describe('useJsonIndex', () => {
   });
 
   it('keeps a newer change event when the initial watch finishes later', async () => {
-    let resolveWatch: (value: unknown) => void = () => undefined;
+    let resolveWatch: (value: { data: unknown; etag: string }) => void = () => undefined;
     bridge.watch.mockReturnValue(new Promise((resolve) => { resolveWatch = resolve; }));
     render(<AppContext.Provider value={context}><Probe /></AppContext.Provider>);
 
@@ -80,7 +80,7 @@ describe('useJsonIndex', () => {
     });
     expect(screen.getByTestId('ids').textContent).toBe('newer');
 
-    await act(async () => resolveWatch([{ id: 'stale-initial' }]));
+    await act(async () => resolveWatch({ data: [{ id: 'stale-initial' }], etag: 'stale-etag' }));
     expect(screen.getByTestId('ids').textContent).toBe('newer');
   });
 

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
@@ -27,8 +27,8 @@ export function useJsonIndex<T>(
         setEntries(normalize(value));
       }
     });
-    void api.watch<unknown>(filePath).then((value) => {
-      if (active && !changedWhileWatching) setEntries(normalize(value));
+    void api.watch<unknown>(filePath).then(({ data }) => {
+      if (active && !changedWhileWatching) setEntries(normalize(data));
     });
     return () => {
       active = false;

--- a/plugins/sero-git-plugin/package.json
+++ b/plugins/sero-git-plugin/package.json
@@ -73,7 +73,7 @@
         "diff"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false
     }
   },

--- a/plugins/sero-git-plugin/ui/store/sero-bridge.ts
+++ b/plugins/sero-git-plugin/ui/store/sero-bridge.ts
@@ -143,9 +143,10 @@ export interface SeroGitHubBridge {
 }
 
 export interface SeroAppStateBridge {
-  watch<T = unknown>(filePath: string): Promise<T>;
+  /** Resolves the current content plus its etag (host protocol since ABI 3). */
+  watch<T = unknown>(filePath: string): Promise<{ data: T; etag: string | null }>;
   unwatch(filePath: string): Promise<void>;
-  onChange<T = unknown>(cb: (filePath: string, data: T) => void): () => void;
+  onChange<T = unknown>(cb: (filePath: string, data: T, etag: string | null) => void): () => void;
 }
 
 interface SeroGitWindow {

--- a/plugins/sero-git-plugin/ui/store/vcs-store.ts
+++ b/plugins/sero-git-plugin/ui/store/vcs-store.ts
@@ -179,7 +179,7 @@ export const useVcsStore = create<VcsStore>((set, get) => ({
     } else {
       gitStateSubs.set(wsId, { filePath, refCount: 1 });
       wsIdByFilePath.set(filePath, wsId);
-      void appState.watch(filePath).then((data: unknown) => {
+      void appState.watch(filePath).then(({ data }) => {
         if (data !== undefined && data !== null) applyGitAppState(set, get, wsId, data);
       });
     }

--- a/plugins/sero-graphify-plugin/package.json
+++ b/plugins/sero-graphify-plugin/package.json
@@ -57,12 +57,13 @@
       "category": "developer-tools",
       "tags": ["knowledge-graph", "search", "context", "graphify"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false,
       "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli", "appRuntime.background"]
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "workspace:*",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/plugins/sero-graphify-plugin/shared/state-io.test.ts
+++ b/plugins/sero-graphify-plugin/shared/state-io.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { readStateFile, appendIndexRequest, appendIndexRequests, writeStateFile, writeIfUnchanged } from './state-io';
+import { withStateLock } from '@sero-ai/extension-runtime';
+import { readStateFile, appendIndexRequest, appendIndexRequests, writeStateFile } from './state-io';
 import { DEFAULT_STATE, withStateDefaults, type GraphifyState } from './types';
 
 describe('state-io', () => {
@@ -66,34 +67,34 @@ describe('withStateDefaults', () => {
 });
 
 describe('appendIndexRequests concurrency', () => {
-  it('refuses to write over content that changed since it was read', async () => {
-    // The extension and the runtime write this file from different processes
-    // with no shared lock. Without the check, an append would revert whatever
-    // the runtime wrote in between, including the applied request watermark.
-    const dir = await mkdtemp(path.join(os.tmpdir(), 'graphify-race-'));
-    const stateFile = path.join(dir, 'state.json');
-    const stale = JSON.stringify(structuredClone(DEFAULT_STATE), null, 2);
-
-    const runtimeWrote = {
-      ...structuredClone(DEFAULT_STATE),
-      provisioning: { status: 'ready' as const, updatedAt: '2026-08-20' },
-    };
-    await writeStateFile(stateFile, runtimeWrote);
-
-    const wrote = await writeIfUnchanged(stateFile, stale, structuredClone(DEFAULT_STATE));
-    expect(wrote).toBe(false);
-    expect((await readStateFile(stateFile))?.provisioning.updatedAt).toBe('2026-08-20');
-  });
-
-  it('writes when the content is untouched', async () => {
+  it('appends under the shared state lock, after a concurrent holder releases', async () => {
+    // The extension and the runtime write this file from different processes.
+    // Both must take the `<stateFile>.lock` mutex (the runtime gets it via the
+    // host's AppStateManager), so an append cannot interleave with a write in
+    // progress and revert it — including the applied request watermark.
     const dir = await mkdtemp(path.join(os.tmpdir(), 'graphify-race-'));
     const stateFile = path.join(dir, 'state.json');
     await writeStateFile(stateFile, structuredClone(DEFAULT_STATE));
-    const current = await readFile(stateFile, 'utf8');
 
-    const wrote = await writeIfUnchanged(stateFile, current, { ...structuredClone(DEFAULT_STATE), nextRequestId: 9 });
-    expect(wrote).toBe(true);
-    expect((await readStateFile(stateFile))?.nextRequestId).toBe(9);
+    let ids: number[] | null = null;
+    await withStateLock(stateFile, async () => {
+      // "The runtime" holds the lock and writes; the append must wait.
+      const append = appendIndexRequests(stateFile, [{ action: 'sync' }]).then((queued) => { ids = queued; });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(ids).toBeNull();
+      await writeStateFile(stateFile, {
+        ...structuredClone(DEFAULT_STATE),
+        provisioning: { status: 'ready' as const, updatedAt: '2026-08-20' },
+      });
+      void append;
+    });
+
+    // Lock released — the append lands on top of the runtime's write.
+    await expect.poll(() => ids).not.toBeNull();
+    const state = await readStateFile(stateFile);
+    expect(state?.provisioning.updatedAt).toBe('2026-08-20');
+    expect(state?.requests).toHaveLength(1);
+    expect(state?.nextRequestId).toBe((DEFAULT_STATE.nextRequestId ?? 1) + 1);
   });
 
   it('refuses to overwrite a state file it cannot parse', async () => {

--- a/plugins/sero-graphify-plugin/shared/state-io.ts
+++ b/plugins/sero-graphify-plugin/shared/state-io.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { withStateLock } from '@sero-ai/extension-runtime';
 import { withStateDefaults, type GraphifyState, type IndexAction, type IndexRequest, type SettingsPatch } from './types';
 
 /** Distinguishes "no state yet" from "state exists but could not be read". */
@@ -52,53 +53,24 @@ export async function appendSettingsRequest(stateFile: string, settings: Setting
   return (await appendIndexRequests(stateFile, [{ action: 'settings', settings }]))[0];
 }
 
-/** How many times to retry when the runtime wrote the file mid-append. */
-const MAX_APPEND_ATTEMPTS = 8;
-
-/**
- * Write `next` only if the file still holds exactly `expected`.
- *
- * Returns false when it changed, so the caller can re-read and rebuild its
- * update on top of the newer content instead of reverting it.
- *
- * This narrows the window; it is not a lock. The runtime writes this file from
- * the main process through its own serialised queue and takes nothing this
- * process holds, so a write landing between the check and the rename is still
- * possible in principle — the gap is now a single rename rather than a read,
- * parse and rebuild. Closing it completely needs one shared write path for both
- * processes.
- */
-export async function writeIfUnchanged(
-  stateFile: string,
-  expected: string | null,
-  next: GraphifyState,
-): Promise<boolean> {
-  if ((await readRaw(stateFile)) !== expected) return false;
-  await writeStateFile(stateFile, next);
-  return true;
-}
-
 /**
  * Append related requests in one state write so the runtime observes them
  * together.
  *
  * This runs in the extension process, while the runtime writes the same file
- * through the host's serialised queue — the two share no lock. A plain
- * read-modify-write would therefore revert everything the runtime wrote since
- * this read, such as a `lastBuiltAt` or the applied-request watermark. Builds
- * write progress every 750ms, so that window is hit routinely.
- *
- * Instead the file is re-read and compared byte-for-byte immediately before the
- * write, and the whole append is retried when it changed. Writes are atomic
- * renames, so a match means nothing landed in between.
+ * from the main process — builds write progress every 750ms, so a plain
+ * read-modify-write would routinely revert what the runtime wrote since the
+ * read (a `lastBuiltAt`, the applied-request watermark). The read and the
+ * write therefore happen under the cross-process lock the host's
+ * AppStateManager takes for every mutation of this file.
  */
 export async function appendIndexRequests(
   stateFile: string,
   requests: Array<Omit<IndexRequest, 'id' | 'requestedAt'>>,
 ): Promise<number[]> {
-  for (let attempt = 0; attempt < MAX_APPEND_ATTEMPTS; attempt += 1) {
-    const before = await readRaw(stateFile);
-    const current = before === null ? withStateDefaults(null) : parseOrThrow(before, stateFile);
+  return withStateLock(stateFile, async () => {
+    const raw = await readRaw(stateFile);
+    const current = raw === null ? withStateDefaults(null) : parseOrThrow(raw, stateFile);
     const requestedAt = new Date().toISOString();
     const queued = requests.map((request, index) => ({
       id: current.nextRequestId + index,
@@ -110,9 +82,7 @@ export async function appendIndexRequests(
       nextRequestId: current.nextRequestId + queued.length,
       requests: [...current.requests, ...queued],
     };
-
-    if (!(await writeIfUnchanged(stateFile, before, next))) continue;
+    await writeStateFile(stateFile, next);
     return queued.map((request) => request.id);
-  }
-  throw new Error('Graphify state is being written too often to queue this request. Try again in a moment.');
+  });
 }

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -41,7 +41,7 @@
         "resources"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "requiredHostCapabilities": [
         "appAgent.invokeTool",
         "tool.cli"

--- a/plugins/sero-orchestrator-plugin/package.json
+++ b/plugins/sero-orchestrator-plugin/package.json
@@ -54,7 +54,7 @@
       "category": "developer-tools",
       "tags": ["orchestration", "loops", "automation"],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false,
       "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli", "appRuntime.background"]
     }

--- a/plugins/sero-orchestrator-plugin/ui/__tests__/orchestrator-navigation-hook.test.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/__tests__/orchestrator-navigation-hook.test.tsx
@@ -27,12 +27,12 @@ describe('useOrchestratorNavigation', () => {
   });
 
   it('writes navigation and layout changes after reading a null state file', async () => {
-    const write = vi.fn(async () => undefined);
+    const write = vi.fn(async () => ({ ok: true as const, etag: 'e1' }));
     Reflect.set(window, 'sero', {
       appState: {
         read: vi.fn(async () => null),
         write,
-        watch: vi.fn(async () => null),
+        watch: vi.fn(async () => ({ data: null, etag: null })),
         unwatch: vi.fn(async () => undefined),
         onChange: vi.fn(() => () => undefined),
       },
@@ -84,7 +84,7 @@ describe('useOrchestratorNavigation', () => {
     expect(write).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenLastCalledWith('/workspace/state.json', expect.objectContaining({
       ui: expect.objectContaining({ navigationViewId: 'rooms/room-1' }),
-    }));
+    }), null);
 
     await act(async () => resize?.());
     expect(write).toHaveBeenCalledTimes(2);
@@ -93,6 +93,6 @@ describe('useOrchestratorNavigation', () => {
         navigationViewId: 'rooms/room-1',
         roomPanelLayouts: { roster: { 'room-1': 35 } },
       }),
-    }));
+    }), 'e1');
   });
 });

--- a/plugins/sero-orchestrator-plugin/ui/__tests__/skill-draft-control.test.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/__tests__/skill-draft-control.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@sero-ai/app-runtime', () => ({
   getSeroApi: () => ({
     appState: {
       onChange: () => () => {},
-      watch: async () => ({ body: '# From the artifact\n' }),
+      watch: async () => ({ data: { body: '# From the artifact\n' }, etag: 'e1' }),
       unwatch: async () => {},
     },
   }),

--- a/plugins/sero-orchestrator-plugin/ui/lib/use-room-members.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/use-room-members.ts
@@ -44,7 +44,7 @@ export function useRoomMembers(roomId: string | null, memberIds: string[]): Map<
       remember(memberId, value);
     });
     for (const [path, memberId] of byPath) {
-      void api.watch<RoomMember | null>(path).then((current) => {
+      void api.watch<RoomMember | null>(path).then(({ data: current }) => {
         if (active && current) remember(memberId, current);
       });
     }

--- a/plugins/sero-orchestrator-plugin/ui/lib/use-watched-json.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/use-watched-json.ts
@@ -25,7 +25,7 @@ export function useWatchedJson<T>(filePath: string | null, fallback: T): T {
       if (!active || changedPath !== filePath) return;
       setData(value == null ? fallbackRef.current : value);
     });
-    void api.watch<T | null>(filePath).then((current) => {
+    void api.watch<T | null>(filePath).then(({ data: current }) => {
       if (active) setData(current == null ? fallbackRef.current : current);
     });
 

--- a/plugins/sero-usage-plugin/extension/refresh.ts
+++ b/plugins/sero-usage-plugin/extension/refresh.ts
@@ -12,7 +12,7 @@ import type { UsageState } from '../shared/types';
 import { aggregate } from './aggregate';
 import { collectSessionFiles } from './scan';
 import { loadScanCache, saveScanCache, scanWithCache } from './scan-cache';
-import { readState, resolveScanCachePath, resolveSessionsDir, resolveStatePath, writeJsonFile } from './state-io';
+import { readState, resolveScanCachePath, resolveSessionsDir, resolveStatePath, updateState } from './state-io';
 
 /** Non-forced refreshes within this window are treated as already fresh. */
 const FRESH_WINDOW_MS = 60_000;
@@ -68,10 +68,9 @@ async function doRefresh(force: boolean): Promise<RefreshSummary> {
   const { periods, daily, hourly } = aggregate(scan.sessions);
   const durationMs = Date.now() - startedAt;
 
-  // Re-read settings just before writing so a mid-scan settings change
+  // Settings are re-read inside the lock, so a mid-scan settings change
   // from the UI is not clobbered.
-  const currentState = await readState(statePath);
-  const state: UsageState = {
+  const state = await updateState(statePath, (currentState) => ({
     schemaVersion: 1,
     settings: currentState.settings,
     lastRefreshedAt: Date.now(),
@@ -79,8 +78,7 @@ async function doRefresh(force: boolean): Promise<RefreshSummary> {
     periods,
     daily,
     hourly,
-  };
-  await writeJsonFile(statePath, state);
+  }));
 
   return { files: scan.files, reused: scan.reused, durationMs, state, skipped: false };
 }

--- a/plugins/sero-usage-plugin/extension/state-io.ts
+++ b/plugins/sero-usage-plugin/extension/state-io.ts
@@ -9,6 +9,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { withStateLock } from '@sero-ai/extension-runtime';
+
 import type { UsageState } from '../shared/types';
 import { normalizeUsageState } from '../shared/types';
 
@@ -68,4 +70,21 @@ export async function writeJsonFile(filePath: string, value: unknown): Promise<v
   } finally {
     if (writeQueues.get(filePath) === next) writeQueues.delete(filePath);
   }
+}
+
+/**
+ * Locked read-modify-write for state.json. The UI writes this file through the
+ * host's AppStateManager, which takes the same `<stateFile>.lock` mutex, so a
+ * settings change from the panel cannot interleave with a refresh writing its
+ * scan results (#428).
+ */
+export async function updateState(
+  filePath: string,
+  updater: (current: UsageState) => UsageState,
+): Promise<UsageState> {
+  return withStateLock(filePath, async () => {
+    const next = updater(await readState(filePath));
+    await writeJsonFile(filePath, next);
+    return next;
+  });
 }

--- a/plugins/sero-usage-plugin/extension/tools.ts
+++ b/plugins/sero-usage-plugin/extension/tools.ts
@@ -12,7 +12,7 @@ import { formatCost, formatCount, formatRelativeTime, formatTokens } from '../sh
 import type { PeriodKey, UsageState } from '../shared/types';
 import { PERIOD_LABELS, REFRESH_INTERVAL_OPTIONS } from '../shared/types';
 import { runRefresh, summarizeRefresh } from './refresh';
-import { readState, resolveStatePath, writeJsonFile } from './state-io';
+import { readState, resolveStatePath, updateState } from './state-io';
 
 const ACTIONS = ['refresh', 'summary', 'sessions', 'config'] as const;
 const PERIODS = ['today', 'thisWeek', 'lastWeek', 'allTime'] as const;
@@ -105,8 +105,7 @@ async function actionConfig(refreshIntervalMinutes?: number): Promise<string> {
   if (!(REFRESH_INTERVAL_OPTIONS as readonly number[]).includes(refreshIntervalMinutes)) {
     return `Error: refreshIntervalMinutes must be one of ${REFRESH_INTERVAL_OPTIONS.join(', ')} (0 = manual).`;
   }
-  const next: UsageState = { ...state, settings: { refreshIntervalMinutes } };
-  await writeJsonFile(statePath, next);
+  await updateState(statePath, (current) => ({ ...current, settings: { refreshIntervalMinutes } }));
   return `Auto-refresh interval set to ${describeInterval(refreshIntervalMinutes)}.`;
 }
 

--- a/plugins/sero-usage-plugin/package.json
+++ b/plugins/sero-usage-plugin/package.json
@@ -51,7 +51,7 @@
         "analytics"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "requiredHostCapabilities": [
         "appAgent.invokeTool",
         "tool.cli"
@@ -62,6 +62,7 @@
     }
   },
   "dependencies": {
+    "@sero-ai/extension-runtime": "workspace:*",
     "typebox": "catalog:"
   },
   "peerDependencies": {

--- a/plugins/sero-user-feedback-plugin/package.json
+++ b/plugins/sero-user-feedback-plugin/package.json
@@ -36,7 +36,7 @@
         "feedback"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false,
       "bridgeTools": false
     }

--- a/plugins/sero-web-plugin/package.json
+++ b/plugins/sero-web-plugin/package.json
@@ -60,7 +60,7 @@
         "github"
       ],
       "minSeroVersion": "0.1.0",
-      "runtimeAbi": 2,
+      "runtimeAbi": 3,
       "preBuilt": false
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       streamdown:
         specifier: 'catalog:'
         version: 2.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@7.2.0)
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,9 @@ importers:
       '@fontsource/ibm-plex-mono':
         specifier: ^5.3.0
         version: 5.3.0
+      '@sero-ai/extension-runtime':
+        specifier: workspace:*
+        version: link:../../packages/extension-runtime
       '@tailwindcss/browser':
         specifier: 'catalog:'
         version: 4.3.3
@@ -1080,6 +1083,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: catalog:peer
         version: 0.84.2
+      '@sero-ai/extension-runtime':
+        specifier: workspace:*
+        version: link:../../packages/extension-runtime
       typebox:
         specifier: 'catalog:'
         version: 1.3.14
@@ -1348,6 +1354,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: catalog:peer
         version: 0.84.2
+      '@sero-ai/extension-runtime':
+        specifier: workspace:*
+        version: link:../../packages/extension-runtime
       typebox:
         specifier: 'catalog:'
         version: 1.3.14

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,11 @@
       ],
       "outputs": ["dist/**"]
     },
+    "@sero/web-remote#build": {
+      "outputs": [
+        "$TURBO_ROOT$/apps/desktop/electron/features/gateway/web-dist/**"
+      ]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Implements #428. Closes #428 when the release ships.

## What this does

A plugin's `state.json` has three writers: the runtime (main process), the extension (Pi agent process), and the UI (renderer). They shared no concurrency control, so interleaved read-modify-write cycles silently erased each other's writes. This PR gives each writer the guard #428 assigned to it.

### Host

- `AppStateManager` takes a cross-process `mkdir` lock (`<stateFile>.lock`) around `write`, `update` and `remove`. Timeout 10 s, then the caller sees the fault.
- Every `readWithEtag`, `watch` result and change event carries a content etag (hash of the raw file text; `null` = absent). `write(path, data, expectedEtag?)` rejects a stale etag and returns the current content instead of clobbering it. Writes without an etag stay unconditional — for whole-file owners (CLI, git-app manager).
- `SERO_PLUGIN_RUNTIME_ABI` 2 → 3. A bundle built on the blind-write protocol is marked incompatible with a reinstall prompt instead of silently losing user changes.

### Packages (need republish — see rollout)

- `@sero-ai/extension-runtime` **0.2.0**: the file-lock helper moves here from sero-design-library-plugin, with the one name rule `stateLockPath(stateFile)` = `<stateFile>.lock` and `withStateLock(stateFile, fn)`.
- `@sero-ai/app-runtime` **0.4.1**: `useAppState` echoes the etag on write and, when rejected, re-applies its updater on top of the newer content (bounded, 5 rounds, then it surfaces the error and re-reads disk). Updaters must be pure functions of `prev`.

### In-repo plugins

- **graphify**: the byte-compare CAS loop in `shared/state-io.ts` becomes one locked append; the "being written too often" error is gone.
- **design-library**: `paths.lockDir` moves from `<home>/.state.lock` to the shared name, and the local `file-lock.ts` copy is deleted in favour of the package import. Its runtime keeps its own locked `updateState`.
- **usage**: the extension's `state.json` writes go through a locked `updateState`; the scan cache stays unlocked (extension-only file).
- **cron** (found during implementation — #428 wrongly listed it as UI-only): its extension wrote `state.json` behind an in-process mutex named `withStateLock`. That mutex now delegates to the shared cross-process lock, keyed per state path.
- All in-repo plugin `runtimeAbi` fields move to 3. Built-in UI writers (admin, orchestrator, user-feedback, cron) get the etag behaviour through the workspace `app-runtime`.

### Tests

- First cross-process writer tests in this repo. A child process appends via `withStateLock` while the parent writes through the real `AppStateManager`; a start barrier makes the interleaving real (verified: the unlocked version of the same interleaving loses up to 49 of 50 appends and crashes on torn reads).
- Etag protocol: accept/reject/absent-file cases on `AppStateManager`; `writeStateWithRebase` unit tests (re-apply on rejection, bounded give-up, already-satisfied short-circuit).
- Lock unit tests: exclusion, dead-owner reclaim, stale-window reclaim, timeout, release-on-throw.

## Rollout (issue sequencing)

1. Land this branch.
2. Publish `@sero-ai/extension-runtime@0.2.0` and `@sero-ai/app-runtime@0.4.1` (with **pnpm publish**, not npm).
3. External repo sweep: every external plugin with a federated UI moves to `app-runtime ^0.4.1` + `runtimeAbi: 3`; extensions that write their state file adopt `withStateLock`; `sero-signal-desk-plugin` threads the etag by hand in its class component. Prepared locally on `feat/app-state-etag-abi3` branches in each repo; they need the publish, then install + build + reinstall.
4. Cut the desktop release with the ABI bump last — nobody runs a host that marks their plugins broken.

## Known risks (from #428)

- The module-federation pin: each external plugin needs a build and a load check, not just a version bump.
- Re-applying an updater assumes it is pure; the sweep checked for closures over stale state.
- The lock adds a new failure mode: a wedged holder makes writes throw after 10 s (stale reclaim at 30 s).

## Status after review round 1

- All five blocking findings from the [routed review](https://github.com/sero-labs/sero/pull/430#issuecomment-5388825252) are fixed in 394e0cc33 — lock reclaim/release semantics (alive owners are never evicted; release checks an ownership token; ownerless directories reclaim by directory age), cron lifecycle writes locked, Git UI on the etag watch shape, ABI 3 + locked-pattern authoring in the template/example/docs. Details in the [response comment](https://github.com/sero-labs/sero/pull/430#issuecomment-5388925403).
- Published: `@sero-ai/app-runtime@0.4.1`, `@sero-ai/extension-runtime@0.2.1` (peer floor >=0.83.0 so plugin `npm install` works against pi 0.83). **Pending publish: `@sero-ai/extension-runtime@0.2.2`** with the corrected lock semantics; external lockfiles move off 0.2.1 right after.
- External sweep is DONE and pushed: 16 plugin repos on main with `runtimeAbi: 3`, `app-runtime ^0.4.1`, locked extension writes, refreshed lockfiles — each verified with install + typecheck + build (+ tests where present) against the published packages. `sero-logbook-plugin` is merged locally only (it has no git remote). During the sweep, `@sero-ai/common` had to move to 0.11.0 across the estate (app-runtime 0.4.x needs its types), and this branch raises app-runtime's common peer floor accordingly.


## Status after review round 2

- Both blocking findings from the updated review are fixed in c97bd0d64. Details in the [response comment](https://github.com/sero-labs/sero/pull/430).
- **Lock protocol rewrite**: acquisition now stages a fully-populated lock directory and publishes it with one atomic rename, so an ownerless lock can never exist mid-acquire (removes the mkdir→owner-write gap). Reclaim renames the lock to a unique grave (atomic, single winner) and verifies the grave before deleting; a live holder moved by a stale observation is restored, never removed. Acquirers withdraw while a live grave exists; release also recovers a lock moved aside mid-steal. A new multi-process stress test (crashed holders + many concurrent reclaimers) fails 3/5 rounds on the previous protocol and passes 10/10 rounds at 20 workers × 10 sections on this one.
- **Active skill copies**: `.agents/skills/sero-plugin/` (tracked) and `.claude/skills/sero-plugin/` (untracked, synced on disk) now mirror the updated template — ABI 3 and locked `updateState`. The two improvements that existed only in `.agents` were ported back into the template first. `plugin-end-to-end-example.md` and the external plugin docs pages now say ABI 3.
- Non-blocking note addressed: cron `runtime.ts` is back under the 500-line limit (types moved to `runtime-helpers.ts`).
- The rewrite is folded into the still-unpublished `@sero-ai/extension-runtime@0.2.2`.
