### PR TITLE
feat(desktop): add browser pack update controls

### DIFF
--- a/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
@@ -77,6 +77,21 @@ describe('BrowserPackInstaller', () => {
     await assertInstalledArtifactShape(harness);
   });
 
+  it('reports the previous installed pack when an update is available', async () => {
+    const previousVersion = `browser-test-previous-${process.pid}-${Date.now()}`;
+    cleanupVersions.push(previousVersion);
+    await fs.promises.mkdir(browserPackInstallRoot(previousVersion), { recursive: true });
+    await fs.promises.writeFile(browserPackInstalledMarker(previousVersion), 'installed\n');
+    const harness = await createHarness();
+    const installer = installerWithArchive(harness);
+
+    await expect(installer.status()).resolves.toMatchObject({
+      state: 'installable',
+      manifestVersion: harness.manifest.version,
+      previousManifestVersion: previousVersion,
+    });
+  });
+
   it('creates adapter candidates that resolve to activated fixture paths from manifest metadata', async () => {
     const harness = await createHarness();
     const installer = installerWithArchive(harness);

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
@@ -79,11 +79,12 @@ describe('BrowserPackInstaller', () => {
   });
 
   it('selects the latest older installed browser pack', async () => {
-    const currentVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.27.3';
-    const previousVersion = 'browser-pack-2026-08-23-r1233-f1011-mf1011-agent-0.27.2';
+    const currentVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.28.0-beta.2';
+    const previousVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.28.0-beta.1';
     const oldestVersion = 'browser-pack-2026-08-22-r999-f999-mf999-agent-0.9.0';
-    const newerVersion = 'browser-pack-2026-08-25-r1235-f1012-mf1012-agent-0.28.0';
-    const installedVersions = [previousVersion, oldestVersion, newerVersion];
+    const newerPrereleaseVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.28.0-beta.3';
+    const newerStableVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.28.0';
+    const installedVersions = [previousVersion, oldestVersion, newerPrereleaseVersion, newerStableVersion];
     cleanupVersions.push(...installedVersions);
     await Promise.all(installedVersions.map(async (version) => {
       await fs.promises.mkdir(browserPackInstallRoot(version), { recursive: true });
@@ -91,6 +92,22 @@ describe('BrowserPackInstaller', () => {
     }));
 
     await expect(findPreviousBrowserPackVersion(currentVersion)).resolves.toBe(previousVersion);
+  });
+
+  it('reports the previous installed pack through status', async () => {
+    const currentVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.27.3';
+    const previousVersion = 'browser-pack-2026-08-23-r1233-f1011-mf1011-agent-0.27.2';
+    cleanupVersions.push(previousVersion);
+    await fs.promises.mkdir(browserPackInstallRoot(previousVersion), { recursive: true });
+    await fs.promises.writeFile(browserPackInstalledMarker(previousVersion), 'installed\n');
+    const harness = await createHarness(currentVersion);
+    const installer = installerWithArchive(harness);
+
+    await expect(installer.status()).resolves.toMatchObject({
+      state: 'installable',
+      manifestVersion: currentVersion,
+      previousManifestVersion: previousVersion,
+    });
   });
 
   it('creates adapter candidates that resolve to activated fixture paths from manifest metadata', async () => {
@@ -323,8 +340,8 @@ function createPendingManifest(): BrowserPackManifest {
   };
 }
 
-async function createHarness(): Promise<Harness> {
-  const version = `browser-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+async function createHarness(versionOverride?: string): Promise<Harness> {
+  const version = versionOverride ?? `browser-test-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   cleanupVersions.push(version);
   const archiveRoot = path.join(SERO_FIXED_ROOT, 'browser-pack-test-archives', version);
   await writeExecutable(path.join(archiveRoot, 'chromium/chrome-mac/Chromium.app/Contents/MacOS/Chromium'), 'Chromium');

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
@@ -21,6 +21,7 @@ import { createBrowserRuntimeAdapter, firstExistingCandidate } from '@electron/f
 import { BrowserPackInstaller } from '@electron/features/workspace/runtime/browser-pack/installer';
 import {
   browserPackDownloadPath,
+  findPreviousBrowserPackVersion,
   browserPackInstallRoot,
   browserPackInstalledMarker,
   browserPackManifestPath,
@@ -77,19 +78,19 @@ describe('BrowserPackInstaller', () => {
     await assertInstalledArtifactShape(harness);
   });
 
-  it('reports the previous installed pack when an update is available', async () => {
-    const previousVersion = `browser-test-previous-${process.pid}-${Date.now()}`;
-    cleanupVersions.push(previousVersion);
-    await fs.promises.mkdir(browserPackInstallRoot(previousVersion), { recursive: true });
-    await fs.promises.writeFile(browserPackInstalledMarker(previousVersion), 'installed\n');
-    const harness = await createHarness();
-    const installer = installerWithArchive(harness);
+  it('selects the latest older installed browser pack', async () => {
+    const currentVersion = 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.27.3';
+    const previousVersion = 'browser-pack-2026-08-23-r1233-f1011-mf1011-agent-0.27.2';
+    const oldestVersion = 'browser-pack-2026-08-22-r999-f999-mf999-agent-0.9.0';
+    const newerVersion = 'browser-pack-2026-08-25-r1235-f1012-mf1012-agent-0.28.0';
+    const installedVersions = [previousVersion, oldestVersion, newerVersion];
+    cleanupVersions.push(...installedVersions);
+    await Promise.all(installedVersions.map(async (version) => {
+      await fs.promises.mkdir(browserPackInstallRoot(version), { recursive: true });
+      await fs.promises.writeFile(browserPackInstalledMarker(version), 'installed\n');
+    }));
 
-    await expect(installer.status()).resolves.toMatchObject({
-      state: 'installable',
-      manifestVersion: harness.manifest.version,
-      previousManifestVersion: previousVersion,
-    });
+    await expect(findPreviousBrowserPackVersion(currentVersion)).resolves.toBe(previousVersion);
   });
 
   it('creates adapter candidates that resolve to activated fixture paths from manifest metadata', async () => {

--- a/apps/desktop/electron/features/workspace/runtime/browser-pack/installer.ts
+++ b/apps/desktop/electron/features/workspace/runtime/browser-pack/installer.ts
@@ -8,6 +8,7 @@ import { validateInstalledBrowserPack } from './adapter';
 import { findBrowserArtifact, findBrowserArtifactAvailability, getBrowserPackManifest } from './manifest';
 import {
   browserPackDownloadPath,
+  findPreviousBrowserPackVersion,
   browserPackInstallRoot,
   browserPackInstalledMarker,
   browserPackManifestPath,
@@ -68,7 +69,15 @@ export class BrowserPackInstaller {
     if (availability.state === 'unsupported') return this.unsupportedStatus();
     const selection = this.selection();
     if (!selection) return this.unsupportedStatus();
-    if (this.inFlight) return { state: 'installing', manifestVersion: this.manifest.version, artifactKey: selection.key };
+    const previousManifestVersion = await findPreviousBrowserPackVersion(this.manifest.version);
+    if (this.inFlight) {
+      return {
+        state: 'installing',
+        manifestVersion: this.manifest.version,
+        previousManifestVersion,
+        artifactKey: selection.key,
+      };
+    }
     if (await exists(browserPackInstalledMarker(this.manifest.version))) {
       try {
         await validateInstalledBrowserPackManifest(this.manifest.version, this.manifest, selection.key);
@@ -76,6 +85,7 @@ export class BrowserPackInstaller {
         return {
           state: 'ready',
           manifestVersion: this.manifest.version,
+          previousManifestVersion,
           artifactKey: selection.key,
           browsersPath: browserPackInstallRoot(this.manifest.version),
         };
@@ -83,15 +93,25 @@ export class BrowserPackInstaller {
         return {
           state: 'failed',
           manifestVersion: this.manifest.version,
+          previousManifestVersion,
           artifactKey: selection.key,
           error: makeBrokenInstallError(error, this.manifest.version, selection.key),
         };
       }
     }
-    if (this.lastFailure) return { state: 'failed', manifestVersion: this.manifest.version, artifactKey: selection.key, error: this.lastFailure };
+    if (this.lastFailure) {
+      return {
+        state: 'failed',
+        manifestVersion: this.manifest.version,
+        previousManifestVersion,
+        artifactKey: selection.key,
+        error: this.lastFailure,
+      };
+    }
     return {
       state: 'installable',
       manifestVersion: this.manifest.version,
+      previousManifestVersion,
       artifactKey: selection.key,
       error: makeError('BROWSER_PACK_REQUIRED', 'Host browser automation pack is not installed.', this.manifest.version, selection.key, true, true),
     };
@@ -152,6 +172,7 @@ export class BrowserPackInstaller {
       const ready: BrowserPackStatus = {
         state: 'ready',
         manifestVersion: this.manifest.version,
+        previousManifestVersion: current.previousManifestVersion,
         artifactKey: selection.key,
         browsersPath: browserPackInstallRoot(this.manifest.version),
       };

--- a/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
+++ b/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
@@ -44,7 +44,7 @@ export async function findPreviousBrowserPackVersion(currentVersion: string): Pr
 
   const versions = (await listToolchainVersions())
     .map((version) => ({ version, parts: parseBrowserPackVersion(version) }))
-    .filter((candidate): candidate is { version: string; parts: number[] } => (
+    .filter((candidate): candidate is { version: string; parts: BrowserPackVersionParts } => (
       candidate.parts !== null && compareVersionParts(candidate.parts, currentParts) < 0
     ))
     .sort((left, right) => compareVersionParts(right.parts, left.parts));
@@ -55,17 +55,61 @@ export async function findPreviousBrowserPackVersion(currentVersion: string): Pr
   return undefined;
 }
 
-function parseBrowserPackVersion(version: string): number[] | null {
-  const match = /^browser-pack-(\d{4})-(\d{2})-(\d{2})-r(\d+)-f(\d+)-mf(\d+)-agent-(\d+(?:\.\d+)*)$/.exec(version);
-  if (!match) return null;
-  return match.slice(1, 7).map(Number).concat(match[7].split('.').map(Number));
+interface BrowserPackVersionParts {
+  pack: number[];
+  agent: AgentVersionParts;
 }
 
-function compareVersionParts(left: number[], right: number[]): number {
+interface AgentVersionParts {
+  core: number[];
+  prerelease: Array<number | string> | null;
+}
+
+function parseBrowserPackVersion(version: string): BrowserPackVersionParts | null {
+  const match = /^browser-pack-(\d{4})-(\d{2})-(\d{2})-r(\d+)-f(\d+)-mf(\d+)-agent-(.+)$/.exec(version);
+  if (!match) return null;
+  const agent = parseAgentVersion(match[7]);
+  return agent ? { pack: match.slice(1, 7).map(Number), agent } : null;
+}
+
+function parseAgentVersion(version: string): AgentVersionParts | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(version);
+  if (!match) return null;
+  return {
+    core: match.slice(1, 4).map(Number),
+    prerelease: match[4]?.split('.').map((part) => /^\d+$/.test(part) ? Number(part) : part) ?? null,
+  };
+}
+
+function compareVersionParts(left: BrowserPackVersionParts, right: BrowserPackVersionParts): number {
+  return compareNumberParts(left.pack, right.pack)
+    || compareNumberParts(left.agent.core, right.agent.core)
+    || comparePrereleaseParts(left.agent.prerelease, right.agent.prerelease);
+}
+
+function compareNumberParts(left: number[], right: number[]): number {
   const length = Math.max(left.length, right.length);
   for (let index = 0; index < length; index += 1) {
     const difference = (left[index] ?? 0) - (right[index] ?? 0);
     if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function comparePrereleaseParts(left: Array<number | string> | null, right: Array<number | string> | null): number {
+  if (left === null) return right === null ? 0 : 1;
+  if (right === null) return -1;
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+    if (typeof leftPart === 'number' && typeof rightPart === 'number') return leftPart - rightPart;
+    if (typeof leftPart === 'number') return -1;
+    if (typeof rightPart === 'number') return 1;
+    return leftPart < rightPart ? -1 : 1;
   }
   return 0;
 }

--- a/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
+++ b/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
@@ -1,9 +1,11 @@
+import fs from 'fs';
 import path from 'path';
 
 import {
   INSTALLED_MARKER,
   STAGING_SUFFIX,
   downloadedArtifactPath,
+  listToolchainVersions,
   toolchainStagingRoot,
   toolchainVersionRoot,
 } from '../toolchains/storage';
@@ -34,4 +36,19 @@ export function browserPackDownloadPath(version: string, artifactKey: string): s
 
 export function browserPackTempRoot(version: string): string {
   return path.join(browserPackInstallRoot(version), 'tmp');
+}
+
+export async function findPreviousBrowserPackVersion(currentVersion: string): Promise<string | undefined> {
+  const versions = (await listToolchainVersions())
+    .filter((version) => version !== currentVersion)
+    .sort((left, right) => right.localeCompare(left));
+
+  for (const version of versions) {
+    if (await exists(browserPackInstalledMarker(version))) return version;
+  }
+  return undefined;
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  return fs.promises.access(filePath).then(() => true, () => false);
 }

--- a/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
+++ b/apps/desktop/electron/features/workspace/runtime/browser-pack/storage.ts
@@ -39,14 +39,35 @@ export function browserPackTempRoot(version: string): string {
 }
 
 export async function findPreviousBrowserPackVersion(currentVersion: string): Promise<string | undefined> {
-  const versions = (await listToolchainVersions())
-    .filter((version) => version !== currentVersion)
-    .sort((left, right) => right.localeCompare(left));
+  const currentParts = parseBrowserPackVersion(currentVersion);
+  if (!currentParts) return undefined;
 
-  for (const version of versions) {
-    if (await exists(browserPackInstalledMarker(version))) return version;
+  const versions = (await listToolchainVersions())
+    .map((version) => ({ version, parts: parseBrowserPackVersion(version) }))
+    .filter((candidate): candidate is { version: string; parts: number[] } => (
+      candidate.parts !== null && compareVersionParts(candidate.parts, currentParts) < 0
+    ))
+    .sort((left, right) => compareVersionParts(right.parts, left.parts));
+
+  for (const candidate of versions) {
+    if (await exists(browserPackInstalledMarker(candidate.version))) return candidate.version;
   }
   return undefined;
+}
+
+function parseBrowserPackVersion(version: string): number[] | null {
+  const match = /^browser-pack-(\d{4})-(\d{2})-(\d{2})-r(\d+)-f(\d+)-mf(\d+)-agent-(\d+(?:\.\d+)*)$/.exec(version);
+  if (!match) return null;
+  return match.slice(1, 7).map(Number).concat(match[7].split('.').map(Number));
+}
+
+function compareVersionParts(left: number[], right: number[]): number {
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
 }
 
 async function exists(filePath: string): Promise<boolean> {

--- a/apps/desktop/electron/features/workspace/runtime/browser-pack/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/browser-pack/types.ts
@@ -64,6 +64,7 @@ export interface BrowserPackError {
 export interface BrowserPackStatus {
   state: BrowserPackState;
   manifestVersion: string;
+  previousManifestVersion?: string;
   artifactKey?: string;
   browsersPath?: string;
   error?: BrowserPackError;

--- a/apps/desktop/electron/features/workspace/runtime/install-actions.ts
+++ b/apps/desktop/electron/features/workspace/runtime/install-actions.ts
@@ -162,6 +162,7 @@ function toBrowserPackStatusIPC(status: BrowserPackStatus): BrowserPackStatusIPC
   return {
     state: status.state,
     manifestVersion: status.manifestVersion,
+    previousManifestVersion: status.previousManifestVersion,
     artifactKey: status.artifactKey,
     browsersPath: status.browsersPath,
     progress: lastBrowserPackProgress,

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -71,6 +71,7 @@ function isLayoutState(value: unknown): value is LoadedLayoutState {
   if (c.theme !== undefined && typeof c.theme !== 'string') return false;
   if (c.activeApp !== undefined && typeof c.activeApp !== 'string') return false;
   if (c.activeThemeId !== undefined && typeof c.activeThemeId !== 'string') return false;
+  if (c.browserPackNoticeVersion !== undefined && typeof c.browserPackNoticeVersion !== 'string') return false;
   // Nullable strings
   if (c.activeWorkspaceId !== undefined && c.activeWorkspaceId !== null && typeof c.activeWorkspaceId !== 'string') return false;
   if (c.activeSessionId !== undefined && c.activeSessionId !== null && typeof c.activeSessionId !== 'string') return false;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,6 +20,7 @@ import { OnboardingWizard } from '@/components/profiles/OnboardingWizard';
 import { subscribeDevServerEvents } from '@/stores/dev-server';
 import { NewAppBanner } from '@/components/layout/shell/NewAppBanner';
 import { StorageSecurityBanner } from '@/components/layout/shell/StorageSecurityBanner';
+import { BrowserPackUpdateNotice } from '@/components/layout/shell/BrowserPackUpdateNotice';
 import { useSessionAgent } from '@/hooks/useSessionAgent';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { CommandMenu } from '@/components/layout/shell/CommandMenu';
@@ -332,6 +333,7 @@ export function App() {
         <GlobalSearchDialog />
         <GitHubAuthDialog />
         <NewAppBanner />
+        <BrowserPackUpdateNotice />
         <StorageSecurityBanner />
         <OnboardingWizard />
         <GlobalQuestionPrompt />

--- a/apps/desktop/src/components/layout/shell/BrowserPackUpdateNotice.tsx
+++ b/apps/desktop/src/components/layout/shell/BrowserPackUpdateNotice.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { Download, X } from 'lucide-react';
+import { openSeroApp } from '@sero-ai/app-runtime';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { useBrowserPackNoticeStore } from '@/stores/browser-pack-notice';
+import { useProfileStore } from '@/stores/profiles';
+
+export function BrowserPackUpdateNotice() {
+  const onboarded = useProfileStore((state) => state.activeProfile?.onboarded === true);
+  const visible = useBrowserPackNoticeStore((state) => state.visible);
+  const status = useBrowserPackNoticeStore((state) => state.status);
+  const check = useBrowserPackNoticeStore((state) => state.check);
+  const dismiss = useBrowserPackNoticeStore((state) => state.dismiss);
+
+  useEffect(() => {
+    if (onboarded) void check();
+  }, [check, onboarded]);
+
+  if (!visible || !status?.previousManifestVersion) return null;
+
+  const openSettings = async () => {
+    const opened = await openSeroApp('admin', {
+      section: 'settings',
+      configKey: 'settings',
+    });
+    if (opened) dismiss();
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex shrink-0 items-center gap-2.5 border-t border-[var(--banner-primary-border)] bg-[var(--banner-primary-muted)] px-4 py-2 text-xs"
+    >
+      <Download className="size-3.5 shrink-0 text-[var(--banner-primary)]" />
+      <span className="min-w-0 flex-1 text-[var(--text-primary)]">
+        Sero can install a newer browser automation pack.
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        className="shrink-0 text-[var(--banner-primary)]"
+        onClick={() => void openSettings()}
+      >
+        Open settings
+      </Button>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss browser pack update"
+        className="shrink-0 rounded p-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -23,6 +23,7 @@ import { useSessionStore } from '@/stores/sessions';
 import { useModelPreferences } from '@/stores/model-preferences';
 import { useDashboardStore } from '@/stores/dashboard';
 import { useStorageSecurityStore } from '@/stores/storage-security';
+import { useBrowserPackNoticeStore } from '@/stores/browser-pack-notice';
 import { useBrowserStore } from '@/stores/browser';
 import { useExplorerStore } from '@/stores/explorer';
 import { useZoomStore } from '@/stores/zoom';
@@ -58,6 +59,9 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
     zoomFactor: partial.zoomFactor ?? useZoomStore.getState().factor,
     storageWarningDismissed: partial.storageWarningDismissed
       ?? useStorageSecurityStore.getState().bannerDismissed,
+    browserPackNoticeVersion: partial.browserPackNoticeVersion
+      ?? useBrowserPackNoticeStore.getState().notifiedVersion
+      ?? undefined,
     activeSessionId: partial.activeSessionId !== undefined
       ? partial.activeSessionId
       : sess.activeSessionId,

--- a/apps/desktop/src/stores/app/layout-hydration.test.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useDashboardStore } from '@/stores/dashboard';
 import { useNavigationStore } from '@/stores/navigation';
 import { useStorageSecurityStore } from '@/stores/storage-security';
+import { useBrowserPackNoticeStore } from '@/stores/browser-pack-notice';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAppStore } from './state';
 import { loadLayout } from './layout-hydration';
@@ -27,6 +28,7 @@ describe('layout hydration', () => {
   const initialAppState = useAppStore.getState();
   const initialNavigationState = useNavigationStore.getState();
   const initialStorageSecurityState = useStorageSecurityStore.getState();
+  const initialBrowserPackNoticeState = useBrowserPackNoticeStore.getState();
   const initialWorkspaceState = useWorkspaceStore.getState();
 
   afterEach(() => {
@@ -34,6 +36,7 @@ describe('layout hydration', () => {
     useAppStore.setState(initialAppState, true);
     useNavigationStore.setState(initialNavigationState, true);
     useStorageSecurityStore.setState(initialStorageSecurityState, true);
+    useBrowserPackNoticeStore.setState(initialBrowserPackNoticeState, true);
     useWorkspaceStore.setState(initialWorkspaceState, true);
     Reflect.deleteProperty(window, 'sero');
   });
@@ -122,6 +125,27 @@ describe('layout hydration', () => {
       }],
       index: 0,
     });
+  });
+
+  it('restores the browser pack version that already showed an update notice', async () => {
+    Reflect.set(window, 'sero', {
+      layout: {
+        load: vi.fn(async () => ({
+          mainSidebarOpen: true,
+          chatPanelOpen: true,
+          favouriteApps: [],
+          browserPackNoticeVersion: 'browser-pack-2026-08-24',
+        })),
+      },
+      dashboard: {
+        getBackground: vi.fn(async () => null),
+        onBackgroundChanged: vi.fn(() => () => undefined),
+      },
+    });
+
+    await loadLayout();
+
+    expect(useBrowserPackNoticeStore.getState().notifiedVersion).toBe('browser-pack-2026-08-24');
   });
 
   it('persists an app preference outside the workspace scope', async () => {

--- a/apps/desktop/src/stores/app/layout-hydration.test.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.test.ts
@@ -145,7 +145,10 @@ describe('layout hydration', () => {
 
     await loadLayout();
 
-    expect(useBrowserPackNoticeStore.getState().notifiedVersion).toBe('browser-pack-2026-08-24');
+    expect(useBrowserPackNoticeStore.getState()).toMatchObject({
+      hydrated: true,
+      notifiedVersion: 'browser-pack-2026-08-24',
+    });
   });
 
   it('persists an app preference outside the workspace scope', async () => {

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -9,6 +9,7 @@ import { useAgentBoardStore } from '@/stores/agent-board';
 import { seedNavigationHistory } from '@/stores/navigation';
 import { hydrateZoom } from '@/stores/zoom';
 import { useStorageSecurityStore } from '@/stores/storage-security';
+import { useBrowserPackNoticeStore } from '@/stores/browser-pack-notice';
 import { useNodesStore } from '@/stores/nodes';
 import { normaliseChromeShortcuts, normaliseFavouriteApps } from './shared';
 import type { AppState } from './state';
@@ -24,6 +25,7 @@ function isGlobalApp(state: AppState, appId: string): boolean {
 /** Load layout state from disk and hydrate all stores. */
 export async function loadLayout(): Promise<void> {
   let storageWarningDismissed = false;
+  let browserPackNoticeVersion: string | undefined;
   try {
     const dashboardApi = window.sero.dashboard;
     let backgroundChangedDuringLoad = false;
@@ -47,6 +49,9 @@ export async function loadLayout(): Promise<void> {
       useDashboardStore.getState().setBackgroundImage(backgroundImage);
     }
     storageWarningDismissed = state?.storageWarningDismissed === true;
+    browserPackNoticeVersion = typeof state?.browserPackNoticeVersion === 'string'
+      ? state.browserPackNoticeVersion
+      : undefined;
     if (state) {
       const favouriteApps = normaliseFavouriteApps(state.favouriteApps);
       const update: Partial<AppState> & { layoutReady: true } = {
@@ -147,6 +152,7 @@ export async function loadLayout(): Promise<void> {
     const storageSecurity = useStorageSecurityStore.getState();
     storageSecurity.hydrateDismissed(storageWarningDismissed);
     void storageSecurity.check();
+    useBrowserPackNoticeStore.getState().hydrate(browserPackNoticeVersion);
   }
 
   useAppStore.setState({ layoutReady: true });

--- a/apps/desktop/src/stores/browser-pack-notice.test.ts
+++ b/apps/desktop/src/stores/browser-pack-notice.test.ts
@@ -18,6 +18,7 @@ const updateStatus = {
 describe('browser pack update notice', () => {
   afterEach(() => {
     useBrowserPackNoticeStore.setState({
+      hydrated: false,
       notifiedVersion: null,
       status: null,
       visible: false,
@@ -30,6 +31,7 @@ describe('browser pack update notice', () => {
     Reflect.set(window, 'sero', {
       workspace: { getBrowserPackStatus: vi.fn(async () => updateStatus) },
     });
+    useBrowserPackNoticeStore.getState().hydrate(undefined);
 
     await useBrowserPackNoticeStore.getState().check();
 
@@ -55,10 +57,22 @@ describe('browser pack update notice', () => {
         })),
       },
     });
+    useBrowserPackNoticeStore.getState().hydrate(undefined);
 
     await useBrowserPackNoticeStore.getState().check();
 
     expect(useBrowserPackNoticeStore.getState().visible).toBe(false);
     expect(persistLayout).not.toHaveBeenCalled();
+  });
+
+  it('does not check or persist before layout hydration', async () => {
+    const getBrowserPackStatus = vi.fn(async () => updateStatus);
+    Reflect.set(window, 'sero', { workspace: { getBrowserPackStatus } });
+
+    await useBrowserPackNoticeStore.getState().check();
+
+    expect(getBrowserPackStatus).not.toHaveBeenCalled();
+    expect(persistLayout).not.toHaveBeenCalled();
+    expect(useBrowserPackNoticeStore.getState().visible).toBe(false);
   });
 });

--- a/apps/desktop/src/stores/browser-pack-notice.test.ts
+++ b/apps/desktop/src/stores/browser-pack-notice.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const persistLayout = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/persist-layout', () => ({ persistLayout }));
+
+import { useBrowserPackNoticeStore } from './browser-pack-notice';
+
+const updateStatus = {
+  state: 'installable' as const,
+  manifestVersion: 'browser-pack-current',
+  previousManifestVersion: 'browser-pack-previous',
+  artifactKey: 'browser-darwin-arm64',
+};
+
+describe('browser pack update notice', () => {
+  afterEach(() => {
+    useBrowserPackNoticeStore.setState({
+      notifiedVersion: null,
+      status: null,
+      visible: false,
+    });
+    persistLayout.mockReset();
+    Reflect.deleteProperty(window, 'sero');
+  });
+
+  it('shows and records each browser pack update once', async () => {
+    Reflect.set(window, 'sero', {
+      workspace: { getBrowserPackStatus: vi.fn(async () => updateStatus) },
+    });
+
+    await useBrowserPackNoticeStore.getState().check();
+
+    expect(useBrowserPackNoticeStore.getState()).toMatchObject({
+      notifiedVersion: updateStatus.manifestVersion,
+      visible: true,
+    });
+    expect(persistLayout).toHaveBeenCalledWith({
+      browserPackNoticeVersion: updateStatus.manifestVersion,
+    });
+
+    useBrowserPackNoticeStore.getState().dismiss();
+    await useBrowserPackNoticeStore.getState().check();
+    expect(useBrowserPackNoticeStore.getState().visible).toBe(false);
+  });
+
+  it('does not announce a first browser pack install as an update', async () => {
+    Reflect.set(window, 'sero', {
+      workspace: {
+        getBrowserPackStatus: vi.fn(async () => ({
+          ...updateStatus,
+          previousManifestVersion: undefined,
+        })),
+      },
+    });
+
+    await useBrowserPackNoticeStore.getState().check();
+
+    expect(useBrowserPackNoticeStore.getState().visible).toBe(false);
+    expect(persistLayout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/stores/browser-pack-notice.ts
+++ b/apps/desktop/src/stores/browser-pack-notice.ts
@@ -3,6 +3,7 @@ import { persistLayout } from '@/lib/persist-layout';
 import type { BrowserPackStatusIPC } from '@sero-ai/common';
 
 interface BrowserPackNoticeState {
+  hydrated: boolean;
   notifiedVersion: string | null;
   status: BrowserPackStatusIPC | null;
   visible: boolean;
@@ -12,13 +13,18 @@ interface BrowserPackNoticeState {
 }
 
 export const useBrowserPackNoticeStore = create<BrowserPackNoticeState>((set, get) => ({
+  hydrated: false,
   notifiedVersion: null,
   status: null,
   visible: false,
 
-  hydrate: (notifiedVersion) => set({ notifiedVersion: notifiedVersion ?? null }),
+  hydrate: (notifiedVersion) => set({
+    hydrated: true,
+    notifiedVersion: notifiedVersion ?? null,
+  }),
 
   check: async () => {
+    if (!get().hydrated) return;
     try {
       const status = await window.sero.workspace.getBrowserPackStatus();
       const isUpdate = status.state === 'installable'

--- a/apps/desktop/src/stores/browser-pack-notice.ts
+++ b/apps/desktop/src/stores/browser-pack-notice.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+import { persistLayout } from '@/lib/persist-layout';
+import type { BrowserPackStatusIPC } from '@sero-ai/common';
+
+interface BrowserPackNoticeState {
+  notifiedVersion: string | null;
+  status: BrowserPackStatusIPC | null;
+  visible: boolean;
+  hydrate: (notifiedVersion: string | undefined) => void;
+  check: () => Promise<void>;
+  dismiss: () => void;
+}
+
+export const useBrowserPackNoticeStore = create<BrowserPackNoticeState>((set, get) => ({
+  notifiedVersion: null,
+  status: null,
+  visible: false,
+
+  hydrate: (notifiedVersion) => set({ notifiedVersion: notifiedVersion ?? null }),
+
+  check: async () => {
+    try {
+      const status = await window.sero.workspace.getBrowserPackStatus();
+      const isUpdate = status.state === 'installable'
+        && typeof status.previousManifestVersion === 'string';
+      if (!isUpdate || get().notifiedVersion === status.manifestVersion) {
+        set({ status, visible: false });
+        return;
+      }
+
+      set({
+        notifiedVersion: status.manifestVersion,
+        status,
+        visible: true,
+      });
+      persistLayout({ browserPackNoticeVersion: status.manifestVersion });
+    } catch {
+      set({ visible: false });
+    }
+  },
+
+  dismiss: () => set({ visible: false }),
+}));

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -78,6 +78,8 @@ export interface LayoutState {
    * condition never becomes invisible.
    */
   storageWarningDismissed?: boolean;
+  /** Last browser pack version announced in the one-time update notice. */
+  browserPackNoticeVersion?: string;
   /** Hidden model keys ("provider/modelId"). */
   hiddenModels?: string[];
   /** Provider IDs entirely hidden from the model selector. */

--- a/apps/docs-site/docs/reference/troubleshooting.md
+++ b/apps/docs-site/docs/reference/troubleshooting.md
@@ -122,7 +122,7 @@ Common Doctor results and next actions:
 | --- | --- |
 | Host core tools missing | Use onboarding or Runtime settings to install Sero-managed core tools, or confirm Node, pnpm, Git/SSH, and your shell are available on `PATH`. |
 | Managed tools still installing | Wait for the install to finish, then rerun Doctor. |
-| Browser pack missing but installable | Use the in-app install action if offered, then rerun Doctor. |
+| Browser pack missing but installable | Open **Admin → Settings → Settings**, then install or update the browser pack under **Runtime diagnostics**. Rerun Doctor after the install finishes. |
 | Browser pack failed | Check disk space and network access, then rerun Doctor. Include the report if it still fails. |
 | Browser pack unavailable for your platform | Use a container runtime for browser automation, or move to a supported platform. |
 | Native build tools missing | Install your platform compiler stack, or use a container runtime when you need image-provided tools. |

--- a/packages/common/src/admin-bridge.ts
+++ b/packages/common/src/admin-bridge.ts
@@ -324,6 +324,7 @@ export interface BrowserPackProgressIPC {
 export interface BrowserPackStatusIPC {
   state: 'ready' | 'missing' | 'installable' | 'installing' | 'failed';
   manifestVersion: string;
+  previousManifestVersion?: string;
   artifactKey?: string;
   browsersPath?: string;
   progress?: BrowserPackProgressIPC;

--- a/plugins/sero-admin-plugin/ui/AdminApp.tsx
+++ b/plugins/sero-admin-plugin/ui/AdminApp.tsx
@@ -36,6 +36,26 @@ import { SkillEditor } from './components/SkillEditor';
 import { SkillList } from './components/SkillList';
 import './styles.css';
 
+interface AdminLaunchParams extends Record<string, unknown> {
+  agentPluginId?: unknown;
+  section?: unknown;
+  configKey?: unknown;
+}
+
+function readAdminLaunchParams(): {
+  agentPluginId: string | null;
+  section: AdminSection | null;
+  configKey: string | null;
+} {
+  const params = consumeAppLaunchParams<AdminLaunchParams>('admin');
+  const section = params?.section;
+  return {
+    agentPluginId: typeof params?.agentPluginId === 'string' ? params.agentPluginId : null,
+    section: section === 'settings' ? section : null,
+    configKey: typeof params?.configKey === 'string' ? params.configKey : null,
+  };
+}
+
 function normalizeSection(section: AdminState['lastSection'] | 'modelDefaults' | null | undefined): AdminSection {
   if (section === 'modelDefaults') return 'model';
   return section ?? 'agents';
@@ -43,10 +63,7 @@ function normalizeSection(section: AdminState['lastSection'] | 'modelDefaults' |
 
 export function AdminApp() {
   const [state, updateState] = useAppState<AdminState>(DEFAULT_STATE);
-  const [linkedAgentPluginId, setLinkedAgentPluginId] = useState<string | null>(() => {
-    const params = consumeAppLaunchParams<{ agentPluginId?: unknown }>('admin');
-    return typeof params?.agentPluginId === 'string' ? params.agentPluginId : null;
-  });
+  const [launchParams, setLaunchParams] = useState(readAdminLaunchParams);
   const { activeProfile, loading: profilesLoading } = useProfiles();
 
   const [resourceLoading, setResourceLoading] = useState(true);
@@ -69,16 +86,21 @@ export function AdminApp() {
 
   const profilePath = activeProfile?.path ?? null;
   const profileName = activeProfile?.name ?? null;
-  const activeSection = linkedAgentPluginId
+  const activeSection = launchParams.agentPluginId
     ? 'plugins'
-    : normalizeSection(state.lastSection as AdminState['lastSection'] | 'modelDefaults' | null | undefined);
-  const selectedConfigKey = state.lastConfigKey;
+    : launchParams.section
+      ?? normalizeSection(state.lastSection as AdminState['lastSection'] | 'modelDefaults' | null | undefined);
+  const selectedConfigKey = launchParams.configKey ?? state.lastConfigKey;
   const selectedSessionId = state.lastSessionFile;
   const skillVisibility = useSkillVisibility(profilePath);
 
   useEffect(() => {
-    return onAppLaunchParams<{ agentPluginId?: unknown }>('admin', (params) => {
-      if (typeof params.agentPluginId === 'string') setLinkedAgentPluginId(params.agentPluginId);
+    return onAppLaunchParams<AdminLaunchParams>('admin', (params) => {
+      setLaunchParams({
+        agentPluginId: typeof params.agentPluginId === 'string' ? params.agentPluginId : null,
+        section: params.section === 'settings' ? params.section : null,
+        configKey: typeof params.configKey === 'string' ? params.configKey : null,
+      });
     });
   }, []);
 
@@ -131,11 +153,12 @@ export function AdminApp() {
 
   const handleSectionChange = useCallback((section: AdminSection) => {
     setError(null);
-    setLinkedAgentPluginId(null);
+    setLaunchParams({ agentPluginId: null, section: null, configKey: null });
     updateState((prev) => ({ ...prev, lastSection: section }));
   }, [updateState]);
 
   const handleSelectConfig = useCallback((key: string) => {
+    setLaunchParams((current) => ({ ...current, configKey: null }));
     updateState((prev) => ({ ...prev, lastConfigKey: key }));
   }, [updateState]);
 
@@ -295,7 +318,7 @@ export function AdminApp() {
         return <ModelPanel />;
 
       case 'plugins':
-        return <PluginsPanel focusedAgentPluginId={linkedAgentPluginId} />;
+        return <PluginsPanel focusedAgentPluginId={launchParams.agentPluginId} />;
 
       case 'logs':
         return <LogViewer />;

--- a/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.test.tsx
+++ b/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { BrowserPackStatusIPC, ToolchainProgressIPC, ToolchainStatusIPC } from '../../hooks/host';
+import { InstallDetail } from './RuntimeInstallControls';
+
+const readyBrowserStatus: BrowserPackStatusIPC = {
+  state: 'ready',
+  manifestVersion: 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.27.3',
+};
+
+describe('runtime install details', () => {
+  it('shows update versions instead of the required-pack error', () => {
+    const browserStatus: BrowserPackStatusIPC = {
+      state: 'installable',
+      manifestVersion: 'browser-pack-2026-08-24-r1234-f1011-mf1011-agent-0.27.3',
+      previousManifestVersion: 'browser-pack-2026-08-23-r1233-f1011-mf1011-agent-0.27.2',
+      error: {
+        code: 'BROWSER_PACK_REQUIRED',
+        message: 'Host browser automation pack is not installed.',
+        retryable: true,
+        installable: true,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      <InstallDetail
+        coreStatus={null}
+        browserStatus={browserStatus}
+        error={null}
+      />,
+    );
+
+    expect(html).toContain('Update available from');
+    expect(html).not.toContain('Host browser automation pack is not installed.');
+  });
+
+  it('shows core install progress when the browser pack is ready', () => {
+    const coreStatus: ToolchainStatusIPC = {
+      state: 'installing',
+      tools: [],
+    };
+    const coreProgress: ToolchainProgressIPC = {
+      tool: 'node',
+      phase: 'downloading',
+      artifactKey: 'node-darwin-arm64',
+      manifestVersion: 'toolchain-2026-08-24',
+    };
+
+    const html = renderToStaticMarkup(
+      <InstallDetail
+        coreStatus={coreStatus}
+        browserStatus={readyBrowserStatus}
+        coreProgress={coreProgress}
+        error={null}
+      />,
+    );
+
+    expect(html).toContain('Install progress: downloading');
+    expect(html).not.toContain('is installed.');
+  });
+});

--- a/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.tsx
+++ b/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.tsx
@@ -168,7 +168,7 @@ export function RuntimeInstallControls({ disabled = false, onChanged }: RuntimeI
   );
 }
 
-function InstallDetail(props: {
+export function InstallDetail(props: {
   coreStatus: ToolchainStatusIPC | null;
   browserStatus: BrowserPackStatusIPC | null;
   coreProgress?: ToolchainProgressIPC;
@@ -188,13 +188,6 @@ function InstallDetail(props: {
       </p>
     );
   }
-  if (failure) {
-    return (
-      <p className="border-t border-border/40 px-3 py-2 text-destructive">
-        {failure.message} {failure.retryable && failure.installable ? 'Retry is available.' : 'Manual setup may be required.'}
-      </p>
-    );
-  }
   if (props.browserStatus?.state === 'installable' && props.browserStatus.previousManifestVersion) {
     return (
       <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">
@@ -202,16 +195,23 @@ function InstallDetail(props: {
       </p>
     );
   }
-  if (props.browserStatus?.state === 'ready') {
+  if (failure) {
     return (
-      <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">
-        {props.browserStatus.manifestVersion} is installed.
+      <p className="border-t border-border/40 px-3 py-2 text-destructive">
+        {failure.message} {failure.retryable && failure.installable ? 'Retry is available.' : 'Manual setup may be required.'}
       </p>
     );
   }
   if (progress && progress.phase !== 'ready') {
     const bytes = progress.bytesTotal ? ` (${progress.bytesReceived ?? 0}/${progress.bytesTotal} bytes)` : '';
     return <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">Install progress: {progress.phase}{bytes}</p>;
+  }
+  if (props.browserStatus?.state === 'ready') {
+    return (
+      <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">
+        {props.browserStatus.manifestVersion} is installed.
+      </p>
+    );
   }
   return null;
 }

--- a/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.tsx
+++ b/plugins/sero-admin-plugin/ui/components/runtime/RuntimeInstallControls.tsx
@@ -108,6 +108,8 @@ export function RuntimeInstallControls({ disabled = false, onChanged }: RuntimeI
     && browserStatus.state !== 'missing'
     && browserStatus.state !== 'installing'
     && (browserStatus.state !== 'failed' || browserRetryable);
+  const browserUpdateAvailable = browserStatus?.state === 'installable'
+    && typeof browserStatus.previousManifestVersion === 'string';
 
   return (
     <div className="border-t border-border/40 text-sm">
@@ -138,7 +140,13 @@ export function RuntimeInstallControls({ disabled = false, onChanged }: RuntimeI
             </Badge>
             {showBrowserInstall ? (
               <Button size="sm" variant="outline" className="h-7 px-2 text-sm" disabled={disabled || busy !== null} onClick={installBrowser}>
-                {busy === 'browser' ? 'Installing…' : browserStatus.state === 'failed' ? 'Retry browser pack' : 'Install browser pack'}
+                {busy === 'browser'
+                  ? 'Installing…'
+                  : browserStatus.state === 'failed'
+                    ? 'Retry browser pack'
+                    : browserUpdateAvailable
+                      ? 'Update browser pack'
+                      : 'Install browser pack'}
               </Button>
             ) : null}
             {browserStatus?.state === 'ready' ? (
@@ -184,6 +192,20 @@ function InstallDetail(props: {
     return (
       <p className="border-t border-border/40 px-3 py-2 text-destructive">
         {failure.message} {failure.retryable && failure.installable ? 'Retry is available.' : 'Manual setup may be required.'}
+      </p>
+    );
+  }
+  if (props.browserStatus?.state === 'installable' && props.browserStatus.previousManifestVersion) {
+    return (
+      <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">
+        Update available from {props.browserStatus.previousManifestVersion} to {props.browserStatus.manifestVersion}.
+      </p>
+    );
+  }
+  if (props.browserStatus?.state === 'ready') {
+    return (
+      <p className="border-t border-border/40 px-3 py-2 text-muted-foreground/70">
+        {props.browserStatus.manifestVersion} is installed.
       </p>
     );
   }


### PR DESCRIPTION
## Summary

- Show one dismissible browser pack update notice for each new pack version.
- Open the exact Admin runtime settings page from the notice.
- Distinguish browser pack updates from first-time installs and show both versions.
- Document the browser pack install and update path.

## Validation

- `pnpm typecheck`
- Desktop focused tests: 24 passed
- Admin plugin tests: 27 passed
- Docs build
- React Doctor: 83/100, no issues found
- `git diff --check`