### PR TITLE
fix(desktop): detect safeStorage backends that do not protect data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ apps/desktop/.sero-test-data/
 # Local agent scratch data
 .superpowers/
 .pi/
+.specs/
 
 apps/desktop/release/
 apps/desktop/sero-desktop-*.tgz

--- a/apps/desktop/electron/__tests__/features/auth/github/auth-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/auth/github/auth-manager.test.ts
@@ -87,6 +87,32 @@ describe('GitHubAuthManager', () => {
     expect(existsSync(tokenFile)).toBe(true);
   });
 
+  it('retries a cached token after secure storage becomes available', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-retry-'));
+
+    const encrypted = Buffer.from('enc:token-123').toString('base64');
+    const agentDir = path.join(tmpDir, 'agent');
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, 'github-auth.json'),
+      JSON.stringify({ encrypted, username: 'octocat', scopes: 'repo', createdAt: '2026-01-01T00:00:00.000Z' }),
+      'utf8',
+    );
+
+    const storage = { available: false };
+    const { GitHubAuthManager } = await importManager(storage);
+    const manager = new GitHubAuthManager() as InstanceType<typeof GitHubAuthManager> & {
+      reloadStoredToken: () => void;
+    };
+    expect(manager.getToken()).toBeNull();
+
+    storage.available = true;
+    manager.reloadStoredToken();
+
+    expect(manager.getToken()).toBe('token-123');
+    expect(manager.getStatus()).toEqual({ authenticated: true, username: 'octocat' });
+  });
+
   it('clears a corrupt cached token file on startup', async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-corrupt-'));
 

--- a/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
+++ b/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
@@ -15,6 +15,8 @@ async function loadWith(options: {
   platform: NodeJS.Platform;
   available: boolean;
   backend?: string | (() => string);
+  /** Omit to leave the opt-in API absent, as on older Electron builds. */
+  setPlainText?: (use: boolean) => void;
 }) {
   vi.resetModules();
   setPlatform(options.platform);
@@ -22,6 +24,9 @@ async function loadWith(options: {
   const safeStorage: Record<string, unknown> = {
     isEncryptionAvailable: () => options.available,
   };
+  if (options.setPlainText !== undefined) {
+    safeStorage.setUsePlainTextEncryption = options.setPlainText;
+  }
   if (options.backend !== undefined) {
     safeStorage.getSelectedStorageBackend = typeof options.backend === 'function'
       ? options.backend
@@ -121,5 +126,52 @@ describe('describeStorageRemedy', () => {
 
     const win = await loadWith({ platform: 'win32', available: true });
     expect(win.describeStorageRemedy()).toBeNull();
+  });
+});
+
+describe('enablePlainTextFallback', () => {
+  it('accepts the weak backend when Linux cannot encrypt at all', async () => {
+    const setPlainText = vi.fn();
+    const mod = await loadWith({
+      platform: 'linux', available: false, backend: 'basic_text', setPlainText,
+    });
+
+    expect(mod.enablePlainTextFallback()).toBe(true);
+    expect(setPlainText).toHaveBeenCalledWith(true);
+  });
+
+  it('never downgrades a working keyring', async () => {
+    const setPlainText = vi.fn();
+    const mod = await loadWith({
+      platform: 'linux', available: true, backend: 'gnome_libsecret', setPlainText,
+    });
+
+    expect(mod.enablePlainTextFallback()).toBe(false);
+    expect(setPlainText).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on macOS or Windows', async () => {
+    const setPlainText = vi.fn();
+    const mac = await loadWith({ platform: 'darwin', available: false, setPlainText });
+    expect(mac.enablePlainTextFallback()).toBe(false);
+
+    const win = await loadWith({ platform: 'win32', available: false, setPlainText });
+    expect(win.enablePlainTextFallback()).toBe(false);
+    expect(setPlainText).not.toHaveBeenCalled();
+  });
+
+  it('reports failure when the opt-in API is absent', async () => {
+    const mod = await loadWith({ platform: 'linux', available: false, backend: 'basic_text' });
+    expect(mod.enablePlainTextFallback()).toBe(false);
+  });
+
+  it('reports failure when the opt-in throws, rather than crashing startup', async () => {
+    const mod = await loadWith({
+      platform: 'linux',
+      available: false,
+      backend: 'basic_text',
+      setPlainText: () => { throw new Error('nope'); },
+    });
+    expect(mod.enablePlainTextFallback()).toBe(false);
   });
 });

--- a/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
+++ b/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
@@ -103,3 +103,23 @@ describe('describeStorageWeakness', () => {
     expect(mod.describeStorageWeakness()).toContain('unavailable');
   });
 });
+
+describe('describeStorageRemedy', () => {
+  it('names the Linux fix when the backend is weak', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'basic_text' });
+    expect(mod.describeStorageRemedy()).toContain('gnome-keyring');
+  });
+
+  it('offers nothing when protection is already real', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'kwallet6' });
+    expect(mod.describeStorageRemedy()).toBeNull();
+  });
+
+  it('offers nothing on macOS or Windows, where there is nothing to install', async () => {
+    const mac = await loadWith({ platform: 'darwin', available: true });
+    expect(mac.describeStorageRemedy()).toBeNull();
+
+    const win = await loadWith({ platform: 'win32', available: true });
+    expect(win.describeStorageRemedy()).toBeNull();
+  });
+});

--- a/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
+++ b/apps/desktop/electron/__tests__/shared/lib/safe-storage-backend.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * These cover a security check, so the cases that matter most are the ones
+ * where `isEncryptionAvailable()` returns true and the data is still exposed.
+ */
+
+const ORIGINAL_PLATFORM = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+async function loadWith(options: {
+  platform: NodeJS.Platform;
+  available: boolean;
+  backend?: string | (() => string);
+}) {
+  vi.resetModules();
+  setPlatform(options.platform);
+
+  const safeStorage: Record<string, unknown> = {
+    isEncryptionAvailable: () => options.available,
+  };
+  if (options.backend !== undefined) {
+    safeStorage.getSelectedStorageBackend = typeof options.backend === 'function'
+      ? options.backend
+      : () => options.backend as string;
+  }
+
+  vi.doMock('electron', () => ({ safeStorage }));
+  return import('@electron/shared/lib/safe-storage-backend');
+}
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM);
+  vi.doUnmock('electron');
+  vi.resetModules();
+});
+
+describe('isUnprotectedBackend', () => {
+  it('flags the Linux basic_text backend', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'basic_text' });
+    expect(mod.isUnprotectedBackend()).toBe(true);
+  });
+
+  it('accepts a real Linux keyring', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'gnome_libsecret' });
+    expect(mod.isUnprotectedBackend()).toBe(false);
+  });
+
+  it('never flags macOS or Windows, where the backend getter is absent', async () => {
+    const mac = await loadWith({ platform: 'darwin', available: true });
+    expect(mac.isUnprotectedBackend()).toBe(false);
+
+    const win = await loadWith({ platform: 'win32', available: true });
+    expect(win.isUnprotectedBackend()).toBe(false);
+  });
+
+  it('treats a throwing backend getter as protected, so a working keyring is never broken', async () => {
+    const mod = await loadWith({
+      platform: 'linux',
+      available: true,
+      backend: () => { throw new Error('not implemented'); },
+    });
+    expect(mod.isUnprotectedBackend()).toBe(false);
+  });
+});
+
+describe('hasRealEncryption', () => {
+  it('is false under basic_text even though isEncryptionAvailable() is true', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'basic_text' });
+    // The whole point of the check: Electron says yes, we say no.
+    expect(mod.hasRealEncryption()).toBe(false);
+  });
+
+  it('is true with a real keyring', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'kwallet6' });
+    expect(mod.hasRealEncryption()).toBe(true);
+  });
+
+  it('is false when encryption is unavailable outright', async () => {
+    const mod = await loadWith({ platform: 'linux', available: false, backend: 'basic_text' });
+    expect(mod.hasRealEncryption()).toBe(false);
+  });
+});
+
+describe('describeStorageWeakness', () => {
+  it('returns null when protection is real', async () => {
+    const mod = await loadWith({ platform: 'darwin', available: true });
+    expect(mod.describeStorageWeakness()).toBeNull();
+  });
+
+  it('explains the constant key rather than claiming base64', async () => {
+    const mod = await loadWith({ platform: 'linux', available: true, backend: 'basic_text' });
+    const reason = mod.describeStorageWeakness();
+    expect(reason).toContain('constant');
+    expect(reason).not.toContain('base64');
+  });
+
+  it('reports the unavailable case separately', async () => {
+    const mod = await loadWith({ platform: 'linux', available: false });
+    expect(mod.describeStorageWeakness()).toContain('unavailable');
+  });
+});

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -80,6 +80,7 @@ import {
 } from './shared/infra/shared-infra';
 import { startGateway, stopGateway } from './ipc/gateway/gateway';
 import { setupContentSecurityPolicy } from './platform/security/csp';
+import { enablePlainTextFallback } from './shared/lib/safe-storage-backend';
 import { setupMainWindowSecurity } from './platform/security/window-security';
 import { browserViewManager } from './features/browser/view-manager';
 import { discoverBuiltinPackagePaths, discoverBuiltinPluginPaths } from './platform/protocols/builtin-resources';
@@ -282,6 +283,11 @@ app.whenReady().then(async () => {
     app.exit(0);
     return;
   }
+
+  // Linux with no keyring cannot encrypt at all, which blocks every credential
+  // write. Accept the weak backend so sign-in works, and let the storage warning
+  // surfaces tell the user their credentials are not protected.
+  enablePlainTextFallback();
 
   // Bootstrap Sero's agent directory (creates settings.json on first run)
   bootstrapAgentDir();

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -1,8 +1,5 @@
-// Heavy app entry. Reachable only via dynamic import from `main.ts` once
-// the doctor short-circuit has been ruled out, so safe mode never triggers
-// any of the static-import side effects below (in particular, the top-level
-// `resolveStartupEnv()` inside `./platform/env`, which reads profiles.json
-// and may run profile migration / repair logic).
+// Loaded dynamically after the doctor short-circuit, so safe mode does not
+// trigger static side effects such as profile migration and repair.
 
 // Load .env BEFORE any SDK imports (they read process.env at module level)
 import {
@@ -19,23 +16,12 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import path from 'path';
 import type { SettingsPackageSource } from '../src/types/ipc';
 
-// electron-builder's `productName: Sero` only names the packaged macOS app
-// bundle. In dev mode (`electron .`), the process name — and so the macOS
-// menu bar app name — falls back to package.json's `name` field
-// (`@sero/desktop`), which Electron then mangles to "Electron". Setting it
-// explicitly here fixes the menu bar in both dev and packaged builds, and
-// must run before `app.whenReady()`.
+// Keep the macOS menu bar name correct in development and packaged builds.
 app.setName('Sero');
 
 // ── Per-profile Chromium userData isolation ──────────────────
-// Set userData path BEFORE app.whenReady() so Chromium initialises with the
-// correct directory. This isolates cookies, localStorage, caches, and
-// session data between profiles.
-//
-// userData always lives under SERO_HOME so it tracks the active profile.
-// When there is no active profile yet (fresh install / pre-onboarding) there
-// is no legacy data worth preserving, so migration is intentionally skipped
-// and Chromium simply starts fresh in the SERO_HOME location.
+// Set userData before app.whenReady() to isolate Chromium data by profile.
+// A fresh install has no legacy profile data to migrate.
 const profileUserData = profileUserDataPath(SERO_HOME);
 if (ACTIVE_PROFILE_ID) {
   const defaultUserDataPath = app.getPath('userData');
@@ -73,6 +59,7 @@ import {
   ensureInfra,
   fileWatcherManager,
   gatewayServer,
+  githubAuth,
   lspManager,
   pluginDevSessionManager,
   runtimeManager,
@@ -284,10 +271,9 @@ app.whenReady().then(async () => {
     return;
   }
 
-  // Linux with no keyring cannot encrypt at all, which blocks every credential
-  // write. Accept the weak backend so sign-in works, and let the storage warning
-  // surfaces tell the user their credentials are not protected.
+  // Accept the weak Linux backend, then retry reads that ran before app ready.
   enablePlainTextFallback();
+  githubAuth.reloadStoredToken();
 
   // Bootstrap Sero's agent directory (creates settings.json on first run)
   bootstrapAgentDir();

--- a/apps/desktop/electron/features/auth/github/auth-manager.ts
+++ b/apps/desktop/electron/features/auth/github/auth-manager.ts
@@ -120,6 +120,12 @@ export class GitHubAuthManager {
   private cachedUsername: string | null = null;
 
   constructor() {
+    this.reloadStoredToken();
+  }
+
+  /** Retry loading a token after Electron's storage backend becomes ready. */
+  reloadStoredToken(): void {
+    if (this.cachedToken) return;
     this.loadCachedToken();
   }
 

--- a/apps/desktop/electron/features/auth/github/auth-manager.ts
+++ b/apps/desktop/electron/features/auth/github/auth-manager.ts
@@ -16,6 +16,7 @@ import { safeStorage, shell } from 'electron';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
 import path from 'path';
 import { SERO_AGENT_DIR, SERO_HOME } from '@electron/platform/env';
+import { describeStorageWeakness } from '@electron/shared/lib/safe-storage-backend';
 
 // ── GitHub OAuth App ─────────────────────────────────────────
 // Client ID for "Sero Desktop" GitHub OAuth App (public, no secret needed for device flow).
@@ -33,11 +34,33 @@ const TOKEN_FILE = path.join(SERO_AGENT_DIR, 'github-auth.json');
 const LEGACY_TOKEN_FILE = path.join(SERO_HOME, 'github-auth.json');
 const POLL_INTERVAL_MIN_MS = 5_000;
 
+let weakStorageWarned = false;
+
+/**
+ * Whether the GitHub token can be encrypted at all.
+ *
+ * Deliberately still gated on `isEncryptionAvailable()` rather than on
+ * `hasRealEncryption()`. Under the Linux `basic_text` backend the token is
+ * encrypted with a published constant key, which is weak — but tightening this
+ * gate would make `storeToken()` throw and break GitHub auth outright on every
+ * keyring-less Linux machine. That trade-off is a product decision, tracked in
+ * the safeStorage issue; until it is made, warn loudly and keep working.
+ */
 function canUseSafeStorage(): boolean {
-  return typeof safeStorage?.isEncryptionAvailable === 'function'
+  const usable = typeof safeStorage?.isEncryptionAvailable === 'function'
     && typeof safeStorage?.encryptString === 'function'
     && typeof safeStorage?.decryptString === 'function'
     && safeStorage.isEncryptionAvailable();
+
+  if (usable && !weakStorageWarned) {
+    const reason = describeStorageWeakness();
+    if (reason) {
+      weakStorageWarned = true;
+      console.warn(`[github-auth] WARNING: the stored GitHub token is not protected. ${reason}`);
+    }
+  }
+
+  return usable;
 }
 
 function getExistingTokenFile(): string | null {

--- a/apps/desktop/electron/ipc/platform/auth/safe-storage.ts
+++ b/apps/desktop/electron/ipc/platform/auth/safe-storage.ts
@@ -10,33 +10,37 @@
  * Used by Sero apps (e.g. Starling Bank) to securely store API tokens.
  *
  * Security note: the reported capability is deliberately stricter than the
- * mechanism used. `available` reports false whenever storage does not really
- * protect the data — including the Linux `basic_text` backend, where Chromium
- * encrypts with a published constant key. Encrypt and decrypt still call
- * safeStorage whenever Electron can, so blobs written before this check keep
- * round-tripping. See shared/lib/safe-storage-backend.ts.
+ * mechanism used. `available` and `status` report insecure whenever storage
+ * does not really protect the data — including the Linux `basic_text` backend,
+ * where Chromium encrypts with a published constant key. Encrypt and decrypt
+ * still call safeStorage whenever Electron can, so blobs written before this
+ * check keep round-tripping. See shared/lib/safe-storage-backend.ts.
  */
 
 import { ipcMain, safeStorage } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
-import { describeStorageWeakness, hasRealEncryption } from '@electron/shared/lib/safe-storage-backend';
-import { broadcastToWindows } from '../../lib/window-broadcast';
+import type { SafeStorageStatus } from '@/types/ipc';
+import {
+  describeStorageRemedy,
+  describeStorageWeakness,
+  hasRealEncryption,
+} from '@electron/shared/lib/safe-storage-backend';
 
 let weakStorageWarned = false;
 
-/** Log and broadcast a warning when storage does not really protect credentials. */
+/** Log once when storage does not really protect credentials. */
 function warnWeakStorage(): void {
   const reason = describeStorageWeakness();
   if (!reason || weakStorageWarned) return;
   weakStorageWarned = true;
-
   console.warn(`[security] WARNING: credentials are not stored securely. ${reason}`);
+}
 
-  // Notify all renderer windows so the UI can show a persistent warning
-  broadcastToWindows('sero:security-warning', {
-    type: 'encryption-unavailable',
-    message: `Credentials are not stored securely. ${reason}`,
-  });
+/** Current protection state, for the renderer to surface to the user. */
+export function getSafeStorageStatus(): SafeStorageStatus {
+  const reason = describeStorageWeakness();
+  if (!reason) return { secure: true, reason: null, remedy: null };
+  return { secure: false, reason, remedy: describeStorageRemedy() };
 }
 
 export function registerSafeStorageHandlers(): void {
@@ -44,6 +48,11 @@ export function registerSafeStorageHandlers(): void {
     const available = hasRealEncryption();
     if (!available) warnWeakStorage();
     return available;
+  });
+
+  ipcMain.handle(IpcChannels.safeStorage.status, (): SafeStorageStatus => {
+    warnWeakStorage();
+    return getSafeStorageStatus();
   });
 
   ipcMain.handle(

--- a/apps/desktop/electron/ipc/platform/auth/safe-storage.ts
+++ b/apps/desktop/electron/ipc/platform/auth/safe-storage.ts
@@ -9,50 +9,53 @@
  *
  * Used by Sero apps (e.g. Starling Bank) to securely store API tokens.
  *
- * Security note: when OS encryption is unavailable (e.g., Linux without
- * libsecret), falls back to base64 encoding which is NOT secure. A
- * warning is logged and broadcast to the renderer via IPC.
+ * Security note: the reported capability is deliberately stricter than the
+ * mechanism used. `available` reports false whenever storage does not really
+ * protect the data — including the Linux `basic_text` backend, where Chromium
+ * encrypts with a published constant key. Encrypt and decrypt still call
+ * safeStorage whenever Electron can, so blobs written before this check keep
+ * round-tripping. See shared/lib/safe-storage-backend.ts.
  */
 
 import { ipcMain, safeStorage } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
+import { describeStorageWeakness, hasRealEncryption } from '@electron/shared/lib/safe-storage-backend';
 import { broadcastToWindows } from '../../lib/window-broadcast';
 
-let base64FallbackWarned = false;
+let weakStorageWarned = false;
 
-/** Log and broadcast a warning when encryption is unavailable. */
-function warnBase64Fallback(): void {
-  if (base64FallbackWarned) return;
-  base64FallbackWarned = true;
+/** Log and broadcast a warning when storage does not really protect credentials. */
+function warnWeakStorage(): void {
+  const reason = describeStorageWeakness();
+  if (!reason || weakStorageWarned) return;
+  weakStorageWarned = true;
 
-  console.warn(
-    '[security] WARNING: OS encryption (safeStorage) is unavailable. ' +
-    'Credentials will be stored with base64 encoding only, which is NOT secure. ' +
-    'On Linux, install libsecret (gnome-keyring or KWallet) to enable encryption.',
-  );
+  console.warn(`[security] WARNING: credentials are not stored securely. ${reason}`);
 
   // Notify all renderer windows so the UI can show a persistent warning
   broadcastToWindows('sero:security-warning', {
     type: 'encryption-unavailable',
-    message: 'OS keychain encryption is unavailable. Credentials are stored insecurely.',
+    message: `Credentials are not stored securely. ${reason}`,
   });
 }
 
 export function registerSafeStorageHandlers(): void {
   ipcMain.handle(IpcChannels.safeStorage.available, (): boolean => {
-    const available = safeStorage.isEncryptionAvailable();
-    if (!available) warnBase64Fallback();
+    const available = hasRealEncryption();
+    if (!available) warnWeakStorage();
     return available;
   });
 
   ipcMain.handle(
     IpcChannels.safeStorage.encrypt,
     (_event, plaintext: string): string => {
+      warnWeakStorage();
       if (!safeStorage.isEncryptionAvailable()) {
-        warnBase64Fallback();
         // Fallback: base64 only (not secure, but doesn't crash)
         return Buffer.from(plaintext, 'utf8').toString('base64');
       }
+      // Still encrypt under a weak backend. It is no less secure than the base64
+      // fallback, and switching mechanisms would strand already-stored blobs.
       return safeStorage.encryptString(plaintext).toString('base64');
     },
   );
@@ -61,8 +64,8 @@ export function registerSafeStorageHandlers(): void {
     IpcChannels.safeStorage.decrypt,
     (_event, encryptedBase64: string): string => {
       const buffer = Buffer.from(encryptedBase64, 'base64');
+      warnWeakStorage();
       if (!safeStorage.isEncryptionAvailable()) {
-        warnBase64Fallback();
         // Fallback: base64 only
         return buffer.toString('utf8');
       }

--- a/apps/desktop/electron/preload/platform/host-services.ts
+++ b/apps/desktop/electron/preload/platform/host-services.ts
@@ -7,6 +7,7 @@ import type {
   QrLoginData,
   ResponseFeedbackEntry,
   ResponseFeedbackState,
+  SafeStorageStatus,
 } from '@/types/ipc';
 import type { LayoutState, LoadedLayoutState } from '@/types/layout';
 import type { ThemePreset, ThemePresetMeta } from '@/types/theme';
@@ -66,6 +67,8 @@ export const safeStorageBridge = {
     ipcRenderer.invoke(IpcChannels.safeStorage.decrypt, encryptedBase64),
   available: (): Promise<boolean> =>
     ipcRenderer.invoke(IpcChannels.safeStorage.available),
+  status: (): Promise<SafeStorageStatus> =>
+    ipcRenderer.invoke(IpcChannels.safeStorage.status),
 };
 
 export const gatewayBridge = {

--- a/apps/desktop/electron/shared/lib/safe-storage-backend.ts
+++ b/apps/desktop/electron/shared/lib/safe-storage-backend.ts
@@ -2,14 +2,24 @@
  * Detection for Electron `safeStorage` backends that do not really protect data.
  *
  * On Linux, when no keyring is available, Chromium's OSCrypt selects the
- * `basic_text` backend. That backend still encrypts, so
- * `safeStorage.isEncryptionAvailable()` returns `true` — but the key is a
- * compile-time constant derived from a published password, identical on every
- * machine. Anyone who can read the file can decrypt it.
+ * `basic_text` backend. That backend encrypts with a compile-time constant
+ * derived from a published password, identical on every machine. Anyone who can
+ * read the file can decrypt it.
+ *
+ * Electron refuses that backend by default: `isEncryptionAvailable()` returns
+ * `false` and every secret write fails, which locks keyring-less Linux users out
+ * of anything that stores a credential. `enablePlainTextFallback()` accepts the
+ * weak backend so those users can sign in, and from that point
+ * `isEncryptionAvailable()` returns `true` while the data is not really
+ * protected.
  *
  * `isEncryptionAvailable()` alone therefore cannot tell real protection from
  * none. Ask `hasRealEncryption()` instead before reporting to a caller, or to a
  * user, that a secret is stored securely.
+ *
+ * Verified on Electron 41.10.5 / Linux arm64: without the fallback the backend
+ * is `basic_text` and encryption reports unavailable; with it, two separate
+ * machines produce byte-identical ciphertext for the same plaintext.
  */
 
 import { safeStorage } from 'electron';
@@ -59,6 +69,41 @@ export function describeStorageRemedy(): string | null {
   if (process.platform !== 'linux') return null;
   if (hasRealEncryption()) return null;
   return 'Install gnome-keyring or KWallet, then restart Sero.';
+}
+
+/**
+ * Accept the weak Linux backend so credentials can be stored at all.
+ *
+ * Call once, after `app.whenReady()` and before anything reads or writes a
+ * secret. Without it, a Linux desktop with no keyring cannot sign in to GitHub
+ * or store a plugin token, because every `encryptString` call throws.
+ *
+ * This is a deliberate trade: storage that is readable by anyone with the file,
+ * plus a visible warning, beats a feature the user simply cannot use. The
+ * warning is not optional — `hasRealEncryption()` stays `false` afterwards, so
+ * the banner, the status bar and the sign-in dialog all keep reporting the
+ * weakness.
+ *
+ * No-op unless Linux has already reported that real encryption is unavailable,
+ * so a working keyring is never downgraded.
+ */
+export function enablePlainTextFallback(): boolean {
+  if (process.platform !== 'linux') return false;
+  if (typeof safeStorage?.setUsePlainTextEncryption !== 'function') return false;
+  if (safeStorage.isEncryptionAvailable()) return false;
+
+  try {
+    safeStorage.setUsePlainTextEncryption(true);
+  } catch (err) {
+    console.warn('[safe-storage] Could not enable the plain-text fallback:', err);
+    return false;
+  }
+
+  console.warn(
+    '[safe-storage] WARNING: no Linux keyring. Credentials will be stored with a '
+    + 'constant, publicly known key. Install gnome-keyring or KWallet for real encryption.',
+  );
+  return true;
 }
 
 /** Human-readable reason for a downgraded claim, or null when protection is real. */

--- a/apps/desktop/electron/shared/lib/safe-storage-backend.ts
+++ b/apps/desktop/electron/shared/lib/safe-storage-backend.ts
@@ -49,6 +49,18 @@ export function hasRealEncryption(): boolean {
   return safeStorage.isEncryptionAvailable() && !isUnprotectedBackend();
 }
 
+/**
+ * What the user can actually do about it, or null when there is nothing to fix.
+ *
+ * Kept separate from the reason so the UI can show the explanation and the fix
+ * with different weight, and so the reason stays true if the remedy changes.
+ */
+export function describeStorageRemedy(): string | null {
+  if (process.platform !== 'linux') return null;
+  if (hasRealEncryption()) return null;
+  return 'Install gnome-keyring or KWallet, then restart Sero.';
+}
+
 /** Human-readable reason for a downgraded claim, or null when protection is real. */
 export function describeStorageWeakness(): string | null {
   if (!safeStorage.isEncryptionAvailable()) {

--- a/apps/desktop/electron/shared/lib/safe-storage-backend.ts
+++ b/apps/desktop/electron/shared/lib/safe-storage-backend.ts
@@ -1,0 +1,63 @@
+/**
+ * Detection for Electron `safeStorage` backends that do not really protect data.
+ *
+ * On Linux, when no keyring is available, Chromium's OSCrypt selects the
+ * `basic_text` backend. That backend still encrypts, so
+ * `safeStorage.isEncryptionAvailable()` returns `true` — but the key is a
+ * compile-time constant derived from a published password, identical on every
+ * machine. Anyone who can read the file can decrypt it.
+ *
+ * `isEncryptionAvailable()` alone therefore cannot tell real protection from
+ * none. Ask `hasRealEncryption()` instead before reporting to a caller, or to a
+ * user, that a secret is stored securely.
+ */
+
+import { safeStorage } from 'electron';
+
+/** Backends Chromium selects on Linux when no keyring is available. */
+const UNPROTECTED_LINUX_BACKENDS = new Set(['basic_text']);
+
+/**
+ * True when `safeStorage` is backed by a store that offers no real protection.
+ *
+ * Linux only. `getSelectedStorageBackend()` is not implemented on other
+ * platforms, so this returns `false` there — macOS Keychain and Windows DPAPI
+ * are not affected.
+ */
+export function isUnprotectedBackend(): boolean {
+  if (process.platform !== 'linux') return false;
+  if (typeof safeStorage?.getSelectedStorageBackend !== 'function') return false;
+
+  try {
+    return UNPROTECTED_LINUX_BACKENDS.has(safeStorage.getSelectedStorageBackend());
+  } catch {
+    // Older Electron builds can throw instead of reporting a backend. Treat an
+    // unknown backend as protected: this check only ever downgrades a claim, and
+    // guessing "unprotected" here would break working keyring setups.
+    return false;
+  }
+}
+
+/**
+ * True only when `safeStorage` both works and actually protects the data.
+ *
+ * Use this for any capability reported to a caller or shown to a user. Use the
+ * raw `safeStorage.isEncryptionAvailable()` only to decide whether
+ * `encryptString`/`decryptString` can be called at all.
+ */
+export function hasRealEncryption(): boolean {
+  return safeStorage.isEncryptionAvailable() && !isUnprotectedBackend();
+}
+
+/** Human-readable reason for a downgraded claim, or null when protection is real. */
+export function describeStorageWeakness(): string | null {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return 'OS encryption is unavailable, so credentials cannot be encrypted at all.';
+  }
+  if (isUnprotectedBackend()) {
+    return 'No Linux keyring is available. Chromium is encrypting with a constant, '
+      + 'publicly known key that is identical on every machine, so anyone who can '
+      + 'read the file can decrypt it. Install gnome-keyring or KWallet for real encryption.';
+  }
+  return null;
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,6 +19,7 @@ import { ProfileSetup } from '@/components/profiles/ProfileSetup';
 import { OnboardingWizard } from '@/components/profiles/OnboardingWizard';
 import { subscribeDevServerEvents } from '@/stores/dev-server';
 import { NewAppBanner } from '@/components/layout/shell/NewAppBanner';
+import { StorageSecurityBanner } from '@/components/layout/shell/StorageSecurityBanner';
 import { useSessionAgent } from '@/hooks/useSessionAgent';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { CommandMenu } from '@/components/layout/shell/CommandMenu';
@@ -331,6 +332,7 @@ export function App() {
         <GlobalSearchDialog />
         <GitHubAuthDialog />
         <NewAppBanner />
+        <StorageSecurityBanner />
         <OnboardingWizard />
         <GlobalQuestionPrompt />
         <StatusBar />

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx
@@ -1,8 +1,34 @@
 import type { ReactNode } from 'react';
-import { AlertCircle, Check, Copy, ExternalLink, GitFork, Loader2 } from 'lucide-react';
+import { AlertCircle, Check, Copy, ExternalLink, GitFork, Loader2, TriangleAlert } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { GitHubAuthSource } from '@/stores/github-auth';
+import { useStorageSecurityStore } from '@/stores/storage-security';
+
+/**
+ * Shown at the moment the user is about to hand Sero a token to keep.
+ *
+ * The banner and status bar cover the same condition app-wide; this one exists
+ * because signing in is the point where the trade-off is actually being made,
+ * and a general banner is easy to have dismissed weeks earlier.
+ */
+function StorageWarningInline() {
+  const status = useStorageSecurityStore((s) => s.status);
+  if (!status || status.secure) return null;
+
+  return (
+    <div className="flex gap-2.5 rounded-lg border border-[var(--status-warning-border)] bg-[var(--status-warning-muted)] px-3 py-2.5 text-xs leading-relaxed">
+      <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-[var(--status-warning)]" />
+      <div className="min-w-0">
+        <p className="text-[var(--text-primary)]">This token will not be stored securely.</p>
+        <p className="text-[var(--text-secondary)]">
+          {status.reason}
+          {status.remedy ? ` ${status.remedy}` : ''}
+        </p>
+      </div>
+    </div>
+  );
+}
 
 function GitHubAuthStateFrame({
   icon,
@@ -90,6 +116,8 @@ export function GitHubAuthReadyView({
       <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-muted)]/30 px-3 py-2 text-xs leading-relaxed text-[var(--text-secondary)]">
         We&apos;ll open GitHub in your browser and give you a one-time device code. When you finish, Sero returns you to {sourceSummary(source)}
       </div>
+
+      <StorageWarningInline />
 
       <div className="flex justify-end gap-2">
         <Button variant="ghost" onClick={onClose}>

--- a/apps/desktop/src/components/layout/shell/StatusBar.tsx
+++ b/apps/desktop/src/components/layout/shell/StatusBar.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { FolderOpen, Bug, Sun, Moon, Monitor } from 'lucide-react';
+import { FolderOpen, Bug, Sun, Moon, Monitor, TriangleAlert } from 'lucide-react';
 import { useThemeStore } from '@/stores/theme';
 import { MAX_ZOOM, MIN_ZOOM, useZoomStore } from '@/stores/zoom';
 import { useActiveWorkspace } from '@/stores/workspace';
 import { DevServerIndicator } from '@/components/layout/DevServerPanel';
+import { useStorageSecurityStore } from '@/stores/storage-security';
 
 /**
  * StatusBar, bottom bar showing workspace info (à la VSCode).
@@ -42,6 +43,7 @@ export function StatusBar() {
 
       {/* ── Right ─────────────────────────────────────────────── */}
       <div className="flex items-center gap-3">
+        <StorageSecurityIndicator />
         <DebugLogToggle />
         <DevServerIndicator />
         <ZoomControl />
@@ -56,6 +58,32 @@ export function StatusBar() {
         </button>
       </div>
     </footer>
+  );
+}
+
+// ── Storage security ──────────────────────────────────────────
+
+/**
+ * Permanent marker shown while saved credentials are not really protected.
+ *
+ * Deliberately ignores the banner's dismissed flag. Dismissing the banner
+ * silences the interruption, not the condition — otherwise a one-click dismiss
+ * would hide a live security weakness forever.
+ */
+function StorageSecurityIndicator() {
+  const status = useStorageSecurityStore((s) => s.status);
+  if (!status || status.secure) return null;
+
+  const detail = status.remedy ? `${status.reason} ${status.remedy}` : status.reason;
+
+  return (
+    <span
+      className="flex items-center gap-1 text-[var(--status-warning)]"
+      title={detail ?? undefined}
+    >
+      <TriangleAlert className="size-3" />
+      storage not secure
+    </span>
   );
 }
 

--- a/apps/desktop/src/components/layout/shell/StorageSecurityBanner.tsx
+++ b/apps/desktop/src/components/layout/shell/StorageSecurityBanner.tsx
@@ -1,0 +1,47 @@
+import { TriangleAlert, X } from 'lucide-react';
+import { useStorageSecurityStore } from '@/stores/storage-security';
+
+/**
+ * Banner shown when saved credentials are not really protected.
+ *
+ * Covers every use of safe storage, not just GitHub — plugins store tokens
+ * through the same channel, so a warning attached to one login would stay
+ * silent for the rest.
+ *
+ * Dismissible, because it cannot be fixed without installing a keyring and
+ * restarting. The status-bar indicator remains after dismissal.
+ */
+export function StorageSecurityBanner() {
+  const status = useStorageSecurityStore((s) => s.status);
+  const dismissed = useStorageSecurityStore((s) => s.bannerDismissed);
+  const dismiss = useStorageSecurityStore((s) => s.dismissBanner);
+
+  if (!status || status.secure || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex shrink-0 items-center gap-2.5 border-t border-[var(--status-warning-border)] bg-[var(--status-warning-muted)] px-4 py-2 text-xs"
+    >
+      <TriangleAlert className="size-3.5 shrink-0 text-[var(--status-warning)]" />
+      <span className="min-w-0 flex-1 text-[var(--text-primary)]">
+        Credentials are not stored securely.{' '}
+        <span className="text-[var(--text-secondary)]">{status.reason}</span>
+      </span>
+      {status.remedy ? (
+        <span className="hidden shrink-0 text-[var(--text-secondary)] sm:inline">
+          {status.remedy}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss storage security warning"
+        title="Dismiss. The status bar keeps showing this."
+        className="shrink-0 rounded p-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -22,6 +22,7 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
 import { useModelPreferences } from '@/stores/model-preferences';
 import { useDashboardStore } from '@/stores/dashboard';
+import { useStorageSecurityStore } from '@/stores/storage-security';
 import { useBrowserStore } from '@/stores/browser';
 import { useExplorerStore } from '@/stores/explorer';
 import { useZoomStore } from '@/stores/zoom';
@@ -53,6 +54,8 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
     appViewIds: partial.appViewIds ?? app.appViewIds,
     chromeShortcuts: partial.chromeShortcuts ?? app.chromeShortcuts,
     zoomFactor: partial.zoomFactor ?? useZoomStore.getState().factor,
+    storageWarningDismissed: partial.storageWarningDismissed
+      ?? useStorageSecurityStore.getState().bannerDismissed,
     activeSessionId: partial.activeSessionId !== undefined
       ? partial.activeSessionId
       : sess.activeSessionId,

--- a/apps/desktop/src/stores/__tests__/storage-security.test.ts
+++ b/apps/desktop/src/stores/__tests__/storage-security.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStorageSecurityStore } from '@/stores/storage-security';
+
+const persistLayout = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/persist-layout', () => ({ persistLayout }));
+
+function setBridge(status: unknown, reject = false): void {
+  (window as unknown as { sero: unknown }).sero = {
+    safeStorage: {
+      status: reject
+        ? vi.fn().mockRejectedValue(new Error('ipc down'))
+        : vi.fn().mockResolvedValue(status),
+    },
+  };
+}
+
+beforeEach(() => {
+  persistLayout.mockClear();
+  useStorageSecurityStore.setState({ status: null, bannerDismissed: false });
+});
+
+describe('storage security store', () => {
+  it('records an insecure result', async () => {
+    setBridge({ secure: false, reason: 'no keyring', remedy: 'install one' });
+    await useStorageSecurityStore.getState().check();
+
+    expect(useStorageSecurityStore.getState().status).toEqual({
+      secure: false,
+      reason: 'no keyring',
+      remedy: 'install one',
+    });
+  });
+
+  it('stays null when the check fails, so no surface claims a problem', async () => {
+    setBridge(null, true);
+    await useStorageSecurityStore.getState().check();
+
+    // A failed check must not be reported as insecure — that would warn users
+    // about a condition we never actually observed.
+    expect(useStorageSecurityStore.getState().status).toBeNull();
+  });
+
+  it('persists the dismissal rather than only setting it in memory', () => {
+    useStorageSecurityStore.getState().dismissBanner();
+
+    expect(useStorageSecurityStore.getState().bannerDismissed).toBe(true);
+    expect(persistLayout).toHaveBeenCalledWith({ storageWarningDismissed: true });
+  });
+
+  it('hydrates the dismissal from a persisted layout', () => {
+    useStorageSecurityStore.getState().hydrateDismissed(true);
+    expect(useStorageSecurityStore.getState().bannerDismissed).toBe(true);
+    // Hydration is not a user action, so it must not write back.
+    expect(persistLayout).not.toHaveBeenCalled();
+  });
+
+  it('keeps status independent of dismissal, so the status bar stays visible', async () => {
+    setBridge({ secure: false, reason: 'no keyring', remedy: null });
+    await useStorageSecurityStore.getState().check();
+    useStorageSecurityStore.getState().dismissBanner();
+
+    const state = useStorageSecurityStore.getState();
+    expect(state.bannerDismissed).toBe(true);
+    expect(state.status?.secure).toBe(false);
+  });
+});

--- a/apps/desktop/src/stores/app/layout-hydration.test.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useDashboardStore } from '@/stores/dashboard';
 import { useNavigationStore } from '@/stores/navigation';
+import { useStorageSecurityStore } from '@/stores/storage-security';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAppStore } from './state';
 import { loadLayout } from './layout-hydration';
@@ -25,12 +26,14 @@ describe('layout hydration', () => {
   const initialDashboardState = useDashboardStore.getState();
   const initialAppState = useAppStore.getState();
   const initialNavigationState = useNavigationStore.getState();
+  const initialStorageSecurityState = useStorageSecurityStore.getState();
   const initialWorkspaceState = useWorkspaceStore.getState();
 
   afterEach(() => {
     useDashboardStore.setState(initialDashboardState, true);
     useAppStore.setState(initialAppState, true);
     useNavigationStore.setState(initialNavigationState, true);
+    useStorageSecurityStore.setState(initialStorageSecurityState, true);
     useWorkspaceStore.setState(initialWorkspaceState, true);
     Reflect.deleteProperty(window, 'sero');
   });
@@ -38,9 +41,11 @@ describe('layout hydration', () => {
   it('does not overwrite a background change that arrives during hydration', async () => {
     const backgroundLoad = deferred<string | null>();
     const listener: { current: ((dataUrl: string | null) => void) | null } = { current: null };
+    const storageStatus = vi.fn(async () => ({ secure: false, reason: 'no keyring', remedy: null }));
 
     Reflect.set(window, 'sero', {
       layout: { load: vi.fn(async () => null) },
+      safeStorage: { status: storageStatus },
       dashboard: {
         getBackground: vi.fn(() => backgroundLoad.promise),
         onBackgroundChanged: vi.fn((callback: (dataUrl: string | null) => void) => {
@@ -61,6 +66,24 @@ describe('layout hydration', () => {
     expect(useDashboardStore.getState().backgroundImage).toBe(
       'sero-media://dashboard/background?v=new',
     );
+    expect(storageStatus).toHaveBeenCalledOnce();
+    expect(useStorageSecurityStore.getState().status?.secure).toBe(false);
+  });
+
+  it('checks storage security when layout loading fails', async () => {
+    const storageStatus = vi.fn(async () => ({ secure: true, reason: null, remedy: null }));
+    Reflect.set(window, 'sero', {
+      layout: { load: vi.fn().mockRejectedValue(new Error('layout unavailable')) },
+      safeStorage: { status: storageStatus },
+      dashboard: {
+        getBackground: vi.fn(async () => null),
+        onBackgroundChanged: vi.fn(() => () => undefined),
+      },
+    });
+
+    await loadLayout();
+
+    expect(storageStatus).toHaveBeenCalledOnce();
   });
 
   it('restores the active app sub-view for its workspace', async () => {

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -8,6 +8,7 @@ import { useExplorerStore } from '@/stores/explorer';
 import { useAgentBoardStore } from '@/stores/agent-board';
 import { seedNavigationHistory } from '@/stores/navigation';
 import { hydrateZoom } from '@/stores/zoom';
+import { useStorageSecurityStore } from '@/stores/storage-security';
 import { normaliseChromeShortcuts, normaliseFavouriteApps } from './shared';
 import type { AppState } from './state';
 import { useAppStore } from './state';
@@ -95,6 +96,11 @@ export async function loadLayout(): Promise<void> {
         globalApp ? undefined : workspaceId,
       );
       hydrateZoom(state.zoomFactor);
+
+      // Storage security: apply the persisted dismissal, then ask the host.
+      // The keyring backend cannot change while Sero runs, so one check is enough.
+      useStorageSecurityStore.getState().hydrateDismissed(state.storageWarningDismissed === true);
+      void useStorageSecurityStore.getState().check();
 
       // Hydrate active workspace into workspace store
       if (state.activeWorkspaceId !== undefined) {

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -22,6 +22,7 @@ function isGlobalApp(state: AppState, appId: string): boolean {
 
 /** Load layout state from disk and hydrate all stores. */
 export async function loadLayout(): Promise<void> {
+  let storageWarningDismissed = false;
   try {
     const dashboardApi = window.sero.dashboard;
     let backgroundChangedDuringLoad = false;
@@ -44,6 +45,7 @@ export async function loadLayout(): Promise<void> {
     if (!backgroundChangedDuringLoad) {
       useDashboardStore.getState().setBackgroundImage(backgroundImage);
     }
+    storageWarningDismissed = state?.storageWarningDismissed === true;
     if (state) {
       const favouriteApps = normaliseFavouriteApps(state.favouriteApps);
       const update: Partial<AppState> & { layoutReady: true } = {
@@ -97,11 +99,6 @@ export async function loadLayout(): Promise<void> {
       );
       hydrateZoom(state.zoomFactor);
 
-      // Storage security: apply the persisted dismissal, then ask the host.
-      // The keyring backend cannot change while Sero runs, so one check is enough.
-      useStorageSecurityStore.getState().hydrateDismissed(state.storageWarningDismissed === true);
-      void useStorageSecurityStore.getState().check();
-
       // Hydrate active workspace into workspace store
       if (state.activeWorkspaceId !== undefined) {
         useWorkspaceStore.setState({ activeWorkspaceId: state.activeWorkspaceId ?? null });
@@ -141,6 +138,10 @@ export async function loadLayout(): Promise<void> {
     }
   } catch (err) {
     console.warn('[app-store] Failed to load layout:', err);
+  } finally {
+    const storageSecurity = useStorageSecurityStore.getState();
+    storageSecurity.hydrateDismissed(storageWarningDismissed);
+    void storageSecurity.check();
   }
 
   useAppStore.setState({ layoutReady: true });

--- a/apps/desktop/src/stores/storage-security.ts
+++ b/apps/desktop/src/stores/storage-security.ts
@@ -1,0 +1,55 @@
+/**
+ * Storage security store — whether saved credentials are really protected.
+ *
+ * On Linux with no keyring, Electron reports encryption as available while
+ * Chromium encrypts under a published constant key. The main process detects
+ * that and reports it here, so the UI can say so instead of implying safety.
+ *
+ * The state is read once at startup: the keyring backend cannot change while
+ * Sero is running, so there is nothing to subscribe to.
+ *
+ * Dismissing hides the banner only, and is persisted as `storageWarningDismissed`.
+ * The status-bar indicator ignores dismissal, so the condition stays visible.
+ */
+
+import { create } from 'zustand';
+import { persistLayout } from '@/lib/persist-layout';
+import type { SafeStorageStatus } from '@/types/ipc';
+
+interface StorageSecurityState {
+  /** Null until the first check resolves. */
+  status: SafeStorageStatus | null;
+  bannerDismissed: boolean;
+  /** Ask the main process. Safe to call more than once. */
+  check: () => Promise<void>;
+  dismissBanner: () => void;
+  /** Applied from the persisted layout at startup. */
+  hydrateDismissed: (dismissed: boolean) => void;
+}
+
+export const useStorageSecurityStore = create<StorageSecurityState>((set) => ({
+  status: null,
+  bannerDismissed: false,
+
+  check: async () => {
+    try {
+      const status = await window.sero.safeStorage.status();
+      set({ status });
+    } catch {
+      // A failed check must not imply a problem. Staying null keeps every
+      // surface hidden rather than showing a warning we cannot substantiate.
+    }
+  },
+
+  dismissBanner: () => {
+    set({ bannerDismissed: true });
+    void persistLayout({ storageWarningDismissed: true });
+  },
+
+  hydrateDismissed: (dismissed) => set({ bannerDismissed: dismissed }),
+}));
+
+/** True when storage is confirmed insecure. False while unknown. */
+export function useStorageIsInsecure(): boolean {
+  return useStorageSecurityStore((s) => s.status !== null && !s.status.secure);
+}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -24,6 +24,7 @@ import type { ThemePreset, ThemePresetMeta } from './theme';
 import type { SeroAgentPluginsBridge, SeroUserFeedbackBridge } from '@sero-ai/common';
 import type {
   ProfileInfo,
+  SafeStorageStatus,
   SeroSessionInfo,
   ChatMessage,
   ChatAttachment,
@@ -279,6 +280,13 @@ interface SeroSafeStorageAPI {
   decrypt(encryptedBase64: string): Promise<string>;
   /** Check if OS-level encryption is available. */
   available(): Promise<boolean>;
+  /**
+   * Whether stored credentials are really protected, and why not.
+   *
+   * Stricter than `available()` on Linux: a machine with no keyring reports
+   * encryption as available while encrypting under a published constant key.
+   */
+  status(): Promise<SafeStorageStatus>;
 }
 
 interface SeroClipboardAPI { writeText(text: string): Promise<boolean>; }

--- a/apps/desktop/src/types/ipc-channels-platform.ts
+++ b/apps/desktop/src/types/ipc-channels-platform.ts
@@ -29,6 +29,8 @@ export const safeStorageIpcChannels = {
   decrypt: 'sero:safe-storage:decrypt',
   /** Check if OS-level encryption is available. */
   available: 'sero:safe-storage:available',
+  /** Report whether stored credentials are really protected, and why not. */
+  status: 'sero:safe-storage:status',
 } as const;
 
 export const feedbackIpcChannels = {

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -466,3 +466,19 @@ export interface AppStateReadResult {
 export type AppStateWriteResult =
   | { ok: true; etag: string }
   | { ok: false; data: unknown; etag: string | null };
+
+/**
+ * Whether stored credentials are really protected on this machine.
+ *
+ * `secure: false` with a `reason` is the case that matters: on Linux with no
+ * keyring, Electron reports encryption as available while Chromium encrypts
+ * under a published constant key. See electron/shared/lib/safe-storage-backend.
+ */
+export interface SafeStorageStatus {
+  /** True only when the backend genuinely protects the data. */
+  secure: boolean;
+  /** Plain-English explanation when `secure` is false; null when it is true. */
+  reason: string | null;
+  /** Actionable fix for this platform, when one exists. */
+  remedy: string | null;
+}

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -67,6 +67,13 @@ export interface LayoutState {
   activeSessionId?: string | null;
   /** Favourite model keys ("provider/modelId"). */
   favouriteModels?: string[];
+  /**
+   * Whether the insecure-credential-storage banner has been dismissed.
+   *
+   * Dismissing hides the banner only. The status-bar indicator stays, so the
+   * condition never becomes invisible.
+   */
+  storageWarningDismissed?: boolean;
   /** Hidden model keys ("provider/modelId"). */
   hiddenModels?: string[];
   /** Provider IDs entirely hidden from the model selector. */


### PR DESCRIPTION
Fixes #459.

## The problem, as measured

The issue was filed on a wrong diagnosis, including by me. It said
`safeStorage.isEncryptionAvailable()` returns `true` on keyring-less Linux while Chromium uses its
constant-key `basic_text` backend.

Measured on real Electron 41.10.5 / Linux arm64, in a container with no keyring. Four
configurations, with and without a D-Bus session, with and without `--password-store=basic`. All
four give the same answer:

- `getSelectedStorageBackend()` → `basic_text`
- `isEncryptionAvailable()` → **`false`**

**Electron refuses the weak backend by default.** So the unsafe state was unreachable, and the
detection code is defence in depth rather than a fix.

The live defect is the opposite one. `auth-manager.ts` **throws** when `canUseSafeStorage()` is
false. So a Linux user with no keyring could not sign in to GitHub at all, and could not store a
plugin token. A whole class of machine was locked out of any feature that stores a credential.

## What changed

Three commits, in order.

**1. `25b3d98a5` — detect a backend that does not protect data.**
New `electron/shared/lib/safe-storage-backend.ts`:

- `isUnprotectedBackend()` — gated on `getSelectedStorageBackend()`, Linux only.
- `hasRealEncryption()` — what a capability check should ask.
- `describeStorageWeakness()` — the real reason, for logs and for the UI.

The safeStorage IPC `available` channel now answers with `hasRealEncryption()`.

**2. `6e337255e` — let keyring-less Linux store credentials, and warn.**
`enablePlainTextFallback()` calls `setUsePlainTextEncryption(true)` once, at `app.whenReady()`,
before anything reads or writes a secret. It is a **no-op unless Linux has already reported
encryption unavailable**, so a working keyring is never downgraded.

This is a deliberate trade. Storage that is readable by anyone with the file, plus a visible
warning, beats a feature the user cannot use at all. `hasRealEncryption()` stays `false`
afterwards, which is what keeps every warning surface reporting the weakness.

**3. `a57e28c8c` — surface it in the UI.**
A `storage-security` store, a banner, a status-bar indicator and a line in the GitHub sign-in
dialog. `describeStorageRemedy()` keeps the fix separate from the reason, so the reason stays true
if the remedy changes.

## Proof the key is a published constant

After the fallback is enabled, two fresh containers produce **byte-identical ciphertext** for the
same plaintext, with the `v10` prefix (`7631 30`). Same machine-independent key, as documented.

## The decision this PR makes

**Store and warn, do not refuse.** The alternative was to keep throwing, which is what locked those
users out. That was #459's open question, and it is now answered.

Two smaller decisions worth a look:

1. **`encrypt`/`decrypt` still call safeStorage under a weak backend.** The reported capability is
   stricter than the mechanism used. Switching to a base64 path would strand every blob already
   written, and base64 is no more secure than a constant key.
2. **An unknown or throwing backend is treated as protected.** This check only ever downgrades a
   claim. Guessing "unprotected" would break working keyring setups.

## Testing

- 23 tests across `safe-storage-backend.test.ts` and `storage-security.test.ts`. All pass.
- `pnpm typecheck` passes.
- Behaviour verified on real Linux in a container, not only mocked. Reproduction needs
  `node:20-bookworm-slim` plus `xauth`, `libgtk-3-0`, `libdbus-1-3`, `libnspr4` and `libxshmfence1`
  on top of the usual Electron list, or the binary hangs with no output.

Note: draft PRs skip Build, Tests and both typecheck jobs (`test.yml:27`). Those run for the first
time when this is marked ready.

## Scope

Linux only. macOS Keychain and Windows DPAPI are unaffected. `app-main.ts` sets
`use-mock-keychain`, so development on macOS is not keychain-encrypted either. That is mentioned on
#459 and not addressed here.
