### PR TITLE
feat(worktree): reuse lease pool slots safely

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,14 @@ backend. Runtime-specific capability limits must remain visible to callers.
   disposition is intent: the host classifies the checkout and preserves work
   it cannot prove disposable. Repository identity is the canonical Git common
   directory, which is also where the pool state and its two lock domains live,
-  so every workspace registration of one repository shares one authority. See
+  so every workspace registration of one repository shares one authority.
+  Reusable slots are detached at an exact prepared commit and retain ignored
+  caches. Before reset or removal, process owners stop Sero terminals, sessions,
+  commands, and managed dev servers, then a platform adapter proves no process
+  remains rooted in the checkout. Detection supports macOS and Linux through
+  `lsof`; unsupported Windows hosts and all detection failures preserve the
+  checkout. The pool retains two proved-safe idle slots per repository, has no
+  active-lease cap, and never evicts leased or unproved work. See
   `apps/desktop/electron/features/git/worktree/README.md`.
 - Managed tools install once per machine under the host-artifacts root. Tool
   resolution uses a verified system tool first, a verified managed tool second,

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/disposability.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/disposability.test.ts
@@ -1,0 +1,83 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+import { acquireWorktree } from '@electron/features/git/worktree/pool/acquire';
+import {
+  classifyDisposability,
+  type PullRequestEvidenceProvider,
+} from '@electron/features/git/worktree/pool/disposability';
+import { openPool } from '@electron/features/git/worktree/pool/session';
+import type { PoolSlot } from '@electron/features/git/worktree/pool/types';
+import { git, newWorkspaceRepo, removeWorkspaceRepos } from '../worktree-test-helpers';
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+function evidence(state: 'open' | 'closed' | 'merged' | 'unknown'): PullRequestEvidenceProvider {
+  return { forBranch: async (_workspace, _branch, knownNumber) => ({ number: knownNumber ?? 17, state }) };
+}
+
+async function slotWithCommit(
+  holder: string,
+  existingBranch?: string,
+  pullRequestNumber?: number,
+): Promise<{ workspace: string; slot: PoolSlot }> {
+  const { workspace } = await newWorkspaceRepo('sero-disposal-');
+  if (existingBranch) await git(workspace, 'branch', existingBranch, 'main');
+  const result = await acquireWorktree(workspace, {
+    holder,
+    title: 'Change parser',
+    existingBranch,
+    pullRequestNumber,
+  });
+  if (result.status !== 'acquired') throw new Error(result.reason);
+  await writeFile(path.join(result.lease.worktreePath, `${holder}.md`), 'change');
+  await git(result.lease.worktreePath, 'add', '.');
+  await git(result.lease.worktreePath, 'commit', '-m', `change ${holder}`);
+  const opened = await openPool(workspace);
+  if (opened.status !== 'ok') throw new Error(opened.reason);
+  const slot = opened.session.state.slots.find((candidate) => candidate.slotId === result.lease.slotId);
+  if (!slot) throw new Error('slot missing');
+  return { workspace, slot };
+}
+
+afterAll(removeWorkspaceRepos);
+
+describe('branch disposability', () => {
+  it('accepts a merge commit only when the exact target contains the branch tip', async () => {
+    const { workspace, slot } = await slotWithCommit('merge-r1');
+    await git(workspace, 'merge', '--no-ff', '-m', 'merge feature', slot.branchName as string);
+    const target = await git(workspace, 'rev-parse', 'HEAD');
+
+    const result = await classifyDisposability(workspace, slot, target, evidence('unknown'));
+    expect(result).toMatchObject({ status: 'disposable' });
+    expect(result.reason).toContain('contained');
+  });
+
+  it('classifies squash, rebase, open, closed, and local-unmerged evidence from one branch', async () => {
+    const { workspace, slot } = await slotWithCommit('pr-evidence-r1', undefined, 42);
+    const target = await git(workspace, 'rev-parse', 'main');
+
+    const authoritative = await classifyDisposability(workspace, slot, target, evidence('merged'));
+    expect(authoritative).toMatchObject({ status: 'disposable' });
+    expect(authoritative.reason).toContain('including squash or rebase merges');
+    for (const state of ['open', 'closed'] as const) {
+      const result = await classifyDisposability(workspace, slot, target, evidence(state));
+      expect(result.status).toBe('unmerged');
+      expect(result.reason).toContain(state);
+    }
+    const local = await classifyDisposability(workspace, slot, target, evidence('unknown'));
+    expect(local.status).toBe('unmerged');
+    expect(local.reason).toContain('no merged PR');
+  });
+
+  it('requires authoritative merged evidence for an external PR checkout', async () => {
+    const { workspace, slot } = await slotWithCommit('external-r1', 'contributor/topic', 55);
+    const target = await git(workspace, 'rev-parse', 'main');
+
+    expect(await classifyDisposability(workspace, slot, target, evidence('open')))
+      .toMatchObject({ status: 'unmerged' });
+    expect(await classifyDisposability(workspace, slot, target, evidence('merged')))
+      .toMatchObject({ status: 'disposable' });
+  });
+});

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/fetch-concurrency.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/fetch-concurrency.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const tracker = vi.hoisted(() => ({
+  active: 0,
+  maximum: 0,
+  releases: [] as Array<() => void>,
+}));
+
+vi.mock('@electron/features/git/worktree/exec', () => ({
+  execWorktreeGit: vi.fn(async () => new Promise<{ stdout: string; stderr: string }>((resolve) => {
+    tracker.active += 1;
+    tracker.maximum = Math.max(tracker.maximum, tracker.active);
+    tracker.releases.push(() => {
+      tracker.active -= 1;
+      resolve({ stdout: '', stderr: '' });
+    });
+  })),
+}));
+
+import { fetchBranchBestEffort } from '@electron/features/git/worktree/provision';
+
+describe('fetch concurrency', () => {
+  it('allows independent fetches to overlap outside the Git mutation gate', async () => {
+    const first = fetchBranchBestEffort('/repo', 'feature-a');
+    const second = fetchBranchBestEffort('/repo', 'feature-b');
+    await until(() => tracker.releases.length === 2);
+    expect(tracker.maximum).toBe(2);
+    for (const release of tracker.releases.splice(0)) release();
+    await Promise.all([first, second]);
+  });
+});
+
+async function until(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error('condition did not become true');
+}

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/lease-lifecycle.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/lease-lifecycle.test.ts
@@ -187,7 +187,7 @@ describe('release fencing', () => {
     expect(await git(workspace, 'rev-parse', '--verify', `refs/heads/${lease.branchName}`)).toBeTruthy();
   });
 
-  it('removes a clean no-op checkout and deletes only its merged local branch', async () => {
+  it('recycles a clean no-op checkout and deletes only its proved-disposable local branch', async () => {
     const workspace = await newWorkspace();
     const lease = await acquireOrThrow(workspace, 'loop-5-r1');
 
@@ -199,7 +199,8 @@ describe('release fencing', () => {
     });
 
     expect(outcome.status).toBe('released');
-    expect(await exists(lease.worktreePath)).toBe(false);
+    expect(await exists(lease.worktreePath)).toBe(true);
+    expect(await git(lease.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('HEAD');
     await expect(git(workspace, 'rev-parse', '--verify', `refs/heads/${lease.branchName}`)).rejects.toThrow();
   });
 
@@ -368,6 +369,6 @@ describe('a workspace reached through a symlink', () => {
       disposition: 'recycle',
     });
     expect(released.status).toBe('released');
-    expect(await exists(acquired.lease.worktreePath)).toBe(false);
+    expect(await exists(acquired.lease.worktreePath)).toBe(true);
   });
 });

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/locks.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/locks.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { withGitMutationGate } from '@electron/features/git/worktree/pool/locks';
+
+const roots: string[] = [];
+
+afterAll(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('Git mutation gate', () => {
+  it('does not overlap conflicting registration mutations', async () => {
+    const poolDir = await mkdtemp(path.join(os.tmpdir(), 'sero-git-gate-'));
+    roots.push(poolDir);
+    const events: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const holdFirst = new Promise<void>((resolve) => { releaseFirst = resolve; });
+
+    const first = withGitMutationGate(poolDir, async () => {
+      events.push('first-enter');
+      await holdFirst;
+      events.push('first-leave');
+    });
+    await until(() => events.includes('first-enter'));
+    const second = withGitMutationGate(poolDir, async () => { events.push('second-enter'); });
+    await Promise.resolve();
+    expect(events).toEqual(['first-enter']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-enter', 'first-leave', 'second-enter']);
+  });
+});
+
+async function until(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error('condition did not become true');
+}

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/process-guard.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/process-guard.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SeroOwnedProcessRegistry } from '@electron/features/git/worktree/pool/owned-processes';
+import {
+  parseLsofFields,
+  LsofProcessDetector,
+  WorktreeProcessGuard,
+  type SlotProcessDetector,
+} from '@electron/features/git/worktree/pool/process-guard';
+
+function detector(
+  detect: SlotProcessDetector['detect'],
+  platform: NodeJS.Platform = 'linux',
+): SlotProcessDetector {
+  return { platform, detect };
+}
+
+describe('worktree process guard', () => {
+  it('confirms Sero-owned shutdown before platform detection starts', async () => {
+    const events: string[] = [];
+    const owned = new SeroOwnedProcessRegistry();
+    owned.register({
+      id: 'terminal-1',
+      kind: 'terminal',
+      cwd: '/repo/slot-1/subdir',
+      stop: async () => { events.push('owned-stopped'); },
+    });
+    const guard = new WorktreeProcessGuard({
+      owned,
+      detector: detector(async () => {
+        events.push('detected');
+        return { status: 'clear' };
+      }),
+    });
+
+    await expect(guard.prepare('/repo/slot-1')).resolves.toEqual({ status: 'safe', stoppedOwned: 1 });
+    expect(events).toEqual(['owned-stopped', 'detected']);
+  });
+
+  it('blocks on a foreign process without terminating it', async () => {
+    const owned = new SeroOwnedProcessRegistry();
+    const stop = vi.fn(async () => undefined);
+    owned.register({ id: 'outside', kind: 'command', cwd: '/elsewhere', stop });
+    const guard = new WorktreeProcessGuard({
+      owned,
+      detector: detector(async () => ({
+        status: 'in-use',
+        processes: [{ pid: 41, command: 'node' }],
+      })),
+    });
+
+    const result = await guard.prepare('/repo/slot-1');
+    expect(result.status).toBe('in-use');
+    if (result.status !== 'in-use') throw new Error('expected in-use');
+    expect(result.reason).toContain('Foreign processes were not terminated');
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when detection or owned shutdown cannot be confirmed', async () => {
+    const owned = new SeroOwnedProcessRegistry();
+    owned.register({
+      id: 'session-1',
+      kind: 'agent-session',
+      cwd: '/repo/slot-1',
+      stop: async () => { throw new Error('abort timed out'); },
+    });
+    const detect = vi.fn(async () => ({ status: 'clear' as const }));
+    const shutdownFailure = await new WorktreeProcessGuard({ owned, detector: detector(detect) })
+      .prepare('/repo/slot-1');
+    expect(shutdownFailure).toMatchObject({ status: 'unverifiable' });
+    expect(detect).not.toHaveBeenCalled();
+
+    const detectionFailure = await new WorktreeProcessGuard({
+      owned: new SeroOwnedProcessRegistry(),
+      detector: detector(async () => ({ status: 'unverifiable', reason: 'permission denied' })),
+    }).prepare('/repo/slot-1');
+    expect(detectionFailure).toEqual({ status: 'unverifiable', reason: 'permission denied' });
+  });
+
+  it('turns an unconfirmed owned shutdown into bounded unverifiable backpressure', async () => {
+    const owned = new SeroOwnedProcessRegistry();
+    owned.register({
+      id: 'server-1',
+      kind: 'managed-dev-server',
+      cwd: '/repo/slot-1',
+      stop: () => new Promise<void>(() => undefined),
+    });
+    const result = await new WorktreeProcessGuard({
+      owned,
+      detector: detector(async () => ({ status: 'clear' })),
+      ownedShutdownTimeoutMs: 1,
+    }).prepare('/repo/slot-1');
+    expect(result).toMatchObject({ status: 'unverifiable' });
+  });
+
+  it('fails closed on unsupported platforms and parses adapter records deterministically', async () => {
+    const unsupported = await new LsofProcessDetector('win32').detect('/repo/slot-1');
+    expect(unsupported.status).toBe('unverifiable');
+    expect(parseLsofFields('p12\ncnode\np19\ncbash\n')).toEqual([
+      { pid: 12, command: 'node' },
+      { pid: 19, command: 'bash' },
+    ]);
+  });
+});

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/reconcile.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/reconcile.test.ts
@@ -83,6 +83,9 @@ async function interrupt(
           startedAt: '2026-01-01T00:00:00.000Z',
           intendedState: transition === 'provisioning' ? ('leased' as const) : ('available' as const),
           leaseId: slot.lease?.leaseId ?? null,
+          resetTarget: transition === 'recycling'
+            ? { ref: 'main', commit: slot.lease?.baseCommit ?? 'unknown-commit' }
+            : null,
         },
         updatedAt: '2026-01-01T00:00:00.000Z',
       }

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/reuse-reset.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/reuse-reset.test.ts
@@ -1,0 +1,268 @@
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+import { acquireWorktree } from '@electron/features/git/worktree/pool/acquire';
+import type { PullRequestEvidenceProvider } from '@electron/features/git/worktree/pool/disposability';
+import { SeroOwnedProcessRegistry } from '@electron/features/git/worktree/pool/owned-processes';
+import { WorktreeProcessGuard, type ProcessDetectionResult } from '@electron/features/git/worktree/pool/process-guard';
+import { releaseWorktree, type ReleaseWorktreeDependencies } from '@electron/features/git/worktree/pool/release';
+import { openPool } from '@electron/features/git/worktree/pool/session';
+import type { PoolState } from '@electron/features/git/worktree/pool/types';
+import type { AppRuntimeWorktreeLease } from '@sero-ai/common';
+import { git, newWorkspaceRepo, removeWorkspaceRepos } from '../worktree-test-helpers';
+
+vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
+
+const clearGuard = guard({ status: 'clear' });
+const mergedPullRequest: PullRequestEvidenceProvider = {
+  forBranch: async (_workspace, _branch, knownNumber) => ({ number: knownNumber, state: 'merged' }),
+};
+
+function guard(result: ProcessDetectionResult): WorktreeProcessGuard {
+  return new WorktreeProcessGuard({
+    owned: new SeroOwnedProcessRegistry(),
+    detector: { platform: 'linux', detect: async () => result },
+  });
+}
+
+async function workspaceWithIgnores(): Promise<string> {
+  const { workspace } = await newWorkspaceRepo('sero-pool-reuse-');
+  await writeFile(path.join(workspace, '.gitignore'), 'node_modules/\ndist/\n');
+  await git(workspace, 'add', '.gitignore');
+  await git(workspace, 'commit', '-m', 'add ignores');
+  return workspace;
+}
+
+async function acquire(workspace: string, holder: string, existingBranch?: string): Promise<AppRuntimeWorktreeLease> {
+  const result = await acquireWorktree(workspace, { holder, title: 'Build parser', existingBranch }, { processGuard: clearGuard });
+  if (result.status !== 'acquired') throw new Error(result.reason);
+  return result.lease;
+}
+
+async function recycle(
+  workspace: string,
+  lease: AppRuntimeWorktreeLease,
+  dependencies: ReleaseWorktreeDependencies = {},
+) {
+  return releaseWorktree(workspace, {
+    slotId: lease.slotId,
+    expectedLeaseId: lease.leaseId,
+    disposition: 'recycle',
+  }, { processGuard: clearGuard, ...dependencies });
+}
+
+function statePath(workspace: string): string {
+  return path.join(workspace, '.git', 'sero-worktree-pool', 'pool.json');
+}
+
+afterAll(removeWorkspaceRepos);
+
+describe('cache-preserving reuse', () => {
+  it('treats a fresh-branch collision as recovery evidence instead of attaching a lease', async () => {
+    const workspace = await workspaceWithIgnores();
+    const branch = 'build/build-parser-collision-holder';
+    await git(workspace, 'branch', branch, 'main');
+
+    const result = await acquireWorktree(workspace, {
+      holder: 'collision-holder',
+      title: 'Build parser',
+    }, { processGuard: clearGuard });
+    expect(result.status).toBe('blocked');
+    if (result.status !== 'blocked') return;
+    expect(result.reason).toContain('reattachment or recovery evidence');
+    expect(await git(workspace, 'rev-parse', '--verify', `refs/heads/${branch}`)).toBeTruthy();
+  });
+
+  it('resets to the exact target, preserves ignored caches, and reuses the slot with a new lease', async () => {
+    const workspace = await workspaceWithIgnores();
+    const first = await acquire(workspace, 'workflow-r1');
+    const dependency = path.join(first.worktreePath, 'node_modules', 'pkg', 'cache.txt');
+    const output = path.join(first.worktreePath, 'dist', 'compiler.cache');
+    await mkdir(path.dirname(dependency), { recursive: true });
+    await mkdir(path.dirname(output), { recursive: true });
+    await writeFile(dependency, 'dependency cache');
+    await writeFile(output, 'compiler output');
+    const target = await git(workspace, 'rev-parse', 'main');
+
+    expect(await recycle(workspace, first)).toMatchObject({ status: 'released', checkout: 'removed' });
+    expect(await git(first.worktreePath, 'rev-parse', 'HEAD')).toBe(target);
+    expect(await git(first.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('HEAD');
+    expect(await git(first.worktreePath, 'status', '--porcelain', '--untracked-files=all')).toBe('');
+    expect(await readFile(dependency, 'utf8')).toBe('dependency cache');
+    expect(await readFile(output, 'utf8')).toBe('compiler output');
+
+    const second = await acquire(workspace, 'room-r1');
+    expect(second.slotId).toBe(first.slotId);
+    expect(second.leaseId).not.toBe(first.leaseId);
+    expect(second.branchName).toBe('build/build-parser-room-r1');
+    expect(await readFile(dependency, 'utf8')).toBe('dependency cache');
+
+    const delayed = await recycle(workspace, first);
+    expect(delayed.status).toBe('stale-lease');
+    expect(await git(second.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe(second.branchName);
+  });
+
+  it.each([
+    ['tracked modification', async (root: string) => writeFile(path.join(root, 'readme.md'), 'changed')],
+    ['non-ignored untracked file', async (root: string) => writeFile(path.join(root, 'notes.txt'), 'work')],
+  ])('preserves a checkout with a %s and reports why', async (_name, damage) => {
+    const workspace = await workspaceWithIgnores();
+    const lease = await acquire(workspace, 'workflow-r1');
+    await damage(lease.worktreePath);
+
+    const result = await recycle(workspace, lease);
+    expect(result.status).toBe('preserved');
+    expect(result.reason).toContain('tracked changes or non-ignored untracked files');
+    expect(await stat(lease.worktreePath)).toBeTruthy();
+  });
+
+  it('preserves the lease when a process is detected or detection fails', async () => {
+    const workspace = await workspaceWithIgnores();
+    const processStates: ProcessDetectionResult[] = [
+      { status: 'in-use' as const, processes: [{ pid: 99, command: 'node' }] },
+      { status: 'unverifiable' as const, reason: 'permission denied' },
+    ];
+    const leases = await Promise.all(processStates.map((processState) =>
+      acquire(workspace, `workflow-${processState.status}`),
+    ));
+    for (const [index, processState] of processStates.entries()) {
+      const lease = leases[index];
+      const result = await recycle(workspace, lease, { processGuard: guard(processState) });
+      expect(result.status).toBe(processState.status === 'in-use' ? 'preserved' : 'recovery-required');
+      expect(await stat(lease.worktreePath)).toBeTruthy();
+      const opened = await openPool(workspace);
+      if (opened.status !== 'ok') throw new Error(opened.reason);
+      expect(opened.session.state.slots.find((slot) => slot.slotId === lease.slotId)?.lease?.leaseId)
+        .toBe(lease.leaseId);
+    }
+  });
+
+  it.each([
+    {
+      name: 'dirty checkout',
+      damage: async (root: string, workspace: string) => {
+        await writeFile(path.join(root, 'unexpected.txt'), 'do not erase');
+        return { processGuard: clearGuard, expected: 'became dirty' };
+      },
+    },
+    {
+      name: 'detected process',
+      damage: async (_root: string, _workspace: string) => ({
+        processGuard: guard({ status: 'in-use', processes: [{ pid: 73, command: 'python' }] }),
+        expected: 'Foreign processes were not terminated',
+      }),
+    },
+    {
+      name: 'locked registration',
+      damage: async (root: string, workspace: string) => {
+        await git(workspace, 'worktree', 'lock', '--reason', 'still installing', root);
+        return { processGuard: clearGuard, expected: 'locked' };
+      },
+    },
+  ])('preserves an idle slot whose $name reuse proof fails and allocates elsewhere', async ({ damage }) => {
+    const workspace = await workspaceWithIgnores();
+    const first = await acquire(workspace, 'first-holder');
+    expect((await recycle(workspace, first)).status).toBe('released');
+    const proof = await damage(first.worktreePath, workspace);
+
+    const next = await acquireWorktree(workspace, {
+      holder: 'next-holder',
+      title: 'Build parser',
+    }, { processGuard: proof.processGuard });
+    expect(next.status).toBe('acquired');
+    if (next.status !== 'acquired') return;
+    expect(next.lease.slotId).not.toBe(first.slotId);
+    const opened = await openPool(workspace);
+    if (opened.status !== 'ok') throw new Error(opened.reason);
+    const preserved = opened.session.state.slots.find((slot) => slot.slotId === first.slotId);
+    expect(preserved?.state).not.toBe('available');
+    expect(preserved?.reason).toContain(proof.expected);
+    expect(await stat(first.worktreePath)).toBeTruthy();
+  });
+
+  it('never deletes an external pull-request branch after authoritative merge evidence', async () => {
+    const workspace = await workspaceWithIgnores();
+    await git(workspace, 'branch', 'contributor/topic', 'main');
+    const lease = await acquire(workspace, 'pr-r1', 'contributor/topic');
+    expect(await recycle(workspace, lease, { pullRequests: mergedPullRequest })).toMatchObject({ status: 'released' });
+    expect(await git(workspace, 'rev-parse', '--verify', 'refs/heads/contributor/topic')).toBeTruthy();
+    expect(await git(lease.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('HEAD');
+  });
+
+  it('retains two idle slots without limiting active Workflow or Room leases', async () => {
+    const workspace = await workspaceWithIgnores();
+    const leases = await Promise.all([
+      acquire(workspace, 'workflow-a'),
+      acquire(workspace, 'workflow-b'),
+      acquire(workspace, 'room-member-a'),
+      acquire(workspace, 'room-member-b'),
+      acquire(workspace, 'room-member-c'),
+    ]);
+    expect(new Set(leases.map((lease) => lease.slotId)).size).toBe(5);
+
+    const releases = [];
+    for (const lease of leases) releases.push(await recycle(workspace, lease));
+    expect(releases.every((result) => result.status === 'released')).toBe(true);
+    const opened = await openPool(workspace);
+    if (opened.status !== 'ok') throw new Error(opened.reason);
+    expect(opened.session.state.slots.filter((slot) => slot.state === 'available')).toHaveLength(2);
+    expect(opened.session.state.slots.filter((slot) => slot.state === 'leased')).toHaveLength(0);
+    expect(await stat(leases[4].worktreePath).catch(() => null)).toBeNull();
+  });
+});
+
+describe('transition fault fences', () => {
+  it('confirms Sero-owned shutdown and detection before reset starts', async () => {
+    const workspace = await workspaceWithIgnores();
+    const lease = await acquire(workspace, 'shutdown-order');
+    const events: string[] = [];
+    const owned = new SeroOwnedProcessRegistry();
+    owned.register({
+      id: 'terminal-1',
+      kind: 'terminal',
+      cwd: lease.worktreePath,
+      stop: async () => { events.push('owned-stopped'); },
+    });
+    const processGuard = new WorktreeProcessGuard({
+      owned,
+      detector: {
+        platform: 'linux',
+        detect: async () => {
+          events.push('detected-clear');
+          return { status: 'clear' };
+        },
+      },
+    });
+
+    await expect(recycle(workspace, lease, {
+      processGuard,
+      fault: async (point) => {
+        if (point !== 'after-owned-shutdown') return;
+        events.push('reset-boundary');
+        expect(await git(lease.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe(lease.branchName);
+        throw new Error('stop before reset');
+      },
+    })).rejects.toThrow('stop before reset');
+    expect(events).toEqual(['owned-stopped', 'detected-clear', 'reset-boundary']);
+  });
+
+  it.each([
+    'after-reservation',
+    'after-owned-shutdown',
+    'after-reset',
+    'before-final-commit',
+  ] as const)('does not expose an available slot after a crash at %s', async (faultPoint) => {
+    const workspace = await workspaceWithIgnores();
+    const lease = await acquire(workspace, `fault-${faultPoint}`);
+    await expect(recycle(workspace, lease, {
+      fault: (point) => { if (point === faultPoint) throw new Error(`crash at ${point}`); },
+    })).rejects.toThrow(`crash at ${faultPoint}`);
+
+    const raw = JSON.parse(await readFile(statePath(workspace), 'utf8')) as PoolState;
+    const slot = raw.slots.find((candidate) => candidate.slotId === lease.slotId);
+    expect(slot?.state).toBe('recycling');
+    expect(slot?.operation?.resetTarget?.commit).toBeTruthy();
+    expect(slot?.lease?.leaseId).toBe(lease.leaseId);
+  });
+});

--- a/apps/desktop/electron/__tests__/features/git/worktree/pool/state-store.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/pool/state-store.test.ts
@@ -37,12 +37,14 @@ function leasedSlot(): PoolSlot {
       baseRef: 'origin/main',
       baseCommit: 'aaaa',
       acquiredHead: 'bbbb',
+      pullRequestNumber: null,
       acquiredAt: '2026-01-01T00:00:00.000Z',
       greenfield: false,
     },
     operation: null,
     branchName: 'feat/thing-loop-1-r1',
     branchKind: 'fresh-task',
+    preparedHead: null,
     lastReleased: null,
     reason: 'Leased.',
     legacy: false,
@@ -92,6 +94,47 @@ describe('pool state persistence', () => {
     await writeFile(statePath, JSON.stringify(state), 'utf8');
     const read = await readPoolState(statePath);
     expect(read.status).toBe('unavailable');
+  });
+
+  it('migrates a version 2 leased slot by adding only null safety evidence', async () => {
+    const statePath = await tempStatePath();
+    const state = populatedState();
+    const slot = state.slots[0];
+    const { preparedHead: _preparedHead, ...legacySlot } = slot;
+    const { pullRequestNumber: _pullRequestNumber, ...legacyLease } = slot.lease!;
+    await writeFile(statePath, JSON.stringify({
+      ...state,
+      version: 2,
+      slots: [{ ...legacySlot, lease: legacyLease }],
+    }), 'utf8');
+
+    const read = await readPoolState(statePath);
+    expect(read.status).toBe('ok');
+    if (read.status !== 'ok') return;
+    expect(read.migrated).toBe(true);
+    expect(read.state.version).toBe(POOL_SCHEMA_VERSION);
+    expect(read.state.slots[0].preparedHead).toBeNull();
+    expect(read.state.slots[0].lease?.pullRequestNumber).toBeNull();
+  });
+
+  it('does not promote a version 2 slot that claims to be available', async () => {
+    const statePath = await tempStatePath();
+    const state = populatedState();
+    const slot = state.slots[0];
+    const { preparedHead: _preparedHead, ...legacySlot } = slot;
+    await writeFile(statePath, JSON.stringify({
+      ...state,
+      version: 2,
+      slots: [{
+        ...legacySlot,
+        state: 'available',
+        lease: null,
+        branchName: null,
+        branchKind: null,
+      }],
+    }), 'utf8');
+
+    expect((await readPoolState(statePath)).status).toBe('unavailable');
   });
 
   it('never reads a truncated state as usable, at any byte offset', async () => {
@@ -165,6 +208,7 @@ describe('pool state persistence', () => {
           operation: {
             operationId: 'op-1', pid: 1, startedAt: '2026-01-01T00:00:00.000Z',
             intendedState: 'leased', leaseId: 'lease-somewhere-else',
+            resetTarget: null,
           },
         }],
       }),

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/host-dev-server-manager.test.ts
@@ -76,7 +76,12 @@ describe('HostDevServerManager', () => {
 
     const server = await manager.start({ command: 'pnpm dev', cwd: '/workspace' });
 
-    expect(spawn).toHaveBeenCalledWith({ command: 'pnpm dev', cwd: '/workspace', stdio: 'pipe' });
+    expect(spawn).toHaveBeenCalledWith({
+      command: 'pnpm dev',
+      cwd: '/workspace',
+      stdio: 'pipe',
+      ownerKind: 'managed-dev-server',
+    });
     expect(processAdapter.descendantPids).toHaveBeenCalledWith(1234);
     expect(processAdapter.listeningPort).toHaveBeenCalledWith([1234]);
     expect(server).toMatchObject({
@@ -152,7 +157,12 @@ describe('HostDevServerManager', () => {
     });
     const restarted = await manager.restart({ serverId: server.id });
 
-    expect(spawn).toHaveBeenNthCalledWith(2, { command: 'pnpm dev', cwd: '/workspace/app', stdio: 'pipe' });
+    expect(spawn).toHaveBeenNthCalledWith(2, {
+      command: 'pnpm dev',
+      cwd: '/workspace/app',
+      stdio: 'pipe',
+      ownerKind: 'managed-dev-server',
+    });
     expect(restarted).toMatchObject({
       id: 'workspace-a:card-preview:card-1:5173',
       name: 'Card Preview',

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/start-managed-dev-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/start-managed-dev-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { startManagedDevServer } from '@electron/features/workspace/runtime/start-managed-dev-server';
+import { seroOwnedProcesses } from '@electron/features/git/worktree/pool/owned-processes';
 import type { RuntimeBackend, RuntimeCapabilities, RuntimeDevServer } from '@electron/features/workspace/runtime/types';
 import type { RuntimeManager } from '@electron/features/workspace/runtime/runtime-manager';
 
@@ -101,5 +102,38 @@ describe('startManagedDevServer', () => {
       cwdPath: '/tmp/workspace',
       command: 'pnpm dev',
     }, { runtimeManager: malformedManager })).resolves.toEqual({ reason: 'Managed dev server failed to start.' });
+  });
+
+  it('registers a container dev server with the host path and stops it through its runtime owner', async () => {
+    const stopDevServer = vi.fn(async () => undefined);
+    const runtime = {
+      backend: 'docker',
+      capabilities,
+      startDevServer: vi.fn(async () => ({
+        id: 'container-server',
+        port: 5173,
+        url: 'http://127.0.0.1:5173',
+        command: 'pnpm dev',
+        cwd: '/workspace/.sero/worktrees/slot-1',
+        status: 'running' as const,
+      })),
+      stopDevServer,
+    } satisfies Pick<RuntimeBackend, 'backend' | 'capabilities' | 'startDevServer' | 'stopDevServer'>;
+    const manager = {
+      getRuntime: vi.fn(async () => runtime),
+      onDevServerChange: vi.fn(() => () => undefined),
+    } as unknown as RuntimeManager;
+    const cwdPath = '/tmp/workspace/.sero/worktrees/slot-1';
+
+    await startManagedDevServer({
+      workspaceId: 'workspace-a',
+      workspacePath: '/tmp/workspace',
+      cwdPath,
+      command: 'pnpm dev',
+    }, { runtimeManager: manager });
+    expect(seroOwnedProcesses.listRootedIn(cwdPath)).toHaveLength(1);
+    expect(await seroOwnedProcesses.stopRootedIn(cwdPath)).toEqual([]);
+    expect(stopDevServer).toHaveBeenCalledWith({ serverId: 'container-server' });
+    expect(seroOwnedProcesses.listRootedIn(cwdPath)).toHaveLength(0);
   });
 });

--- a/apps/desktop/electron/features/apps/runtime/capabilities/persistent-sessions/host.ts
+++ b/apps/desktop/electron/features/apps/runtime/capabilities/persistent-sessions/host.ts
@@ -26,6 +26,7 @@ import type {
   PersistentSessionUsage,
   PersistentSessionsApi,
 } from '@sero-ai/common';
+import type { SeroOwnedProcessRegistry } from '@electron/features/git/worktree/pool/owned-processes';
 
 import { GrantStore } from './grant-store';
 import { LiveSessionRegistry } from './live-sessions';
@@ -82,10 +83,12 @@ export interface PersistentSessionHostDeps {
   resolveModel(modelId: string): Promise<CreateAgentSessionOptions['model']>;
   newId(prefix: string): string;
   log(message: string): void;
+  ownedProcesses?: Pick<SeroOwnedProcessRegistry, 'register'>;
 }
 
 export class PersistentSessionHost implements PersistentSessionsApi {
   private readonly live = new LiveSessionRegistry();
+  private readonly ownedUnregister = new Map<string, () => void>();
 
   constructor(private readonly deps: PersistentSessionHostDeps) {}
 
@@ -127,6 +130,7 @@ export class PersistentSessionHost implements PersistentSessionsApi {
       await entry.session.abort().catch(() => undefined);
       this.live.remove(entry.handleId);
       entry.session.dispose();
+      this.unregisterOwned(entry.handleId);
     }
     this.deps.grantStore.clearLive(grantId);
   }
@@ -170,6 +174,7 @@ export class PersistentSessionHost implements PersistentSessionsApi {
 
       const sessionId = sessionManager.getSessionId();
       this.live.add({ handleId, grantId: request.grantId, subject: request.subject, sessionId, sessionPath, session });
+      this.registerOwned(handleId, validation.cwd);
       return { handleId, subject: request.subject, sessionId, sessionPath };
     } catch (error) {
       await this.deps.grantStore.releaseReservation(request.grantId, reservation.reservationId);
@@ -214,6 +219,7 @@ export class PersistentSessionHost implements PersistentSessionsApi {
       }
       const sessionId = sessionManager.getSessionId();
       this.live.add({ handleId, grantId: request.grantId, subject: request.subject, sessionId, sessionPath, session });
+      this.registerOwned(handleId, validation.cwd);
       return { handleId, subject: request.subject, sessionId, sessionPath };
     } catch (error) {
       this.deps.grantStore.releaseLive(request.grantId, handleId);
@@ -283,6 +289,36 @@ export class PersistentSessionHost implements PersistentSessionsApi {
     // that is what lets a member be reopened, and its history stay readable.
     entry.session.dispose();
     this.deps.grantStore.releaseLive(entry.grantId, handleId);
+    this.unregisterOwned(handleId);
+  }
+
+  private registerOwned(handleId: string, cwd: string): void {
+    if (!this.deps.ownedProcesses) return;
+    const unregister = this.deps.ownedProcesses.register({
+      id: `agent-session:${handleId}`,
+      kind: 'agent-session',
+      cwd,
+      stop: async () => this.stopOwned(handleId),
+    });
+    this.ownedUnregister.set(handleId, unregister);
+  }
+
+  private unregisterOwned(handleId: string): void {
+    this.ownedUnregister.get(handleId)?.();
+    this.ownedUnregister.delete(handleId);
+  }
+
+  private async stopOwned(handleId: string): Promise<void> {
+    const entry = this.live.get(handleId);
+    if (!entry) {
+      this.unregisterOwned(handleId);
+      return;
+    }
+    await entry.session.abort();
+    this.live.remove(handleId);
+    entry.session.dispose();
+    this.deps.grantStore.releaseLive(entry.grantId, handleId);
+    this.unregisterOwned(handleId);
   }
 
   async readHistory(

--- a/apps/desktop/electron/features/apps/runtime/capabilities/persistent-sessions/index.ts
+++ b/apps/desktop/electron/features/apps/runtime/capabilities/persistent-sessions/index.ts
@@ -23,6 +23,7 @@ import { SERO_SESSION_DIR } from '@electron/shared/infra/shared-infra';
 import { appStateManager } from '@electron/features/apps/state/manager';
 import { ensureAiInfra } from '@electron/shared/infra/ai-infra';
 import { SERO_HOME } from '@electron/platform/env';
+import { seroOwnedProcesses } from '@electron/features/git/worktree/pool/owned-processes';
 
 import { evaluateBuiltinGate } from './builtin-gate';
 import { GrantStore, type StoredGrant } from './grant-store';
@@ -137,6 +138,7 @@ export async function createPersistentSessionsApi(
     resolveModel: wiring.resolveModel,
     newId: (prefix) => `${prefix}_${Math.random().toString(36).slice(2, 10)}`,
     log: wiring.log,
+    ownedProcesses: seroOwnedProcesses,
   });
 }
 

--- a/apps/desktop/electron/features/git/worktree/README.md
+++ b/apps/desktop/electron/features/git/worktree/README.md
@@ -29,6 +29,12 @@ The last completed releases are retained in `pool.json` (`released`, capped at
 64) so the first two can be told apart. An identity older than that history
 fails closed as `stale-lease`.
 
+`checkout: removed` means the released lease's branch checkout is gone. A
+successful recycle may keep the same physical directory as a detached warm
+slot; it does not keep the old lease's checkout. `retained` means the old lease
+still owns recoverable contents, and `unknown` means the final physical result
+could not be fenced or verified.
+
 ## One resolved spelling for every path
 
 A workspace can be opened through a symlink (`/tmp/link -> /tmp/real`). If a
@@ -98,7 +104,8 @@ deletes nothing, prunes nothing, and never promotes an ambiguous slot to
 - directory without registration → `damaged`
 - registration without directory → `orphaned`
 - Git reports the worktree prunable → `damaged`
-- detached HEAD → `recovery-required` (not a Sero work mode)
+- detached HEAD → `recovery-required`, except an `available` slot whose HEAD
+  exactly matches its recorded prepared commit
 - branch differs from the recorded branch → `recovery-required`
 - Git reports the worktree locked → `in-use`
 - an interrupted `provisioning` with full evidence → `leased`
@@ -112,8 +119,43 @@ cannot be read" have opposite consequences for work already on disk.
 `--porcelain -z` is the parsed format, because a path containing a newline
 splits the newline-only format into two records and could attribute a
 directory to the wrong branch. Git before 2.36 has no `-z` for this command,
-so an unknown-option failure falls back to the newline format; any other
-failure is unavailability.
+so an unknown-option failure falls back to the newline format for recovery
+classification. Reuse requires the path-exact NUL format and fails closed when
+only the fallback is available; any other failure is unavailability.
+
+## Allocation and retained capacity
+
+Slots are stable numbered directories (`slot-1`, `slot-2`, ...). Acquisition
+prefers the oldest `available` slot that passes every reuse proof, and creates
+the next numbered slot when none does. Reservation is committed before Git or
+process work starts. Every successful acquisition mints a new random lease id,
+including reuse by the same logical holder.
+
+Active leases and retained idle slots are different capacities. There is no
+hard active-lease limit, so concurrent Workflow runs and Room members are not
+capped at four or any other arbitrary number. The host retains at most **two**
+safely prepared idle slots per repository. Once that target is full, another
+proved-disposable release removes its checkout instead of evicting any leased,
+retained, or unproved slot. This is a host policy constant, not a new user
+setting, because the repository has no existing pool configuration surface.
+
+## Process guard
+
+Reuse and removal first ask the existing Sero owners of rooted terminals,
+agent sessions, commands, and managed development servers to stop. An owner
+resolves its stop request only after shutdown is confirmed. The host then runs
+the narrow adapter in `pool/process-guard.ts` to look for any remaining process
+whose working directory or open files are rooted in the slot. Remaining
+processes block the operation. They are evidence only: Sero never terminates a
+foreign process.
+
+The detector supports macOS and Linux through machine-readable `lsof -F`
+records. Missing `lsof`, permission errors, timeouts, failed detection, and all
+other unverifiable results preserve the checkout. Windows has no native
+detector in PR 2 and therefore fails closed as unverifiable; Windows checkouts
+are not automatically recycled or removed. OS-specific parsing stays in the
+adapter. Pool lifecycle code consumes typed `clear`, `in-use`, or
+`unverifiable` results.
 
 ## Releasing
 
@@ -130,14 +172,38 @@ Classification then decides disposal, and every unknown fails closed:
 | status unreadable | keep | keep | keep |
 | uncommitted work | keep | keep | keep |
 | branch comparison unreadable | keep | keep | keep |
-| branch holds work the base lacks | keep | dispose | keep |
-| pull-request branch | keep | dispose | keep |
-| clean, nothing added to the base | dispose | dispose | keep |
+| local tip outside target, no merged PR | keep | dispose | keep |
+| open or closed-unmerged PR | keep | dispose checkout only | keep |
+| exact target contains local tip | reset and retain | dispose | keep |
+| authoritative merged PR | reset and retain | dispose checkout only | keep |
 
-`recycle` is the routine end-of-run return. `remove` is explicitly authorised
+`recycle` is the routine end-of-run return. Caller disposition is intent, not
+proof. The host recomputes cleanliness, process state, branch provenance and
+disposability. A fresh branch is disposable when its current tip is an ancestor
+of the exact reset target, covering merge commits, or when the authoritative PR
+record says merged, covering squash and rebase merges. An external PR branch
+requires authoritative merged evidence; open, closed-unmerged, and unknown all
+preserve it. A safely merged external checkout may be recycled, but its branch
+is never deleted. A proved-disposable fresh local branch is deleted with an
+atomic expected-tip fence after the checkout leaves it.
+
+`remove` is explicitly authorised
 disposal — a user deleting the loop — so committed work no longer blocks the
 checkout's removal; the branch itself still survives unless the caller asked
 for its deletion, and a pull-request branch is never deleted at all.
+
+## Cache-preserving reset
+
+Before a recycling transition is persisted, the host resolves and records the
+preferred base ref and its exact commit. It then confirms owned shutdown and
+foreign-process absence, switches the checkout to that exact commit in detached
+mode, resets tracked content, and runs `git clean -fd`. It never runs
+`git clean -x`, so ignored dependencies, compiler output, and local caches stay
+on disk. The host verifies registration, detached branch state, exact HEAD,
+clean tracked and non-ignored-untracked state, and continued existence of every
+ignored path observed before reset. Only then can the slot become `available`.
+Any failed command or verification leaves the checkout and its lease evidence
+in `recovery-required`; a partly reset checkout is never allocatable.
 
 **A preserved checkout keeps its lease.** Clearing it would leave work on disk
 that no consumer names and no pool record owns, at exactly the moment the
@@ -173,6 +239,12 @@ rejects the whole file.
 
 Writes go to a unique temporary file in the same directory, are flushed, and
 replace the target by rename.
+
+PR 2 uses schema version 3. It records pull-request identity on the immutable
+lease, the exact reset target on a recycling operation, and the verified
+prepared HEAD on an available slot. Version 2 migrates only by adding null
+fields and never promotes a checkout to available. A shape that cannot satisfy
+the version 3 invariants, or any unknown version, remains unavailable.
 
 ## Reattachment
 
@@ -213,11 +285,8 @@ information and must be respected rather than overridden.
 
 An `external-pr` branch is never deleted, whatever the caller asked for.
 
-## What PR 1 does not do
+## Scope boundary
 
-Slot **reuse** is disabled. `chooseSlot` in `pool/acquire.ts` always allocates
-a new slot, and is the single place PR 2 changes. Reuse needs every
-precondition proved first — no live process in the checkout, clean including
-untracked files, valid registration, and disposability against the exact reset
-target — and none of that exists yet. Until it does, no checkout is reset under
-work that is still on disk.
+The pool has no cleanup planning API, confirmation token, plan fingerprint,
+renderer-controlled destructive cleanup, admin UI, broad pruning, or arbitrary
+foreign-process termination. Those cleanup controls remain PR 3 work.

--- a/apps/desktop/electron/features/git/worktree/pool/acquire.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/acquire.ts
@@ -1,18 +1,3 @@
-/**
- * Acquisition: one holder, one new lease, one physical checkout.
- *
- * PR 1 deliberately does NOT reuse a slot. Reuse needs every precondition in
- * the plan proved — no live process, clean including untracked files, valid
- * registration, and disposability against the exact reset target — and none of
- * that exists yet. `chooseSlot` is the single place PR 2 changes; until then it
- * always allocates a new slot, so no checkout can be reset under work that is
- * still on disk.
- *
- * The transaction is: reserve under the state lock, do network work outside
- * every lock, mutate Git registration under the Git-mutation gate, then commit
- * under the state lock only if the reservation is still ours.
- */
-
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -23,7 +8,7 @@ import type {
   AppRuntimeWorktreeLease,
 } from '@sero-ai/common';
 
-import { resolvePreferredBaseRef } from '../workspace-sync';
+import { execWorktreeGit } from '../exec';
 import {
   addWorktreeOnExistingBranch,
   addWorktreeOnNewBranch,
@@ -31,26 +16,44 @@ import {
   ensureGitReady,
   fetchBranchBestEffort,
   isUsableBranchName,
+  refExistsIn,
   resolveCommit,
 } from '../provision';
+import { resolvePreferredBaseRef } from '../workspace-sync';
+import { checkoutCleanliness } from './checkout';
 import { withGitMutationGate } from './locks';
-import { type RepositoryIdentity } from './repository';
+import { defaultWorktreeProcessGuard, type WorktreeProcessGuard } from './process-guard';
+import { listWorktreeRegistrations } from './registration';
+import { canonicalPath, type RepositoryIdentity } from './repository';
 import { commitPoolMutation, openPool } from './session';
 import { dropSlot, findSlot, replaceSlot } from './state-store';
 import type { PoolSlot, PoolState } from './types';
 
-/** Outcome of choosing a slot: a new allocation, or a refusal with its reason. */
-type SlotChoice = { status: 'new' } | { status: 'blocked'; reason: string };
+export type AcquireFaultPoint = 'after-reservation' | 'after-checkout' | 'before-final-commit';
+
+export interface AcquireWorktreeDependencies {
+  processGuard?: WorktreeProcessGuard;
+  fault?: (point: AcquireFaultPoint) => Promise<void> | void;
+}
+
+type SlotChoice =
+  | { status: 'new'; slotId: string }
+  | { status: 'reuse'; slot: PoolSlot }
+  | { status: 'blocked'; reason: string };
 
 function blocked(reason: string): AppRuntimeAcquireWorktreeResult {
   return { status: 'blocked', reason };
 }
 
-/**
- * PR 1: always a new slot. A slot that is already leased to this holder is
- * evidence of a restart, not a second acquisition — the caller must reattach.
- */
-function chooseSlot(state: PoolState, holder: string): SlotChoice {
+function nextSlotId(state: PoolState): string {
+  const highest = state.slots.reduce((max, slot) => {
+    const match = /^slot-(\d+)$/.exec(slot.slotId);
+    return match ? Math.max(max, Number.parseInt(match[1], 10)) : max;
+  }, 0);
+  return `slot-${highest + 1}`;
+}
+
+function chooseSlot(state: PoolState, holder: string, allowReuse: boolean): SlotChoice {
   const held = state.slots.find((slot) => slot.state === 'leased' && slot.lease?.leaseHolder === holder);
   if (held) {
     return {
@@ -58,25 +61,33 @@ function chooseSlot(state: PoolState, holder: string): SlotChoice {
       reason: `"${holder}" already holds slot ${held.slotId}. Reattach to that lease instead of acquiring a second checkout.`,
     };
   }
-  return { status: 'new' };
+  if (allowReuse) {
+    const reusable = state.slots
+      .filter((slot) => slot.state === 'available' && !slot.lease && !slot.operation && slot.preparedHead)
+      .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt))[0];
+    if (reusable) return { status: 'reuse', slot: reusable };
+  }
+  return { status: 'new', slotId: nextSlotId(state) };
 }
 
-function newSlot(
-  slotId: string,
-  slotPath: string,
-  workspacePath: string,
-  operationId: string,
-  now: string,
-): PoolSlot {
+function newSlot(slotId: string, slotPath: string, workspacePath: string, operationId: string, now: string): PoolSlot {
   return {
     slotId,
     path: slotPath,
     workspacePath,
     state: 'provisioning',
     lease: null,
-    operation: { operationId, pid: process.pid, startedAt: now, intendedState: 'leased', leaseId: null },
+    operation: {
+      operationId,
+      pid: process.pid,
+      startedAt: now,
+      intendedState: 'leased',
+      leaseId: null,
+      resetTarget: null,
+    },
     branchName: null,
     branchKind: null,
+    preparedHead: null,
     lastReleased: null,
     reason: 'A checkout is being provisioned for a new lease.',
     legacy: false,
@@ -85,13 +96,6 @@ function newSlot(
   };
 }
 
-/**
- * Records that provisioning failed, without deleting anything it may have
- * left. A reservation that never reached the filesystem is dropped — there is
- * nothing to preserve, and keeping it would leave a phantom slot for every
- * failed acquisition. A directory that DOES exist is kept and flagged, because
- * only an explicit decision can say what is in it.
- */
 async function markProvisioningFailed(
   identity: RepositoryIdentity,
   slotId: string,
@@ -103,14 +107,14 @@ async function markProvisioningFailed(
   await commitPoolMutation(identity, (state) => {
     const slot = findSlot(state, slotId);
     if (!slot || slot.operation?.operationId !== operationId) return { value: null };
-    if (!left) return { state: dropSlot(state, slotId), value: null };
+    if (!left && slot.preparedHead === null) return { state: dropSlot(state, slotId), value: null };
     const now = new Date().toISOString();
     return {
       state: replaceSlot(state, {
         ...slot,
         state: 'recovery-required',
         operation: null,
-        reason: `Provisioning failed and left an unproved checkout: ${reason}`,
+        reason: `Provisioning failed and preserved the checkout: ${reason}`,
         updatedAt: now,
       }),
       value: null,
@@ -118,16 +122,79 @@ async function markProvisioningFailed(
   }).catch(() => undefined);
 }
 
+async function proveAvailableSlot(slot: PoolSlot, workspacePath: string, guard: WorktreeProcessGuard): Promise<string | null> {
+  const processState = await guard.prepare(slot.path);
+  if (processState.status !== 'safe') return processState.reason;
+  const cleanliness = await checkoutCleanliness(slot.path);
+  if (cleanliness.status !== 'clean') {
+    return cleanliness.status === 'dirty'
+      ? `The available checkout became dirty: ${cleanliness.detail}`
+      : `The available checkout could not be verified clean: ${cleanliness.reason}`;
+  }
+  const listing = await listWorktreeRegistrations(workspacePath);
+  if (listing.status !== 'ok') return `Registration detection failed: ${listing.reason}`;
+  if (!listing.nulDelimited) return 'Git cannot provide path-exact NUL-delimited registration evidence.';
+  const canonical = await canonicalPath(slot.path);
+  const records = await Promise.all(listing.records.map(async (record) => ({
+    record,
+    path: await canonicalPath(record.path),
+  })));
+  const registration = records.find((entry) => entry.path === canonical)?.record;
+  if (!registration || registration.locked || registration.prunable || !registration.detached) {
+    return 'The available slot registration is missing, locked, prunable, or not in its prepared detached state.';
+  }
+  if (!slot.preparedHead || registration.head !== slot.preparedHead) {
+    return 'The available slot HEAD differs from its recorded prepared HEAD.';
+  }
+  return null;
+}
+
+async function checkoutReusedSlot(
+  workspacePath: string,
+  slotPath: string,
+  branchName: string,
+  external: boolean,
+  baseRef: string | null,
+): Promise<void> {
+  if (external) {
+    if (await refExistsIn(workspacePath, `refs/heads/${branchName}`)) {
+      await execWorktreeGit(['switch', branchName], { cwd: slotPath, timeout: 30_000 });
+      return;
+    }
+    if (!await refExistsIn(workspacePath, `refs/remotes/origin/${branchName}`)) {
+      throw new Error(`Branch "${branchName}" exists neither locally nor on origin`);
+    }
+    await execWorktreeGit(['switch', '--track', '-c', branchName, `origin/${branchName}`], {
+      cwd: slotPath,
+      timeout: 30_000,
+    });
+    return;
+  }
+  await execWorktreeGit(['switch', '-c', branchName, ...(baseRef ? [baseRef] : [])], {
+    cwd: slotPath,
+    timeout: 30_000,
+  });
+}
+
 export async function acquireWorktree(
   workspacePath: string,
   request: AppRuntimeAcquireWorktreeRequest,
+  dependencies: AcquireWorktreeDependencies = {},
+): Promise<AppRuntimeAcquireWorktreeResult> {
+  return acquire(workspacePath, request, dependencies, true);
+}
+
+async function acquire(
+  workspacePath: string,
+  request: AppRuntimeAcquireWorktreeRequest,
+  dependencies: AcquireWorktreeDependencies,
+  allowReuse: boolean,
 ): Promise<AppRuntimeAcquireWorktreeResult> {
   if (!request.holder) return blocked('An acquisition needs a holder key.');
   if (request.existingBranch !== undefined && !isUsableBranchName(request.existingBranch)) {
     return blocked(`Invalid branch name "${request.existingBranch}"`);
   }
 
-  // Greenfield bootstrap has to happen before repository identity resolves.
   let greenfield = false;
   try {
     greenfield = await ensureGitReady(workspacePath);
@@ -138,125 +205,137 @@ export async function acquireWorktree(
   const opened = await openPool(workspacePath);
   if (opened.status !== 'ok') return blocked(opened.reason);
   const { identity } = opened.session;
+  const external = request.existingBranch !== undefined;
+  const branchName = external
+    ? (request.existingBranch as string)
+    : buildTaskBranchName(request.title, request.holder);
+  const alreadyHeld = opened.session.state.slots.find((slot) =>
+    slot.state === 'leased' && slot.lease?.leaseHolder === request.holder,
+  );
+  if (alreadyHeld) {
+    return blocked(`"${request.holder}" already holds slot ${alreadyHeld.slotId}. Reattach to that lease instead of acquiring a second checkout.`);
+  }
+  if (!external && await refExistsIn(opened.session.workspacePath, `refs/heads/${branchName}`)) {
+    return blocked(`Fresh branch "${branchName}" already exists. Treat it as reattachment or recovery evidence.`);
+  }
 
-  const choice = chooseSlot(opened.session.state, request.holder);
-  if (choice.status === 'blocked') return blocked(choice.reason);
-
-  const slotId = `slot-${randomUUID().replace(/-/g, '').slice(0, 12)}`;
-  // The pool root is already resolved, so the recorded path is the same
-  // spelling reconciliation and containment will later compute.
-  const slotPath = path.join(opened.session.poolRoot, slotId);
   const operationId = randomUUID();
-
   const reserved = await commitPoolMutation<SlotChoice>(identity, (state) => {
+    const choice = chooseSlot(state, request.holder, allowReuse);
+    if (choice.status === 'blocked') return { value: choice };
     const now = new Date().toISOString();
-    // Re-check under the lock: another process may have acquired for this
-    // holder between openPool and here.
-    const recheck = chooseSlot(state, request.holder);
-    if (recheck.status === 'blocked') return { value: recheck };
-    if (state.slots.some((slot) => slot.path === slotPath)) {
-      return { value: { status: 'blocked', reason: `Slot path ${slotPath} is already recorded.` } };
+    if (choice.status === 'reuse') {
+      return {
+        state: replaceSlot(state, {
+          ...choice.slot,
+          state: 'provisioning',
+          operation: {
+            operationId,
+            pid: process.pid,
+            startedAt: now,
+            intendedState: 'leased',
+            leaseId: null,
+            resetTarget: null,
+          },
+          reason: `A proven idle checkout is reserved for "${request.holder}".`,
+          updatedAt: now,
+        }),
+        value: choice,
+      };
     }
+    const slotPath = path.join(opened.session.poolRoot, choice.slotId);
     return {
-      state: replaceSlot(state, newSlot(slotId, slotPath, opened.session.workspacePath, operationId, now)),
-      value: { status: 'new' },
+      state: replaceSlot(state, newSlot(choice.slotId, slotPath, opened.session.workspacePath, operationId, now)),
+      value: choice,
     };
   });
   if (reserved.status !== 'ok') return blocked(reserved.reason);
   if (reserved.value.status === 'blocked') return blocked(reserved.value.reason);
+  await dependencies.fault?.('after-reservation');
+
+  const slotId = reserved.value.status === 'reuse' ? reserved.value.slot.slotId : reserved.value.slotId;
+  const slotPath = reserved.value.status === 'reuse'
+    ? reserved.value.slot.path
+    : path.join(opened.session.poolRoot, slotId);
 
   try {
-    return await provision(identity, opened.session.workspacePath, request, {
+    const baseRef = external ? null : await resolvePreferredBaseRef(opened.session.workspacePath);
+    if (external) await fetchBranchBestEffort(opened.session.workspacePath, branchName);
+    const baseCommit = await resolveCommit(opened.session.workspacePath, baseRef ?? 'HEAD');
+
+    if (reserved.value.status === 'reuse') {
+      const refusal = await proveAvailableSlot(
+        reserved.value.slot,
+        opened.session.workspacePath,
+        dependencies.processGuard ?? defaultWorktreeProcessGuard,
+      );
+      if (refusal) {
+        await markProvisioningFailed(identity, slotId, slotPath, operationId, refusal);
+        console.warn(`[worktree-pool] slot ${slotId} was not reusable: ${refusal}`);
+        return acquire(opened.session.workspacePath, request, dependencies, false);
+      }
+      await checkoutReusedSlot(opened.session.workspacePath, slotPath, branchName, external, baseRef);
+    } else {
+      await withGitMutationGate(identity.poolDir, async () => {
+        if (external) {
+          await addWorktreeOnExistingBranch(opened.session.workspacePath, slotPath, branchName, { fetch: false });
+        } else {
+          await addWorktreeOnNewBranch(
+            opened.session.workspacePath,
+            slotPath,
+            branchName,
+            baseRef,
+            { reattachExisting: false },
+          );
+        }
+      });
+    }
+    await dependencies.fault?.('after-checkout');
+
+    const acquiredHead = await resolveCommit(slotPath, 'HEAD');
+    const lease: AppRuntimeWorktreeLease = {
       slotId,
-      slotPath,
-      operationId,
+      leaseId: randomUUID(),
+      leaseHolder: request.holder,
+      worktreePath: slotPath,
+      branchName,
+      branchKind: external ? 'external-pr' : 'fresh-task',
+      baseRef,
+      baseCommit,
+      acquiredHead,
+      pullRequestNumber: request.pullRequestNumber ?? null,
+      acquiredAt: new Date().toISOString(),
       greenfield,
+    };
+    await dependencies.fault?.('before-final-commit');
+    const committed = await commitPoolMutation<'committed' | 'lost'>(identity, (state) => {
+      const slot = findSlot(state, slotId);
+      if (!slot || slot.operation?.operationId !== operationId) return { value: 'lost' };
+      const now = new Date().toISOString();
+      return {
+        state: replaceSlot(state, {
+          ...slot,
+          state: 'leased',
+          lease,
+          operation: null,
+          branchName,
+          branchKind: lease.branchKind,
+          preparedHead: null,
+          reason: `Leased to "${request.holder}" on branch ${branchName}.`,
+          updatedAt: now,
+        }),
+        value: 'committed',
+      };
     });
+    if (committed.status !== 'ok') return blocked(`The checkout was created but its lease could not be recorded: ${committed.reason}`);
+    if (committed.value === 'lost') {
+      return blocked(`Slot ${slotId} changed while it was being provisioned, so the checkout was preserved.`);
+    }
+    console.log(`[worktree-pool] leased ${slotId} to ${request.holder} at ${slotPath} (branch: ${branchName})`);
+    return { status: 'acquired', lease };
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     await markProvisioningFailed(identity, slotId, slotPath, operationId, reason);
     return blocked(reason);
   }
-}
-
-interface ProvisionContext {
-  slotId: string;
-  slotPath: string;
-  operationId: string;
-  greenfield: boolean;
-}
-
-async function provision(
-  identity: RepositoryIdentity,
-  workspacePath: string,
-  request: AppRuntimeAcquireWorktreeRequest,
-  ctx: ProvisionContext,
-): Promise<AppRuntimeAcquireWorktreeResult> {
-  const external = request.existingBranch !== undefined;
-
-  // Network work happens outside both locks so independent acquisitions overlap.
-  const baseRef = external ? null : await resolvePreferredBaseRef(workspacePath);
-  if (external) await fetchBranchBestEffort(workspacePath, request.existingBranch as string);
-
-  const branchName = external
-    ? (request.existingBranch as string)
-    : buildTaskBranchName(request.title, request.holder);
-  const baseCommit = await resolveCommit(workspacePath, baseRef ?? 'HEAD');
-
-  // Only the registration-changing command is serialised.
-  await withGitMutationGate(identity.poolDir, async () => {
-    if (external) {
-      await addWorktreeOnExistingBranch(workspacePath, ctx.slotPath, branchName, { fetch: false });
-    } else {
-      await addWorktreeOnNewBranch(workspacePath, ctx.slotPath, branchName, baseRef);
-    }
-  });
-
-  const acquiredHead = await resolveCommit(ctx.slotPath, 'HEAD');
-  const lease: AppRuntimeWorktreeLease = {
-    slotId: ctx.slotId,
-    leaseId: randomUUID(),
-    leaseHolder: request.holder,
-    worktreePath: ctx.slotPath,
-    branchName,
-    branchKind: external ? 'external-pr' : 'fresh-task',
-    baseRef,
-    baseCommit,
-    acquiredHead,
-    acquiredAt: new Date().toISOString(),
-    greenfield: ctx.greenfield,
-  };
-
-  const committed = await commitPoolMutation<'committed' | 'lost'>(identity, (state) => {
-    const slot = findSlot(state, ctx.slotId);
-    if (!slot || slot.operation?.operationId !== ctx.operationId) {
-      return { value: 'lost' };
-    }
-    const now = new Date().toISOString();
-    return {
-      state: replaceSlot(state, {
-        ...slot,
-        state: 'leased',
-        lease,
-        operation: null,
-        branchName,
-        branchKind: lease.branchKind,
-        reason: `Leased to "${request.holder}" on branch ${branchName}.`,
-        updatedAt: now,
-      }),
-      value: 'committed',
-    };
-  });
-
-  if (committed.status !== 'ok') {
-    return blocked(`The checkout was created but its lease could not be recorded: ${committed.reason}`);
-  }
-  if (committed.value === 'lost') {
-    return blocked(
-      `Slot ${ctx.slotId} was reassigned while it was being provisioned, so the new checkout was preserved rather than used.`,
-    );
-  }
-
-  console.log(`[worktree-pool] leased ${ctx.slotId} to ${request.holder} at ${ctx.slotPath} (branch: ${branchName})`);
-  return { status: 'acquired', lease };
 }

--- a/apps/desktop/electron/features/git/worktree/pool/disposability.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/disposability.ts
@@ -1,0 +1,133 @@
+import { execWorktreeGit } from '../exec';
+import { getPullRequestMergeState, type PullRequestMergeState } from '../../github/merge-state';
+import { ghForPath } from '../../github/invoker';
+import { resolveCommit, stderrOf } from '../provision';
+import type { PoolSlot } from './types';
+
+export interface PullRequestEvidence {
+  number: number | null;
+  state: PullRequestMergeState;
+}
+
+export interface PullRequestEvidenceProvider {
+  forBranch(workspacePath: string, branchName: string, knownNumber: number | null): Promise<PullRequestEvidence>;
+}
+
+export type DisposabilityResult =
+  | { status: 'disposable'; reason: string; branchTip: string; pullRequest: PullRequestEvidence | null }
+  | { status: 'unmerged'; reason: string }
+  | { status: 'unverifiable'; reason: string };
+
+async function pullRequestEvidence(
+  provider: PullRequestEvidenceProvider,
+  workspacePath: string,
+  branchName: string,
+  knownNumber: number | null,
+): Promise<PullRequestEvidence | null> {
+  try {
+    return await provider.forBranch(workspacePath, branchName, knownNumber);
+  } catch {
+    return null;
+  }
+}
+
+export const githubPullRequestEvidence: PullRequestEvidenceProvider = {
+  async forBranch(workspacePath, branchName, knownNumber) {
+    if (knownNumber !== null) {
+      return { number: knownNumber, state: await getPullRequestMergeState(ghForPath(workspacePath), knownNumber) };
+    }
+    try {
+      const { stdout } = await ghForPath(workspacePath)([
+        'pr', 'view', branchName, '--json', 'number,state,mergedAt',
+      ], 15_000);
+      const parsed = JSON.parse(stdout) as { number?: number; state?: string; mergedAt?: string | null };
+      const number = typeof parsed.number === 'number' ? parsed.number : null;
+      if (parsed.mergedAt) return { number, state: 'merged' };
+      if (parsed.state === 'OPEN') return { number, state: 'open' };
+      if (parsed.state === 'CLOSED') return { number, state: 'closed' };
+      return { number, state: 'unknown' };
+    } catch {
+      return { number: null, state: 'unknown' };
+    }
+  },
+};
+
+async function isAncestor(cwd: string, ancestor: string, target: string): Promise<boolean | null> {
+  try {
+    await execWorktreeGit(['merge-base', '--is-ancestor', ancestor, target], { cwd, timeout: 15_000 });
+    return true;
+  } catch (error) {
+    const detail = stderrOf(error);
+    if (/exit code 1|Command failed/i.test(detail) && !/fatal|error/i.test(detail)) return false;
+    // execFile errors do not consistently retain the numeric exit code in the
+    // rendered message. A successful resolution of both commits means exit 1
+    // is the ordinary "not ancestor" result.
+    const [left, right] = await Promise.all([resolveCommit(cwd, ancestor), resolveCommit(cwd, target)]);
+    return left && right ? false : null;
+  }
+}
+
+/** Proves that leaving this branch cannot lose unmerged work. */
+export async function classifyDisposability(
+  workspacePath: string,
+  slot: PoolSlot,
+  targetCommit: string,
+  provider: PullRequestEvidenceProvider = githubPullRequestEvidence,
+): Promise<DisposabilityResult> {
+  const lease = slot.lease;
+  if (!lease || !slot.branchName) {
+    return { status: 'unverifiable', reason: 'The slot has no lease and branch provenance.' };
+  }
+  const branchTip = await resolveCommit(slot.path, 'HEAD');
+  if (!branchTip) return { status: 'unverifiable', reason: 'The branch tip could not be resolved.' };
+
+  if (lease.branchKind === 'external-pr') {
+    const pullRequest = await pullRequestEvidence(provider,
+      workspacePath,
+      slot.branchName,
+      lease.pullRequestNumber,
+    );
+    if (!pullRequest) return { status: 'unverifiable', reason: 'Pull-request evidence could not be read.' };
+    if (pullRequest.state === 'merged') {
+      return {
+        status: 'disposable',
+        reason: `PR #${pullRequest.number ?? 'unknown'} is authoritatively merged; its external branch is retained.`,
+        branchTip,
+        pullRequest,
+      };
+    }
+    const state = pullRequest.state === 'unknown' ? 'could not be verified' : `is ${pullRequest.state}`;
+    return { status: 'unmerged', reason: `The external pull request ${state}, so its checkout is preserved.` };
+  }
+
+  const contained = await isAncestor(slot.path, branchTip, targetCommit);
+  if (contained === true) {
+    return {
+      status: 'disposable',
+      reason: 'The fresh branch tip is contained in the exact reset target.',
+      branchTip,
+      pullRequest: null,
+    };
+  }
+  const pullRequest = await pullRequestEvidence(provider,
+    workspacePath,
+    slot.branchName,
+    lease.pullRequestNumber,
+  );
+  if (!pullRequest) return { status: 'unverifiable', reason: 'Pull-request evidence could not be read.' };
+  if (pullRequest.state === 'merged') {
+    return {
+      status: 'disposable',
+      reason: `PR #${pullRequest.number ?? 'unknown'} is authoritatively merged (including squash or rebase merges).`,
+      branchTip,
+      pullRequest,
+    };
+  }
+  if (contained === null) {
+    return { status: 'unverifiable', reason: 'Git could not compare the branch tip with the exact reset target.' };
+  }
+  if (pullRequest.state === 'open' || pullRequest.state === 'closed') {
+    return { status: 'unmerged', reason: `The branch PR is ${pullRequest.state}, not merged.` };
+  }
+  return { status: 'unmerged', reason: 'The local branch has commits outside the reset target and no merged PR proves disposal.' };
+}

--- a/apps/desktop/electron/features/git/worktree/pool/owned-processes.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/owned-processes.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+
+export type SeroOwnedProcessKind =
+  | 'terminal'
+  | 'agent-session'
+  | 'command'
+  | 'managed-dev-server';
+
+export interface SeroOwnedProcess {
+  id: string;
+  kind: SeroOwnedProcessKind;
+  cwd: string;
+  /** Resolves only after the owner has confirmed shutdown. */
+  stop(): Promise<void>;
+}
+
+export interface OwnedShutdownFailure {
+  id: string;
+  kind: SeroOwnedProcessKind;
+  reason: string;
+}
+
+function isRootedIn(candidate: string, root: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+/**
+ * In-process ownership index. It contains only processes Sero created and may
+ * ask to stop. Remaining OS processes are detection evidence, never entries
+ * that this registry may terminate.
+ */
+export class SeroOwnedProcessRegistry {
+  private readonly entries = new Map<string, SeroOwnedProcess>();
+
+  register(entry: SeroOwnedProcess): () => void {
+    this.entries.set(entry.id, entry);
+    return () => {
+      if (this.entries.get(entry.id) === entry) this.entries.delete(entry.id);
+    };
+  }
+
+  listRootedIn(root: string): SeroOwnedProcess[] {
+    return [...this.entries.values()].filter((entry) => isRootedIn(entry.cwd, root));
+  }
+
+  async stopRootedIn(root: string): Promise<OwnedShutdownFailure[]> {
+    const entries = this.listRootedIn(root);
+    const outcomes = await Promise.all(entries.map(async (entry): Promise<OwnedShutdownFailure | null> => {
+      try {
+        await entry.stop();
+        if (this.entries.get(entry.id) === entry) this.entries.delete(entry.id);
+        return null;
+      } catch (error) {
+        return {
+          id: entry.id,
+          kind: entry.kind,
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }));
+    return outcomes.filter((outcome): outcome is OwnedShutdownFailure => outcome !== null);
+  }
+}
+
+export const seroOwnedProcesses = new SeroOwnedProcessRegistry();

--- a/apps/desktop/electron/features/git/worktree/pool/process-guard.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/process-guard.ts
@@ -1,0 +1,166 @@
+import { execFile } from 'node:child_process';
+
+import {
+  seroOwnedProcesses,
+  type OwnedShutdownFailure,
+  type SeroOwnedProcessRegistry,
+} from './owned-processes';
+
+export interface DetectedSlotProcess {
+  pid: number;
+  command: string | null;
+}
+
+export type ProcessDetectionResult =
+  | { status: 'clear' }
+  | { status: 'in-use'; processes: DetectedSlotProcess[] }
+  | { status: 'unverifiable'; reason: string };
+
+export interface SlotProcessDetector {
+  readonly platform: NodeJS.Platform;
+  detect(root: string): Promise<ProcessDetectionResult>;
+}
+
+export type ProcessGuardResult =
+  | { status: 'safe'; stoppedOwned: number }
+  | { status: 'in-use'; reason: string }
+  | { status: 'unverifiable'; reason: string };
+
+interface ProcessGuardOptions {
+  owned?: SeroOwnedProcessRegistry;
+  detector?: SlotProcessDetector;
+  ownedShutdownTimeoutMs?: number;
+}
+
+interface ExecFailure extends Error {
+  code?: string | number;
+  stdout?: string;
+  stderr?: string;
+  killed?: boolean;
+}
+
+/** Adapter-only parser for lsof's machine-readable field output. */
+export function parseLsofFields(output: string): DetectedSlotProcess[] {
+  const found = new Map<number, DetectedSlotProcess>();
+  let currentPid: number | null = null;
+  for (const line of output.split('\n')) {
+    const field = line[0];
+    const value = line.slice(1);
+    if (field === 'p') {
+      const pid = Number.parseInt(value, 10);
+      currentPid = Number.isInteger(pid) && pid > 0 ? pid : null;
+      if (currentPid) found.set(currentPid, { pid: currentPid, command: null });
+    } else if (field === 'c' && currentPid) {
+      found.set(currentPid, { pid: currentPid, command: value || null });
+    }
+  }
+  return [...found.values()];
+}
+
+/** macOS and Linux adapter. Windows fails closed until it has a native adapter. */
+export class LsofProcessDetector implements SlotProcessDetector {
+  readonly platform: NodeJS.Platform;
+
+  constructor(platform: NodeJS.Platform = process.platform) {
+    this.platform = platform;
+  }
+
+  detect(root: string): Promise<ProcessDetectionResult> {
+    if (this.platform !== 'darwin' && this.platform !== 'linux') {
+      return Promise.resolve({
+        status: 'unverifiable',
+        reason: `Process detection is not supported on ${this.platform}.`,
+      });
+    }
+    return new Promise((resolve) => {
+      execFile('lsof', ['-nP', '-w', '-Fpc', '+D', root], {
+        timeout: 15_000,
+        maxBuffer: 4 * 1024 * 1024,
+      }, (error, stdout, stderr) => {
+        const processes = parseLsofFields(stdout);
+        if (processes.length > 0) {
+          resolve({ status: 'in-use', processes });
+          return;
+        }
+        if (!error && stderr.trim().length === 0) {
+          resolve({ status: 'clear' });
+          return;
+        }
+        const failure = error as ExecFailure | null;
+        // lsof uses exit 1 for "no files found". No stderr and no records is a
+        // successful empty query, not a detection failure.
+        if (!failure?.killed && stderr.trim().length === 0
+          && (failure?.code === 1 || failure?.code === '1'
+            || failure?.message.startsWith('Command failed: lsof '))) {
+          resolve({ status: 'clear' });
+          return;
+        }
+        const detail = stderr.trim() || failure?.message || 'lsof failed';
+        resolve({ status: 'unverifiable', reason: detail });
+      });
+    });
+  }
+}
+
+export class WorktreeProcessGuard {
+  private readonly owned: SeroOwnedProcessRegistry;
+  private readonly detector: SlotProcessDetector;
+  private readonly ownedShutdownTimeoutMs: number;
+
+  constructor(options: ProcessGuardOptions = {}) {
+    this.owned = options.owned ?? seroOwnedProcesses;
+    this.detector = options.detector ?? new LsofProcessDetector();
+    this.ownedShutdownTimeoutMs = options.ownedShutdownTimeoutMs ?? 10_000;
+  }
+
+  async prepare(root: string): Promise<ProcessGuardResult> {
+    const owned = this.owned.listRootedIn(root);
+    const failures = await this.stopOwnedWithTimeout(root);
+    if (failures.length > 0) {
+      const first = failures[0];
+      return {
+        status: 'unverifiable',
+        reason: `Sero could not confirm shutdown of ${first.kind} ${first.id}: ${first.reason}`,
+      };
+    }
+
+    let detection: ProcessDetectionResult;
+    try {
+      detection = await this.detector.detect(root);
+    } catch (error) {
+      return {
+        status: 'unverifiable',
+        reason: `Process detection failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+    if (detection.status === 'clear') return { status: 'safe', stoppedOwned: owned.length };
+    if (detection.status === 'unverifiable') return detection;
+    const sample = detection.processes.slice(0, 3)
+      .map((entry) => `${entry.pid}${entry.command ? ` (${entry.command})` : ''}`)
+      .join(', ');
+    return {
+      status: 'in-use',
+      reason: `The checkout is still used by process ${sample}. Foreign processes were not terminated.`,
+    };
+  }
+
+  private async stopOwnedWithTimeout(root: string): Promise<OwnedShutdownFailure[]> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        this.owned.stopRootedIn(root),
+        new Promise<OwnedShutdownFailure[]>((resolve) => {
+          timeout = setTimeout(() => resolve([{
+            id: 'shutdown-timeout',
+            kind: 'command',
+            reason: `owned shutdown was not confirmed within ${this.ownedShutdownTimeoutMs}ms`,
+          }]), this.ownedShutdownTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+}
+
+export const defaultWorktreeProcessGuard = new WorktreeProcessGuard();

--- a/apps/desktop/electron/features/git/worktree/pool/reattach.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/reattach.ts
@@ -128,6 +128,7 @@ async function adoptLegacyCheckout(
     baseRef: null,
     baseCommit: null,
     acquiredHead: await resolveCommit(canonical, 'HEAD'),
+    pullRequestNumber: null,
     acquiredAt: new Date().toISOString(),
     greenfield: false,
   };
@@ -146,6 +147,7 @@ async function adoptLegacyCheckout(
         operation: null,
         branchName: branch,
         branchKind: lease.branchKind,
+        preparedHead: null,
         lastReleased: current?.lastReleased ?? null,
         reason: `A pre-pool checkout matched to "${request.holder}" and given a migration lease.`,
         legacy: true,

--- a/apps/desktop/electron/features/git/worktree/pool/reconcile.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/reconcile.ts
@@ -129,16 +129,17 @@ function classifyStable(
   if (registration?.prunable) {
     return reclassify(slot, 'damaged', `Git reports this worktree prunable: ${registration.prunableReason ?? 'no reason given'}.`, now);
   }
+  if (registration?.locked) {
+    return reclassify(slot, 'in-use', `Git reports this worktree locked: ${registration.lockedReason ?? 'no reason given'}.`, now);
+  }
   if (registration?.detached) {
-    return reclassify(slot, 'recovery-required', 'The checkout is on a detached HEAD, which is not a Sero work mode.', now);
+    if (slot.state === 'available' && slot.preparedHead && registration.head === slot.preparedHead) return slot;
+    return reclassify(slot, 'recovery-required', 'The checkout is unexpectedly detached or differs from its prepared HEAD.', now);
   }
   const branch = registration ? registrationBranch(registration) : null;
   const expected = slot.lease?.branchName ?? slot.branchName;
   if (expected && branch !== expected) {
     return reclassify(slot, 'recovery-required', `The checkout is on "${branch ?? 'no branch'}", not the recorded "${expected}".`, now);
-  }
-  if (registration?.locked) {
-    return reclassify(slot, 'in-use', `Git reports this worktree locked: ${registration.lockedReason ?? 'no reason given'}.`, now);
   }
   return slot;
 }
@@ -175,6 +176,7 @@ async function adoptUnknownDirectories(
       operation: null,
       branchName: branch,
       branchKind: null,
+      preparedHead: null,
       lastReleased: null,
       reason: isLegacy
         ? 'A pre-pool checkout with no owner recorded in this pool. It is preserved until its owner is proved.'

--- a/apps/desktop/electron/features/git/worktree/pool/release-recycle.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/release-recycle.ts
@@ -1,0 +1,257 @@
+import type { AppRuntimeReleaseWorktreeRequest, AppRuntimeReleaseWorktreeResult } from '@sero-ai/common';
+
+import { execWorktreeGit } from '../exec';
+import { resolveCommit } from '../provision';
+import { resolvePreferredBaseRef } from '../workspace-sync';
+import { checkoutCleanliness } from './checkout';
+import {
+  classifyDisposability,
+  githubPullRequestEvidence,
+  type PullRequestEvidenceProvider,
+} from './disposability';
+import type { WorktreeProcessGuard } from './process-guard';
+import { resetCheckout } from './reset';
+import type { RepositoryIdentity } from './repository';
+import { commitPoolMutation } from './session';
+import { findSlot, replaceSlot } from './state-store';
+import { recordRelease, type PoolSlot } from './types';
+
+export const DEFAULT_RETAINED_IDLE_CAPACITY = 2;
+
+export type RecycleFaultPoint =
+  | 'after-reservation'
+  | 'after-owned-shutdown'
+  | 'after-reset'
+  | 'before-final-commit';
+
+export interface RecycleDependencies {
+  processGuard: WorktreeProcessGuard;
+  pullRequests?: PullRequestEvidenceProvider;
+  retainedIdleCapacity?: number;
+  fault?: (point: RecycleFaultPoint) => Promise<void> | void;
+  removeWhenFull(): Promise<AppRuntimeReleaseWorktreeResult>;
+}
+
+function result(
+  status: AppRuntimeReleaseWorktreeResult['status'],
+  slotId: string,
+  reason: string,
+  checkout: AppRuntimeReleaseWorktreeResult['checkout'],
+): AppRuntimeReleaseWorktreeResult {
+  return { status, slotId, reason, checkout };
+}
+
+async function failTransition(
+  identity: RepositoryIdentity,
+  slotId: string,
+  leaseId: string,
+  reason: string,
+): Promise<void> {
+  await commitPoolMutation(identity, (state) => {
+    const current = findSlot(state, slotId);
+    if (!current || current.lease?.leaseId !== leaseId) return { value: null };
+    return {
+      state: replaceSlot(state, {
+        ...current,
+        state: 'recovery-required',
+        operation: null,
+        reason,
+        updatedAt: new Date().toISOString(),
+      }),
+      value: null,
+    };
+  }).catch(() => undefined);
+}
+
+async function preserveLease(
+  identity: RepositoryIdentity,
+  slot: PoolSlot,
+  request: AppRuntimeReleaseWorktreeRequest,
+  reason: string,
+  recoveryRequired: boolean,
+): Promise<AppRuntimeReleaseWorktreeResult> {
+  const now = new Date().toISOString();
+  const ownedReason = slot.lease
+    ? `Kept for "${slot.lease.leaseHolder}": ${reason}`
+    : reason;
+  const committed = await commitPoolMutation<'preserved' | 'stale'>(identity, (state) => {
+    const current = findSlot(state, slot.slotId);
+    if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' };
+    const record = {
+      slotId: slot.slotId,
+      leaseId: request.expectedLeaseId,
+      disposition: request.disposition,
+      status: 'preserved' as const,
+      at: now,
+      reason: ownedReason,
+    };
+    return {
+      state: recordRelease(replaceSlot(state, {
+        ...current,
+        state: 'leased',
+        operation: null,
+        lastReleased: record,
+        reason: ownedReason,
+        updatedAt: now,
+      }), record),
+      value: 'preserved',
+    };
+  });
+  if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'retained');
+  if (committed.value === 'stale') return result('stale-lease', slot.slotId, 'The slot changed before preservation.', 'unknown');
+  return result(recoveryRequired ? 'recovery-required' : 'preserved', slot.slotId, ownedReason, 'retained');
+}
+
+export async function recycleReleasedSlot(
+  workspacePath: string,
+  identity: RepositoryIdentity,
+  slot: PoolSlot,
+  request: AppRuntimeReleaseWorktreeRequest,
+  dependencies: RecycleDependencies,
+): Promise<AppRuntimeReleaseWorktreeResult> {
+  const cleanliness = await checkoutCleanliness(slot.path);
+  if (cleanliness.status !== 'clean') {
+    const reason = cleanliness.status === 'dirty'
+      ? `The checkout has tracked changes or non-ignored untracked files: ${cleanliness.detail}`
+      : `The checkout cleanliness could not be verified: ${cleanliness.reason}`;
+    return preserveLease(identity, slot, request, reason, cleanliness.status === 'unknown');
+  }
+  let baseRef: string | null;
+  let targetCommit: string | null;
+  try {
+    baseRef = await resolvePreferredBaseRef(workspacePath);
+    targetCommit = await resolveCommit(workspacePath, baseRef ?? 'HEAD');
+  } catch (error) {
+    return preserveLease(
+      identity,
+      slot,
+      request,
+      `The exact reset target could not be resolved: ${String(error)}`,
+      true,
+    );
+  }
+  if (!targetCommit) {
+    return preserveLease(
+      identity,
+      slot,
+      request,
+      'The exact reset target could not be resolved.',
+      true,
+    );
+  }
+
+  const disposal = await classifyDisposability(
+    workspacePath,
+    slot,
+    targetCommit,
+    dependencies.pullRequests ?? githubPullRequestEvidence,
+  );
+  if (disposal.status !== 'disposable') {
+    return preserveLease(identity, slot, request, disposal.reason, disposal.status === 'unverifiable');
+  }
+
+  const capacity = dependencies.retainedIdleCapacity ?? DEFAULT_RETAINED_IDLE_CAPACITY;
+  const reserved = await commitPoolMutation(identity, (state) => {
+    const current = findSlot(state, slot.slotId);
+    if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' as const };
+    const retained = state.slots.filter((candidate) =>
+      candidate.state === 'available'
+      || (candidate.state === 'recycling' && candidate.operation?.intendedState === 'available'),
+    ).length;
+    if (retained >= capacity) return { value: 'remove' as const };
+    const now = new Date().toISOString();
+    return {
+      state: replaceSlot(state, {
+        ...current,
+        state: 'recycling',
+        operation: {
+          operationId: request.expectedLeaseId,
+          pid: process.pid,
+          startedAt: now,
+          intendedState: 'available',
+          leaseId: request.expectedLeaseId,
+          resetTarget: { ref: baseRef ?? 'HEAD', commit: targetCommit },
+        },
+        reason: `The checkout is being reset to ${targetCommit}.`,
+        updatedAt: now,
+      }),
+      value: 'recycle' as const,
+    };
+  });
+  if (reserved.status !== 'ok') return result('recovery-required', slot.slotId, reserved.reason, 'retained');
+  if (reserved.value === 'stale') return result('stale-lease', slot.slotId, 'The slot changed before reset.', 'unknown');
+  if (reserved.value === 'remove') return dependencies.removeWhenFull();
+  await dependencies.fault?.('after-reservation');
+
+  const processes = await dependencies.processGuard.prepare(slot.path);
+  if (processes.status !== 'safe') {
+    return preserveLease(
+      identity,
+      slot,
+      request,
+      processes.reason,
+      processes.status === 'unverifiable',
+    );
+  }
+  await dependencies.fault?.('after-owned-shutdown');
+
+  const reset = await resetCheckout(workspacePath, slot.path, targetCommit);
+  if (reset.status !== 'reset') {
+    const reason = `The cache-preserving reset failed: ${reset.reason}`;
+    await failTransition(identity, slot.slotId, request.expectedLeaseId, reason);
+    return result('recovery-required', slot.slotId, reason, 'retained');
+  }
+  await dependencies.fault?.('after-reset');
+
+  if (slot.lease?.branchKind === 'fresh-task' && slot.branchName) {
+    try {
+      // The exact old tip is an atomic fence. A branch that moved after
+      // classification is preserved instead of being deleted by name alone.
+      await execWorktreeGit([
+        'update-ref', '-d', `refs/heads/${slot.branchName}`, disposal.branchTip,
+      ], { cwd: workspacePath, timeout: 10_000 });
+    } catch (error) {
+      const reason = `The checkout was reset, but its disposable branch could not be deleted with the proved tip fence: ${String(error)}`;
+      await failTransition(identity, slot.slotId, request.expectedLeaseId, reason);
+      return result('recovery-required', slot.slotId, reason, 'retained');
+    }
+  }
+
+  const reason = `The checkout was reset to ${targetCommit} and retained as a reusable idle slot; ${reset.preservedIgnoredPaths} ignored path(s) were preserved.`;
+  const now = new Date().toISOString();
+  await dependencies.fault?.('before-final-commit');
+  const committed = await commitPoolMutation<'committed' | 'stale'>(identity, (state) => {
+    const current = findSlot(state, slot.slotId);
+    if (!current || current.operation?.operationId !== request.expectedLeaseId
+      || current.lease?.leaseId !== request.expectedLeaseId) {
+      return { value: 'stale' };
+    }
+    const record = {
+      slotId: slot.slotId,
+      leaseId: request.expectedLeaseId,
+      disposition: request.disposition,
+      status: 'released' as const,
+      at: now,
+      reason,
+    };
+    return {
+      state: recordRelease(replaceSlot(state, {
+        ...current,
+        state: 'available',
+        lease: null,
+        operation: null,
+        branchName: null,
+        branchKind: null,
+        preparedHead: targetCommit,
+        lastReleased: record,
+        reason,
+        updatedAt: now,
+      }), record),
+      value: 'committed',
+    };
+  });
+  if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'unknown');
+  if (committed.value === 'stale') return result('recovery-required', slot.slotId, 'The reset finished but its final state fence did not match.', 'unknown');
+  // The old lease's checkout is gone even though its physical directory is warm.
+  return result('released', slot.slotId, reason, 'removed');
+}

--- a/apps/desktop/electron/features/git/worktree/pool/release-remove.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/release-remove.ts
@@ -1,0 +1,154 @@
+import type { AppRuntimeReleaseWorktreeRequest, AppRuntimeReleaseWorktreeResult } from '@sero-ai/common';
+
+import {
+  deleteWorktreeBranch,
+  pruneWorktreeRegistrations,
+  removeRegisteredWorktree,
+} from '../removal';
+import { withGitMutationGate } from './locks';
+import type { WorktreeProcessGuard } from './process-guard';
+import type { RepositoryIdentity } from './repository';
+import { commitPoolMutation } from './session';
+import { dropSlot, findSlot, replaceSlot } from './state-store';
+import { recordRelease, type PoolSlot } from './types';
+
+function result(
+  status: AppRuntimeReleaseWorktreeResult['status'],
+  slotId: string,
+  reason: string,
+  checkout: AppRuntimeReleaseWorktreeResult['checkout'],
+): AppRuntimeReleaseWorktreeResult {
+  return { status, slotId, reason, checkout };
+}
+
+export async function removeReleasedSlot(
+  workspacePath: string,
+  identity: RepositoryIdentity,
+  slot: PoolSlot,
+  request: AppRuntimeReleaseWorktreeRequest,
+  processGuard: WorktreeProcessGuard,
+): Promise<AppRuntimeReleaseWorktreeResult> {
+  const reserved = await commitPoolMutation(identity, (state) => {
+    const current = findSlot(state, request.slotId);
+    if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' as const };
+    const now = new Date().toISOString();
+    return {
+      state: replaceSlot(state, {
+        ...current,
+        state: 'removing',
+        operation: {
+          operationId: request.expectedLeaseId,
+          pid: process.pid,
+          startedAt: now,
+          intendedState: 'available',
+          leaseId: request.expectedLeaseId,
+          resetTarget: null,
+        },
+        reason: 'The checkout is being removed after a proved-clean release.',
+        updatedAt: now,
+      }),
+      value: 'reserved' as const,
+    };
+  });
+  if (reserved.status !== 'ok') return result('recovery-required', slot.slotId, reserved.reason, 'retained');
+  if (reserved.value === 'stale') return result('stale-lease', slot.slotId, 'The slot changed before removal.', 'unknown');
+
+  const processes = await processGuard.prepare(slot.path);
+  if (processes.status !== 'safe') {
+    const reason = processes.reason;
+    await commitPoolMutation(identity, (state) => {
+      const current = findSlot(state, slot.slotId);
+      if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: null };
+      return {
+        state: replaceSlot(state, {
+          ...current,
+          state: 'leased',
+          operation: null,
+          reason,
+          updatedAt: new Date().toISOString(),
+        }),
+        value: null,
+      };
+    });
+    return result(processes.status === 'unverifiable' ? 'recovery-required' : 'preserved', slot.slotId, reason, 'retained');
+  }
+
+  const outcome = await withGitMutationGate(identity.poolDir, async () => {
+    const removal = await removeRegisteredWorktree(workspacePath, slot.path);
+    if (removal.status === 'removed') await pruneWorktreeRegistrations(workspacePath);
+    if (removal.status === 'removed'
+      && (request.deleteBranch || request.deleteMergedBranch)
+      && slot.lease?.branchKind === 'fresh-task'
+      && slot.branchName) {
+      await deleteWorktreeBranch(workspacePath, slot.branchName, {
+        deleteBranch: request.deleteBranch,
+        deleteMergedBranch: request.deleteMergedBranch,
+      });
+    }
+    return removal;
+  });
+
+  if (outcome.status === 'preserved') {
+    const reason = `Git refused to remove the checkout, so it was kept: ${outcome.detail}`;
+    await commitPoolMutation(identity, (state) => {
+      const current = findSlot(state, request.slotId);
+      if (!current) return { value: null };
+      return {
+        state: replaceSlot(state, {
+          ...current,
+          state: 'damaged',
+          operation: null,
+          reason,
+          updatedAt: new Date().toISOString(),
+        }),
+        value: null,
+      };
+    });
+    return result('recovery-required', slot.slotId, reason, 'retained');
+  }
+
+  if (outcome.status === 'not-registered') {
+    const reason = `Git no longer registered the checkout, so ownership evidence was preserved: ${outcome.detail}`;
+    await commitPoolMutation(identity, (state) => {
+      const current = findSlot(state, request.slotId);
+      if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: null };
+      return {
+        state: replaceSlot(state, {
+          ...current,
+          state: 'recovery-required',
+          operation: null,
+          reason,
+          updatedAt: new Date().toISOString(),
+        }),
+        value: null,
+      };
+    });
+    return result('recovery-required', slot.slotId, reason, 'unknown');
+  }
+
+  const reason = 'The checkout was clean, so it was removed and its slot returned.';
+  const now = new Date().toISOString();
+  const committed = await commitPoolMutation<'committed' | 'stale'>(identity, (state) => {
+    const current = findSlot(state, request.slotId);
+    if (!current || current.lease?.leaseId !== request.expectedLeaseId
+      || current.operation?.operationId !== request.expectedLeaseId) {
+      return { value: 'stale' };
+    }
+    return {
+      state: recordRelease(dropSlot(state, request.slotId), {
+        slotId: request.slotId,
+        leaseId: request.expectedLeaseId,
+        disposition: request.disposition,
+        status: 'released',
+        at: now,
+        reason,
+      }),
+      value: 'committed',
+    };
+  });
+  if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'removed');
+  if (committed.value === 'stale') {
+    return result('recovery-required', slot.slotId, 'The checkout was removed but its final state fence did not match.', 'removed');
+  }
+  return result('released', slot.slotId, reason, 'removed');
+}

--- a/apps/desktop/electron/features/git/worktree/pool/release.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/release.ts
@@ -1,37 +1,30 @@
-/**
- * Release: conditional on the exact lease identity, and never authoritative
- * about disposal.
- *
- * Three outcomes are distinguished precisely, because they have different
- * consequences for work on disk:
- *
- *  - the first release of lease L1 acts;
- *  - a retry of L1 before reassignment answers `already-released` and changes
- *    nothing;
- *  - a delayed L1 arriving after the slot took lease L2 answers `stale-lease`
- *    and cannot touch L2's checkout.
- *
- * An identity older than the retained release history fails closed as stale.
- * The caller's disposition is intent only: the host re-classifies the checkout
- * and preserves it whenever removal cannot be proved safe.
- */
-
 import type {
   AppRuntimeReleaseWorktreeRequest,
   AppRuntimeReleaseWorktreeResult,
 } from '@sero-ai/common';
 
 import { branchWorkSinceBase, checkoutCleanliness } from './checkout';
-import { withGitMutationGate } from './locks';
 import {
-  deleteWorktreeBranch,
-  pruneWorktreeRegistrations,
-  removeRegisteredWorktree,
-} from '../removal';
+  defaultWorktreeProcessGuard,
+  type WorktreeProcessGuard,
+} from './process-guard';
+import { removeReleasedSlot } from './release-remove';
+import {
+  recycleReleasedSlot,
+  type RecycleFaultPoint,
+} from './release-recycle';
+import type { PullRequestEvidenceProvider } from './disposability';
 import type { RepositoryIdentity } from './repository';
 import { commitPoolMutation, openPool } from './session';
-import { dropSlot, findSlot, replaceSlot } from './state-store';
+import { findSlot, replaceSlot } from './state-store';
 import { recordRelease, type PoolSlot, type PoolState, type SlotState } from './types';
+
+export interface ReleaseWorktreeDependencies {
+  processGuard?: WorktreeProcessGuard;
+  pullRequests?: PullRequestEvidenceProvider;
+  retainedIdleCapacity?: number;
+  fault?: (point: RecycleFaultPoint) => Promise<void> | void;
+}
 
 function result(
   status: AppRuntimeReleaseWorktreeResult['status'],
@@ -46,7 +39,6 @@ function recordedCheckout(status: 'released' | 'preserved'): AppRuntimeReleaseWo
   return status === 'released' ? 'removed' : 'retained';
 }
 
-/** Answers a release whose slot is no longer in the pool. */
 function answerMissingSlot(
   state: PoolState,
   request: AppRuntimeReleaseWorktreeRequest,
@@ -70,28 +62,13 @@ function answerMissingSlot(
   );
 }
 
-interface Classification {
+interface RemovalClassification {
   state: SlotState;
   reason: string;
-  /** False when the checkout must be kept whatever the caller asked for. */
   removable: boolean;
 }
 
-/**
- * What this checkout is, and whether this disposition may dispose of it.
- *
- * Two conditions preserve it under every disposition, because neither can be
- * undone: work Git has not been told about, and a status Git could not report.
- * A `recycle` — the routine end-of-run return — additionally keeps a checkout
- * whose branch holds work the base does not, and an open pull request's
- * checkout. A `remove` is explicitly authorised disposal, so committed work no
- * longer blocks it; the branch itself still survives unless the caller also
- * asked for its deletion, and a pull-request branch is never deleted at all.
- */
-async function classify(
-  slot: PoolSlot,
-  disposition: AppRuntimeReleaseWorktreeRequest['disposition'],
-): Promise<Classification> {
+async function classifyRemoval(slot: PoolSlot): Promise<RemovalClassification> {
   const cleanliness = await checkoutCleanliness(slot.path);
   if (cleanliness.status === 'unknown') {
     return {
@@ -107,90 +84,85 @@ async function classify(
       removable: false,
     };
   }
-
-  const external = slot.lease?.branchKind === 'external-pr';
-  if (external) {
-    // A pull-request checkout may be disposed of by an explicit `remove`; its
-    // branch is never deleted, whatever the caller asked for.
+  if (slot.lease?.branchKind === 'external-pr') {
     return {
-      state: disposition === 'remove' ? 'available' : 'unmerged',
-      reason: 'The checkout is on a pull request branch, whose branch Sero never deletes.',
-      removable: disposition === 'remove',
+      state: 'available',
+      reason: 'Explicit removal may remove this checkout, but never its external pull-request branch.',
+      removable: true,
     };
   }
-
   const work = await branchWorkSinceBase(slot.path, slot.lease?.baseCommit ?? null);
   if (work.status === 'unknown') {
-    // An answer Git could not give is not an answer that the branch is
-    // disposable. No disposition overrides it.
     return {
       state: 'recovery-required',
       reason: `The branch could not be compared with its base: ${work.reason}`,
       removable: false,
     };
   }
-  if (work.status === 'has-work') {
-    return {
-      state: 'unmerged',
-      reason: `The branch holds ${work.commits} commit(s) the base does not.`,
-      // `recycle` is the routine return and keeps committed work; `remove` is
-      // explicitly authorised disposal, and the branch itself still survives.
-      removable: disposition === 'remove',
-    };
-  }
   return {
-    state: 'available',
-    reason: 'The checkout is clean and its branch added nothing to the base.',
+    state: work.status === 'has-work' ? 'unmerged' : 'available',
+    reason: work.status === 'has-work'
+      ? `Explicit removal may remove the checkout holding ${work.commits} local commit(s); its branch is retained unless separately authorised.`
+      : 'The checkout is clean and its branch added nothing to the acquisition base.',
     removable: true,
   };
 }
 
-/**
- * A preserved checkout KEEPS its lease.
- *
- * Clearing it would leave work on disk that no logical consumer names and no
- * pool record owns, at exactly the moment the consumer moves on to its next
- * run. The slot therefore stays `leased` to the same holder — the issue's
- * "preserve lease and checkout" outcome — with the classification recorded as
- * its reason. Only a completed removal ends ownership.
- */
 function preserveSlot(
   state: PoolState,
   slot: PoolSlot,
-  classification: Classification,
+  reason: string,
   disposition: AppRuntimeReleaseWorktreeRequest['disposition'],
 ): PoolState {
   if (!slot.lease) return state;
   const now = new Date().toISOString();
-  const reason = `Kept for "${slot.lease.leaseHolder}": ${classification.reason}`;
-  const withSlot = replaceSlot(state, {
-    ...slot,
-    state: 'leased',
-    operation: null,
-    lastReleased: {
-      slotId: slot.slotId,
-      leaseId: slot.lease.leaseId,
-      disposition,
-      status: 'preserved',
-      at: now,
-      reason,
-    },
-    reason,
-    updatedAt: now,
-  });
-  return recordRelease(withSlot, {
+  const ownedReason = `Kept for "${slot.lease.leaseHolder}": ${reason}`;
+  const record = {
     slotId: slot.slotId,
     leaseId: slot.lease.leaseId,
     disposition,
-    status: 'preserved',
+    status: 'preserved' as const,
     at: now,
-    reason,
+    reason: ownedReason,
+  };
+  return recordRelease(replaceSlot(state, {
+    ...slot,
+    state: 'leased',
+    operation: null,
+    lastReleased: record,
+    reason: ownedReason,
+    updatedAt: now,
+  }), record);
+}
+
+async function commitPreserved(
+  identity: RepositoryIdentity,
+  slot: PoolSlot,
+  request: AppRuntimeReleaseWorktreeRequest,
+  classification: RemovalClassification,
+): Promise<AppRuntimeReleaseWorktreeResult> {
+  const committed = await commitPoolMutation(identity, (state) => {
+    const current = findSlot(state, request.slotId);
+    if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' as const };
+    return {
+      state: preserveSlot(state, current, classification.reason, request.disposition),
+      value: 'preserved' as const,
+    };
   });
+  if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'retained');
+  if (committed.value === 'stale') return result('stale-lease', slot.slotId, 'The slot changed before preservation.', 'unknown');
+  return result(
+    classification.state === 'recovery-required' ? 'recovery-required' : 'preserved',
+    slot.slotId,
+    classification.reason,
+    'retained',
+  );
 }
 
 export async function releaseWorktree(
   workspacePath: string,
   request: AppRuntimeReleaseWorktreeRequest,
+  dependencies: ReleaseWorktreeDependencies = {},
 ): Promise<AppRuntimeReleaseWorktreeResult> {
   const opened = await openPool(workspacePath);
   if (opened.status !== 'ok') return result('recovery-required', request.slotId, opened.reason, 'retained');
@@ -220,15 +192,9 @@ export async function releaseWorktree(
       'unknown',
     );
   }
-  // `openPool` has already weighed this slot against Git and the filesystem. A
-  // matching lease id does not overrule that verdict: a detached checkout, a
-  // changed branch, a missing or locked registration, or a directory Git has
-  // forgotten is not disposable however sound the caller's identity is.
   if (slot.state !== 'leased') {
     return result('recovery-required', slot.slotId, `Slot ${slot.slotId} is ${slot.state}: ${slot.reason}`, 'retained');
   }
-  // An identical retry changes nothing. A different disposition is a new
-  // decision about the same checkout and is classified afresh.
   if (slot.lastReleased?.leaseId === request.expectedLeaseId
     && slot.lastReleased.disposition === request.disposition) {
     return result(
@@ -239,110 +205,26 @@ export async function releaseWorktree(
     );
   }
 
-  const classification = await classify(slot, request.disposition);
-  const removing = request.disposition !== 'preserve' && classification.removable;
-
-  if (!removing) {
-    const committed = await commitPoolMutation(identity, (state) => {
-      const current = findSlot(state, request.slotId);
-      if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' as const };
-      return {
-        state: preserveSlot(state, current, classification, request.disposition),
-        value: 'preserved' as const,
-      };
+  if (request.disposition === 'preserve') {
+    return commitPreserved(identity, slot, request, {
+      state: 'leased',
+      reason: 'The caller requested that this exact lease and checkout be preserved.',
+      removable: false,
     });
-    if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'retained');
-    if (committed.value === 'stale') {
-      return result('stale-lease', slot.slotId, 'The slot was reassigned before this release was committed.', 'unknown');
-    }
-    const status = classification.state === 'recovery-required' ? 'recovery-required' : 'preserved';
-    return result(status, slot.slotId, classification.reason, 'retained');
   }
 
-  return removeSlot(workspacePath, identity, slot, request);
-}
-
-async function removeSlot(
-  workspacePath: string,
-  identity: RepositoryIdentity,
-  slot: PoolSlot,
-  request: AppRuntimeReleaseWorktreeRequest,
-): Promise<AppRuntimeReleaseWorktreeResult> {
-  const reserved = await commitPoolMutation(identity, (state) => {
-    const current = findSlot(state, request.slotId);
-    if (!current || current.lease?.leaseId !== request.expectedLeaseId) return { value: 'stale' as const };
-    const now = new Date().toISOString();
-    return {
-      state: replaceSlot(state, {
-        ...current,
-        state: 'removing',
-        operation: {
-          operationId: request.expectedLeaseId,
-          pid: process.pid,
-          startedAt: now,
-          intendedState: 'available',
-          leaseId: request.expectedLeaseId,
-        },
-        reason: 'The checkout is being removed after a proved-clean release.',
-        updatedAt: now,
-      }),
-      value: 'reserved' as const,
-    };
-  });
-  if (reserved.status !== 'ok') return result('recovery-required', slot.slotId, reserved.reason, 'retained');
-  if (reserved.value === 'stale') {
-    return result('stale-lease', slot.slotId, 'The slot was reassigned before this release was committed.', 'unknown');
-  }
-
-  // No `--force`: cleanliness was proved above, so a Git refusal here is new
-  // information and must preserve the checkout rather than override it.
-  const outcome = await withGitMutationGate(identity.poolDir, async () => {
-    const removal = await removeRegisteredWorktree(workspacePath, slot.path);
-    if (removal.status === 'removed' || removal.status === 'not-registered') {
-      await pruneWorktreeRegistrations(workspacePath);
-    }
-    // An external pull-request branch is never deleted, whatever was asked.
-    if (removal.status === 'removed'
-      && (request.deleteBranch || request.deleteMergedBranch)
-      && slot.lease?.branchKind === 'fresh-task'
-      && slot.branchName) {
-      await deleteWorktreeBranch(workspacePath, slot.branchName, {
-        deleteBranch: request.deleteBranch,
-        deleteMergedBranch: request.deleteMergedBranch,
-      });
-    }
-    return removal;
-  });
-
-  if (outcome.status === 'preserved') {
-    const reason = `Git refused to remove the checkout, so it was kept: ${outcome.detail}`;
-    await commitPoolMutation(identity, (state) => {
-      const current = findSlot(state, request.slotId);
-      if (!current) return { value: null };
-      const now = new Date().toISOString();
-      return {
-        state: replaceSlot(state, { ...current, state: 'damaged', operation: null, reason, updatedAt: now }),
-        value: null,
-      };
+  const guard = dependencies.processGuard ?? defaultWorktreeProcessGuard;
+  if (request.disposition === 'recycle') {
+    return recycleReleasedSlot(opened.session.workspacePath, identity, slot, request, {
+      processGuard: guard,
+      pullRequests: dependencies.pullRequests,
+      retainedIdleCapacity: dependencies.retainedIdleCapacity,
+      fault: dependencies.fault,
+      removeWhenFull: () => removeReleasedSlot(opened.session.workspacePath, identity, slot, request, guard),
     });
-    return result('recovery-required', slot.slotId, reason, 'retained');
   }
 
-  const reason = outcome.status === 'removed'
-    ? 'The checkout was clean, so it was removed and its slot returned.'
-    : 'Git had no registration for the checkout, so the slot was returned without deleting anything.';
-  const now = new Date().toISOString();
-  const committed = await commitPoolMutation(identity, (state) => ({
-    state: recordRelease(dropSlot(state, request.slotId), {
-      slotId: request.slotId,
-      leaseId: request.expectedLeaseId,
-      disposition: request.disposition,
-      status: 'released',
-      at: now,
-      reason,
-    }),
-    value: null,
-  }));
-  if (committed.status !== 'ok') return result('recovery-required', slot.slotId, committed.reason, 'removed');
-  return result('released', slot.slotId, reason, 'removed');
+  const classification = await classifyRemoval(slot);
+  if (!classification.removable) return commitPreserved(identity, slot, request, classification);
+  return removeReleasedSlot(opened.session.workspacePath, identity, slot, request, guard);
 }

--- a/apps/desktop/electron/features/git/worktree/pool/reset.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/reset.ts
@@ -1,0 +1,71 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { execWorktreeGit } from '../exec';
+import { checkoutCleanliness } from './checkout';
+import { listWorktreeRegistrations } from './registration';
+import { canonicalPath } from './repository';
+
+export type ResetResult =
+  | { status: 'reset'; preservedIgnoredPaths: number }
+  | { status: 'failed'; reason: string };
+
+async function ignoredPaths(worktreePath: string): Promise<string[]> {
+  const { stdout } = await execWorktreeGit([
+    'ls-files', '--others', '--ignored', '--exclude-standard', '--directory', '-z',
+  ], { cwd: worktreePath, timeout: 30_000, maxBuffer: 16 * 1024 * 1024 });
+  return stdout.split('\0').filter(Boolean);
+}
+
+async function verifyIgnoredPaths(worktreePath: string, before: string[]): Promise<boolean> {
+  const checks = await Promise.all(before.map(async (entry) => {
+    const relative = entry.endsWith('/') ? entry.slice(0, -1) : entry;
+    return (await fs.stat(path.join(worktreePath, relative)).catch(() => null)) !== null;
+  }));
+  return checks.every(Boolean);
+}
+
+/** Cache-preserving reset of one reserved, already registered checkout. */
+export async function resetCheckout(workspacePath: string, worktreePath: string, targetCommit: string): Promise<ResetResult> {
+  try {
+    const ignoredBefore = await ignoredPaths(worktreePath);
+    await execWorktreeGit(['switch', '--detach', targetCommit], { cwd: worktreePath, timeout: 30_000 });
+    await execWorktreeGit(['reset', '--hard', targetCommit], { cwd: worktreePath, timeout: 30_000 });
+    await execWorktreeGit(['clean', '-fd'], { cwd: worktreePath, timeout: 30_000 });
+
+    const [listing, cleanliness, head, canonical] = await Promise.all([
+      listWorktreeRegistrations(workspacePath),
+      checkoutCleanliness(worktreePath),
+      execWorktreeGit(['rev-parse', 'HEAD'], { cwd: worktreePath, timeout: 10_000 }),
+      canonicalPath(worktreePath),
+    ]);
+    if (listing.status !== 'ok') return { status: 'failed', reason: `Registration verification failed: ${listing.reason}` };
+    if (!listing.nulDelimited) {
+      return { status: 'failed', reason: 'Git cannot provide path-exact NUL-delimited registration evidence.' };
+    }
+    const registration = await Promise.all(listing.records.map(async (record) => ({
+      record,
+      path: await canonicalPath(record.path),
+    }))).then((records) => records.find((entry) => entry.path === canonical)?.record);
+    if (!registration || registration.prunable || registration.locked || !registration.detached) {
+      return { status: 'failed', reason: 'The reset checkout registration is missing, locked, prunable, or not detached.' };
+    }
+    if (registration.head !== targetCommit || head.stdout.trim() !== targetCommit) {
+      return { status: 'failed', reason: 'The reset checkout HEAD does not equal the recorded exact target.' };
+    }
+    if (cleanliness.status !== 'clean') {
+      return {
+        status: 'failed',
+        reason: cleanliness.status === 'dirty'
+          ? `The reset checkout is still dirty: ${cleanliness.detail}`
+          : `The reset checkout could not be verified clean: ${cleanliness.reason}`,
+      };
+    }
+    if (!await verifyIgnoredPaths(worktreePath, ignoredBefore)) {
+      return { status: 'failed', reason: 'At least one ignored dependency or cache path was lost during reset.' };
+    }
+    return { status: 'reset', preservedIgnoredPaths: ignoredBefore.length };
+  } catch (error) {
+    return { status: 'failed', reason: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/apps/desktop/electron/features/git/worktree/pool/session.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/session.ts
@@ -94,7 +94,7 @@ export async function openPool(workspacePath: string): Promise<OpenPoolResult> {
     if (reconciled.notes.length > 0) {
       console.log(`[worktree-pool] reconciled ${canonicalWorkspace}: ${reconciled.notes.join('; ')}`);
     }
-    const state = reconciled.changed || read.status === 'empty'
+    const state = reconciled.changed || read.status === 'empty' || (read.status === 'ok' && read.migrated)
       ? await writePoolState(identity.identity.statePath, reconciled.state)
       : reconciled.state;
     return { status: 'ok' as const, state };

--- a/apps/desktop/electron/features/git/worktree/pool/state-store.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/state-store.ts
@@ -16,10 +16,10 @@ import path from 'node:path';
 
 import type { AppRuntimeWorktreeLease } from '@sero-ai/common';
 import { POOL_SCHEMA_VERSION, type PoolSlot, type PoolState } from './types';
-import { validatePoolState } from './validate-state';
+import { migratePoolState, validatePoolState } from './validate-state';
 
 export type PoolStateRead =
-  | { status: 'ok'; state: PoolState }
+  | { status: 'ok'; state: PoolState; migrated: boolean }
   /** No state file yet. A first-use pool for this repository is safe to create. */
   | { status: 'empty' }
   | { status: 'unavailable'; reason: string };
@@ -52,7 +52,8 @@ export async function readPoolState(statePath: string): Promise<PoolStateRead> {
     return { status: 'unavailable', reason: 'Pool state is not valid JSON. It was preserved for diagnosis.' };
   }
 
-  const validated = validatePoolState(parsed);
+  const migration = migratePoolState(parsed);
+  const validated = validatePoolState(migration.value);
   if (validated.status === 'invalid') {
     await preserveCorruptState(statePath, raw);
     return { status: 'unavailable', reason: `${validated.reason} The file was preserved for diagnosis.` };
@@ -64,7 +65,7 @@ export async function readPoolState(statePath: string): Promise<PoolStateRead> {
         + 'A newer Sero may own this repository.',
     };
   }
-  return { status: 'ok', state: validated.state };
+  return { status: 'ok', state: validated.state, migrated: migration.migrated };
 }
 
 /**

--- a/apps/desktop/electron/features/git/worktree/pool/types.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/types.ts
@@ -14,7 +14,7 @@ import type {
 } from '@sero-ai/common';
 
 /** Bumped whenever a persisted field changes. Unknown versions fail closed. */
-export const POOL_SCHEMA_VERSION = 2;
+export const POOL_SCHEMA_VERSION = 3;
 
 /**
  * Stable states describe what a slot is. Transitional states describe an
@@ -48,6 +48,8 @@ export interface PoolOperation {
   startedAt: string;
   intendedState: SlotState;
   leaseId: string | null;
+  /** Exact checkout target resolved before a recycling transition starts. */
+  resetTarget: { ref: string; commit: string } | null;
 }
 
 /**
@@ -78,6 +80,8 @@ export interface PoolSlot {
   operation: PoolOperation | null;
   branchName: string | null;
   branchKind: AppRuntimeWorktreeBranchKind | null;
+  /** HEAD proved after the last cache-preserving reset. */
+  preparedHead: string | null;
   lastReleased: ReleasedLeaseRecord | null;
   /** Plain-English explanation of the current state. Never an empty string. */
   reason: string;

--- a/apps/desktop/electron/features/git/worktree/pool/validate-state.ts
+++ b/apps/desktop/electron/features/git/worktree/pool/validate-state.ts
@@ -20,7 +20,7 @@ import type {
   AppRuntimeWorktreeLease,
 } from '@sero-ai/common';
 
-import type { PoolOperation, PoolSlot, PoolState, ReleasedLeaseRecord, SlotState } from './types';
+import { isTransitional, type PoolOperation, type PoolSlot, type PoolState, type ReleasedLeaseRecord, type SlotState } from './types';
 
 export type PoolStateValidation =
   | { status: 'valid'; state: PoolState }
@@ -51,6 +51,12 @@ function nullableStr(value: unknown): { ok: true; value: string | null } | { ok:
   return text === null ? { ok: false } : { ok: true, value: text };
 }
 
+function nullablePositiveInt(value: unknown): { ok: true; value: number | null } | { ok: false } {
+  if (value === null) return { ok: true, value: null };
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) return { ok: true, value };
+  return { ok: false };
+}
+
 function parseLease(value: unknown): AppRuntimeWorktreeLease | null {
   const raw = asRecord(value);
   if (!raw) return null;
@@ -66,7 +72,8 @@ function parseLease(value: unknown): AppRuntimeWorktreeLease | null {
   const baseRef = nullableStr(raw.baseRef);
   const baseCommit = nullableStr(raw.baseCommit);
   const acquiredHead = nullableStr(raw.acquiredHead);
-  if (!baseRef.ok || !baseCommit.ok || !acquiredHead.ok) return null;
+  const pullRequestNumber = nullablePositiveInt(raw.pullRequestNumber);
+  if (!baseRef.ok || !baseCommit.ok || !acquiredHead.ok || !pullRequestNumber.ok) return null;
   if (typeof raw.greenfield !== 'boolean') return null;
   return {
     slotId,
@@ -78,6 +85,7 @@ function parseLease(value: unknown): AppRuntimeWorktreeLease | null {
     baseRef: baseRef.value,
     baseCommit: baseCommit.value,
     acquiredHead: acquiredHead.value,
+    pullRequestNumber: pullRequestNumber.value,
     acquiredAt,
     greenfield: raw.greenfield,
   };
@@ -93,12 +101,18 @@ function parseOperation(value: unknown): PoolOperation | null {
   if (!operationId || !startedAt || !intendedState || !leaseId.ok) return null;
   if (!SLOT_STATES.includes(intendedState)) return null;
   if (typeof raw.pid !== 'number' || !Number.isInteger(raw.pid)) return null;
+  const resetRaw = raw.resetTarget === null ? null : asRecord(raw.resetTarget);
+  if (raw.resetTarget !== null && !resetRaw) return null;
+  const resetRef = resetRaw ? str(resetRaw.ref) : null;
+  const resetCommit = resetRaw ? str(resetRaw.commit) : null;
+  if (resetRaw && (!resetRef || !resetCommit)) return null;
   return {
     operationId,
     pid: raw.pid,
     startedAt,
     intendedState: intendedState as SlotState,
     leaseId: leaseId.value,
+    resetTarget: resetRaw ? { ref: resetRef as string, commit: resetCommit as string } : null,
   };
 }
 
@@ -142,6 +156,8 @@ function parseSlot(value: unknown): PoolSlot | null {
   const branchKindRaw = nullableStr(raw.branchKind);
   if (!branchKindRaw.ok) return null;
   if (branchKindRaw.value !== null && !BRANCH_KINDS.includes(branchKindRaw.value)) return null;
+  const preparedHead = nullableStr(raw.preparedHead);
+  if (!preparedHead.ok) return null;
 
   const lease = raw.lease === null ? null : parseLease(raw.lease);
   if (raw.lease !== null && lease === null) return null;
@@ -159,6 +175,7 @@ function parseSlot(value: unknown): PoolSlot | null {
     operation,
     branchName: branchName.value,
     branchKind: branchKindRaw.value as AppRuntimeWorktreeBranchKind | null,
+    preparedHead: preparedHead.value,
     lastReleased,
     reason,
     legacy: raw.legacy,
@@ -171,6 +188,22 @@ function parseSlot(value: unknown): PoolSlot | null {
 function slotDisagreement(slot: PoolSlot): string | null {
   const { lease } = slot;
   if (slot.state === 'leased' && !lease) return `slot ${slot.slotId} is leased but holds no lease`;
+  if (slot.state === 'available'
+    && (lease || !slot.preparedHead || slot.branchName !== null || slot.branchKind !== null)) {
+    return `slot ${slot.slotId} is available without one prepared HEAD, no lease, and no branch`;
+  }
+  if (slot.state === 'leased' && slot.preparedHead !== null) {
+    return `slot ${slot.slotId} is leased but still claims a prepared idle HEAD`;
+  }
+  if (isTransitional(slot.state) !== (slot.operation !== null)) {
+    return `slot ${slot.slotId} disagrees about whether its ${slot.state} state has an operation`;
+  }
+  if (slot.state === 'recycling' && !slot.operation?.resetTarget) {
+    return `slot ${slot.slotId} is recycling without an exact reset target`;
+  }
+  if (slot.state !== 'recycling' && slot.operation?.resetTarget) {
+    return `slot ${slot.slotId} has a reset target outside a recycling transition`;
+  }
   if (lease) {
     if (lease.slotId !== slot.slotId) return `lease ${lease.leaseId} names slot ${lease.slotId}, not ${slot.slotId}`;
     if (lease.worktreePath !== slot.path) return `lease ${lease.leaseId} names a different path from slot ${slot.slotId}`;
@@ -188,6 +221,34 @@ function slotDisagreement(slot: PoolSlot): string | null {
     return `slot ${slot.slotId} records a release belonging to slot ${slot.lastReleased.slotId}`;
   }
   return null;
+}
+
+/**
+ * Schema v2 never reused a checkout. Its slots can therefore be upgraded by
+ * adding only null provenance/reset fields; no v2 slot is promoted available.
+ */
+export function migratePoolState(value: unknown): { migrated: boolean; value: unknown } {
+  const raw = asRecord(value);
+  if (!raw || raw.version !== 2 || !Array.isArray(raw.slots)) return { migrated: false, value };
+  return {
+    migrated: true,
+    value: {
+      ...raw,
+      version: 3,
+      slots: raw.slots.map((entry) => {
+        const slot = asRecord(entry);
+        if (!slot) return entry;
+        const lease = slot.lease === null ? null : asRecord(slot.lease);
+        const operation = slot.operation === null ? null : asRecord(slot.operation);
+        return {
+          ...slot,
+          preparedHead: null,
+          lease: lease ? { ...lease, pullRequestNumber: null } : slot.lease,
+          operation: operation ? { ...operation, resetTarget: null } : slot.operation,
+        };
+      }),
+    },
+  };
 }
 
 /** Relationships that must hold ACROSS slots. */

--- a/apps/desktop/electron/features/git/worktree/provision.ts
+++ b/apps/desktop/electron/features/git/worktree/provision.ts
@@ -127,6 +127,7 @@ export async function addWorktreeOnNewBranch(
   worktreePath: string,
   branchName: string,
   baseRef: string | null,
+  options?: { reattachExisting?: boolean },
 ): Promise<void> {
   await fs.mkdir(path.dirname(worktreePath), { recursive: true });
   const addArgs = ['worktree', 'add', worktreePath, '-b', branchName, ...(baseRef ? [baseRef] : [])];
@@ -135,7 +136,7 @@ export async function addWorktreeOnNewBranch(
   } catch (error: unknown) {
     const detail = stderrOf(error);
     // A branch of that name already exists: attach to it rather than minting.
-    if (detail.includes('already exists')) {
+    if (detail.includes('already exists') && options?.reattachExisting !== false) {
       await execWorktreeGit(['worktree', 'add', worktreePath, branchName], {
         cwd: workspacePath,
         timeout: 30_000,

--- a/apps/desktop/electron/features/workspace/runtime/backends/host/host-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/host/host-backend.ts
@@ -1,8 +1,8 @@
-import { execFile, spawn as spawnProcess } from 'child_process';
+import { spawn as spawnProcess } from 'child_process';
 import path from 'path';
-import { promisify } from 'util';
 
 import { TerminalManager } from '@electron/features/container/terminal';
+import { seroOwnedProcesses } from '@electron/features/git/worktree/pool/owned-processes';
 import type { WorkspaceManager } from '@electron/features/workspace/manager';
 import { getRuntimeCapabilities } from '../../capabilities';
 import { RUNTIME_WORKSPACE_PATH, isRuntimeWorkspacePath, toHostWorkspacePath, toRuntimeWorkspacePath } from '../../runtime-paths';
@@ -50,8 +50,7 @@ import { HostDevServerManager } from './host-dev-server-manager';
 import { runHostDoctorChecks } from './host-doctor';
 import { createHostProcessAdapter } from './process/factory';
 import { createHostProcessEnv } from './host-env';
-
-const execFileAsync = promisify(execFile);
+import { trackedExecFile } from './tracked-exec';
 
 function getSeroAgentRootPath(): string | null {
   const explicitAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -146,7 +145,7 @@ export class HostBackend implements RuntimeBackend {
       env: await createHostProcessEnv(this.workspaceId, input.env, this.substrate.platform),
     });
     try {
-      const { stdout, stderr } = await execFileAsync(rendered.program, rendered.args, {
+      const { stdout, stderr } = await trackedExecFile(this.workspaceId, cwd, rendered.program, rendered.args, {
         cwd: rendered.nativeCwd,
         env: rendered.env,
         timeout: input.timeoutMs ?? 120_000,
@@ -178,7 +177,7 @@ export class HostBackend implements RuntimeBackend {
       env: await createHostProcessEnv(this.workspaceId, input.env, this.substrate.platform),
     });
     try {
-      const { stdout, stderr } = await execFileAsync(rendered.program, rendered.args, {
+      const { stdout, stderr } = await trackedExecFile(this.workspaceId, cwd, rendered.program, rendered.args, {
         cwd: rendered.nativeCwd,
         env: rendered.env,
         timeout: input.timeoutMs ?? 120_000,
@@ -206,9 +205,10 @@ export class HostBackend implements RuntimeBackend {
   }
 
   async spawn(input: RuntimeProcessInput): Promise<RuntimeProcess> {
+    const cwd = (await this.resolveHostPath(input.cwd ?? this.runtimeWorkspacePath)).hostPath;
     const rendered = await this.substrate.shellCommand({
       command: input.command,
-      cwd: (await this.resolveHostPath(input.cwd ?? this.runtimeWorkspacePath)).hostPath,
+      cwd,
       env: await createHostProcessEnv(this.workspaceId, input.env, this.substrate.platform),
     });
     const child = spawnProcess(rendered.program, rendered.args, {
@@ -221,8 +221,23 @@ export class HostBackend implements RuntimeBackend {
 
     child.stdout?.on('data', (chunk: Buffer) => emitData(dataCallbacks, chunk));
     child.stderr?.on('data', (chunk: Buffer) => emitData(dataCallbacks, chunk));
+    let exited = false;
+    let unregister: () => void = () => undefined;
+    const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
     child.on('exit', (exitCode, signal) => {
+      exited = true;
+      unregister();
       for (const cb of exitCallbacks) cb({ exitCode, signal: signal ?? undefined });
+    });
+
+    unregister = seroOwnedProcesses.register({
+      id: `${input.ownerKind ?? 'command'}:${this.workspaceId}:${child.pid ?? 'pending'}`,
+      kind: input.ownerKind ?? 'command',
+      cwd,
+      stop: async () => {
+        if (!exited) await this.substrate.signalChild(child, rendered, 'SIGTERM');
+        await closed;
+      },
     });
 
     const executionPid = await this.substrate.resolveExecutionPid?.(child, rendered);
@@ -293,16 +308,33 @@ export class HostBackend implements RuntimeBackend {
   }
 
   async createTerminal(input: RuntimeTerminalInput): Promise<RuntimeTerminalSession> {
+    const cwd = (await this.resolveHostPath(input.cwd ?? this.runtimeWorkspacePath)).hostPath;
     const terminal = this.terminals.createHostTerminal(
       this.workspaceId,
       input.terminalId,
       await this.substrate.terminalCommand({
-        cwd: (await this.resolveHostPath(input.cwd ?? this.runtimeWorkspacePath)).hostPath,
+        cwd,
         env: await createHostProcessEnv(this.workspaceId, undefined, this.substrate.platform, { tokenMode: 'reusable' }),
       }),
       input.cols,
       input.rows,
     );
+    let exited = false;
+    let unregister: () => void = () => undefined;
+    const exitedPromise = new Promise<void>((resolve) => terminal.onExit(() => {
+      exited = true;
+      unregister();
+      resolve();
+    }));
+    unregister = seroOwnedProcesses.register({
+      id: `terminal:${this.workspaceId}:${input.terminalId}`,
+      kind: 'terminal',
+      cwd,
+      async stop() {
+        if (!exited) terminal.kill();
+        await exitedPromise;
+      },
+    });
     return {
       terminalId: input.terminalId,
       pid: terminal.pid,

--- a/apps/desktop/electron/features/workspace/runtime/backends/host/host-dev-server-manager.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/host/host-dev-server-manager.ts
@@ -77,7 +77,12 @@ export class HostDevServerManager {
 
   async start(input: RuntimeDevServerStartInput): Promise<RuntimeDevServer> {
     const cwd = input.cwd || this.defaultCwd;
-    const process = await this.spawn({ command: input.command, cwd, stdio: 'pipe' });
+    const process = await this.spawn({
+      command: input.command,
+      cwd,
+      stdio: 'pipe',
+      ownerKind: 'managed-dev-server',
+    });
     const pid = process.pid;
     const detectionPid = process.executionPid ?? process.pid;
     const baseId = `${this.workspaceId}:${input.scope ?? 'workspace'}:${input.cardId ?? 'root'}`;

--- a/apps/desktop/electron/features/workspace/runtime/backends/host/tracked-exec.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/host/tracked-exec.ts
@@ -1,0 +1,48 @@
+import { execFile, type ExecFileOptions } from 'node:child_process';
+
+import { seroOwnedProcesses } from '@electron/features/git/worktree/pool/owned-processes';
+
+interface TrackedExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+let nextCommandId = 0;
+
+/** Runs a host command while exposing its owner-confirmed stop to slot reuse. */
+export function trackedExecFile(
+  workspaceId: string,
+  cwd: string,
+  program: string,
+  args: string[],
+  options: ExecFileOptions,
+): Promise<TrackedExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(program, args, options, (error, stdout, stderr) => {
+      unregister();
+      if (error) {
+        Object.assign(error, { stdout, stderr });
+        reject(error);
+        return;
+      }
+      resolve({ stdout: String(stdout), stderr: String(stderr) });
+    });
+    const id = `command:${workspaceId}:${child.pid ?? 'pending'}:${nextCommandId += 1}`;
+    let exited = false;
+    const closed = new Promise<void>((resolveClosed) => {
+      child.once('close', () => {
+        exited = true;
+        resolveClosed();
+      });
+    });
+    const unregister = seroOwnedProcesses.register({
+      id,
+      kind: 'command',
+      cwd,
+      async stop() {
+        if (!exited) child.kill('SIGTERM');
+        await closed;
+      },
+    });
+  });
+}

--- a/apps/desktop/electron/features/workspace/runtime/start-managed-dev-server.ts
+++ b/apps/desktop/electron/features/workspace/runtime/start-managed-dev-server.ts
@@ -1,4 +1,5 @@
 import type { DevServer } from '@/types/ipc';
+import { seroOwnedProcesses } from '@electron/features/git/worktree/pool/owned-processes';
 import { runtimeManager, type RuntimeManager } from './runtime-manager';
 import { toRuntimeWorkspacePath } from './runtime-paths';
 
@@ -55,6 +56,27 @@ export async function startManagedDevServer(
     });
     if (server.status === 'failed' || !server.port || !server.url) {
       return { reason: server.diagnosticCode ?? 'Managed dev server failed to start.' };
+    }
+    if (runtime.backend !== 'host') {
+      let unregister: () => void = () => undefined;
+      let unsubscribe: () => void = () => undefined;
+      const cleanup = (): void => {
+        unregister();
+        unsubscribe();
+      };
+      unregister = seroOwnedProcesses.register({
+        id: `managed-dev-server:${options.workspaceId}:${server.id}`,
+        kind: 'managed-dev-server',
+        cwd: options.cwdPath,
+        stop: async () => {
+          await runtime.stopDevServer({ serverId: server.id });
+          cleanup();
+        },
+      });
+      unsubscribe = manager.onDevServerChange((event) => {
+        if (event.workspaceId !== options.workspaceId || event.serverId !== server.id) return;
+        if (event.type === 'unregistered' || event.status === 'stopped' || event.status === 'failed') cleanup();
+      });
     }
     return { serverId: server.id, url: server.url, port: server.port };
   } catch (err) {

--- a/apps/desktop/electron/features/workspace/runtime/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/types.ts
@@ -109,6 +109,8 @@ export interface RuntimeProcessInput extends RuntimeExecInput {
   stdio?: 'pipe' | 'inherit';
   cols?: number;
   rows?: number;
+  /** Host-internal ownership label used by safe worktree shutdown. */
+  ownerKind?: 'command' | 'managed-dev-server';
 }
 
 export interface RuntimeProcess {

--- a/packages/common/src/app-runtime-worktree-pool.ts
+++ b/packages/common/src/app-runtime-worktree-pool.ts
@@ -29,6 +29,8 @@ export interface AppRuntimeWorktreeLease {
   baseCommit: string | null;
   /** HEAD immediately after provisioning. Immutable evidence. */
   acquiredHead: string | null;
+  /** PR identity known at acquisition. Null for a fresh task or unknown PR. */
+  pullRequestNumber: number | null;
   acquiredAt: string;
   /** True when acquisition had to bootstrap a greenfield repository. */
   greenfield: boolean;
@@ -45,6 +47,8 @@ export interface AppRuntimeAcquireWorktreeRequest {
    * deleted by any release.
    */
   existingBranch?: string;
+  /** Authoritative PR identity for an existing branch, when the caller has it. */
+  pullRequestNumber?: number;
 }
 
 export type AppRuntimeAcquireWorktreeResult =
@@ -82,7 +86,11 @@ export interface AppRuntimeReleaseWorktreeRequest {
    * keeps the checkout whatever its state.
    */
   disposition: AppRuntimeWorktreeDisposition;
-  /** Delete the local branch only when Git confirms it is fully merged. */
+  /**
+   * Delete the local branch on explicit removal only when Git confirms it is
+   * fully merged. Safe recycling separately deletes a fresh local branch with
+   * an exact, proved tip fence.
+   */
   deleteMergedBranch?: boolean;
   /**
    * Force-delete the local branch after a successful removal. Explicit user
@@ -92,7 +100,8 @@ export interface AppRuntimeReleaseWorktreeRequest {
 }
 
 /**
- * - `released` — the checkout was removed and the slot left the pool.
+ * - `released` — the lease's checkout ended. The physical slot may remain as a
+ *   detached, reusable checkout when the host proves it safe.
  * - `preserved` — the checkout was kept; `reason` says what blocked removal.
  * - `already-released` — an identical retry of a recorded release decision. No change.
  * - `stale-lease` — the slot now holds a different lease. No change.

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/fake-host.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/fake-host.ts
@@ -72,7 +72,7 @@ export interface FakeHost extends OrchestratorHost {
   /** Holders that acquired a lease, in order. */
   worktreesCreated: string[];
   /** Full acquireWorktree calls, including the existing-branch option. */
-  worktreeCreates: { loopId: string; existingBranch?: string }[];
+  worktreeCreates: { loopId: string; existingBranch?: string; pullRequestNumber?: number }[];
   /** Holders whose lease was released (removed), in order. */
   worktreesRemoved: string[];
   /** Full releaseWorktree calls, resolved back to the holder that owned them. */
@@ -267,7 +267,11 @@ export function createFakeHost(options: FakeHostOptions = {}): FakeHost {
         };
       }
       this.worktreesCreated.push(request.holder);
-      this.worktreeCreates.push({ loopId: request.holder, existingBranch: request.existingBranch });
+      this.worktreeCreates.push({
+        loopId: request.holder,
+        existingBranch: request.existingBranch,
+        ...(request.pullRequestNumber === undefined ? {} : { pullRequestNumber: request.pullRequestNumber }),
+      });
       const ordinal = this.leases.size + this.worktreesRemoved.length + 1;
       const lease: WorktreeLease = {
         slotId: `slot-${ordinal}`,
@@ -281,6 +285,7 @@ export function createFakeHost(options: FakeHostOptions = {}): FakeHost {
         baseRef: 'origin/main',
         baseCommit: 'base0000',
         acquiredHead: 'head0000',
+        pullRequestNumber: request.pullRequestNumber ?? null,
         acquiredAt: this.now(),
         greenfield: false,
       };
@@ -310,6 +315,7 @@ export function createFakeHost(options: FakeHostOptions = {}): FakeHost {
         baseRef: null,
         baseCommit: null,
         acquiredHead: null,
+        pullRequestNumber: null,
         acquiredAt: this.now(),
         greenfield: false,
       };

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
@@ -279,7 +279,11 @@ describe('event-pr branch resolution (spec 15, FR-P1)', () => {
     const host = createFakeHost();
     const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
     const result = await resolve(host, loop, eventRun({ branch: 'feat/broken-ci', prNumbers: [12] }));
-    expect(host.worktreeCreates).toEqual([{ loopId: worktreeKeyFor(loop), existingBranch: 'feat/broken-ci' }]);
+    expect(host.worktreeCreates).toEqual([{
+      loopId: worktreeKeyFor(loop),
+      existingBranch: 'feat/broken-ci',
+      pullRequestNumber: 12,
+    }]);
     expect(result.workspace?.branchName).toBe('feat/broken-ci');
     expect(result.workspace?.externalBranch).toBe(true);
     expect(result.blocked).toBeUndefined();
@@ -291,6 +295,7 @@ describe('event-pr branch resolution (spec 15, FR-P1)', () => {
     const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
     const result = await resolve(host, loop, eventRun({ prNumber: 12, author: 'ann' }));
     expect(result.workspace?.branchName).toBe('feat/from-pr-12');
+    expect(host.worktreeCreates[0]?.pullRequestNumber).toBe(12);
   });
 
   it('blocks visibly when the run was not event-fired — never a fresh-branch fallback', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/workspace.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/workspace.ts
@@ -72,10 +72,12 @@ const PR_NUMBER_SOURCES = new Set(['github:pr-approved', 'github:review-comment'
  * Deterministic field reads — the payload shapes are our own adapters'
  * (github-kinds.ts), never guessed.
  */
-async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): Promise<string | { error: string }> {
+type EventPrBranch = { branch: string; pullRequestNumber?: number } | { error: string };
+
+async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): Promise<EventPrBranch> {
   const source = run?.firedBy?.source;
   const payload = run?.observations.find((o) => o.source === 'event')?.data as
-    | { branch?: unknown; prNumber?: unknown; number?: unknown }
+    | { branch?: unknown; prNumber?: unknown; number?: unknown; prNumbers?: unknown }
     | undefined;
   if (!source || !payload) {
     return { error: 'This loop works on the PR branch named by its firing event, but this run was not started by an event.' };
@@ -84,7 +86,16 @@ async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): 
     return { error: `The firing event (${source}) is not scoped to a pull request, so there is no PR branch to work on.` };
   }
   if (PR_HEAD_BRANCH_SOURCES.has(source) && typeof payload.branch === 'string' && payload.branch.length > 0) {
-    return payload.branch;
+    const pullRequestNumber = typeof payload.prNumber === 'number'
+      ? payload.prNumber
+      : typeof payload.number === 'number'
+        ? payload.number
+        : Array.isArray(payload.prNumbers)
+          && payload.prNumbers.length === 1
+          && typeof payload.prNumbers[0] === 'number'
+          ? payload.prNumbers[0]
+          : undefined;
+    return { branch: payload.branch, pullRequestNumber };
   }
   const prNumber = typeof payload.prNumber === 'number' ? payload.prNumber : typeof payload.number === 'number' ? payload.number : undefined;
   if (prNumber === undefined) {
@@ -98,7 +109,7 @@ async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): 
   }
   const pr = open.find((candidate) => candidate.number === prNumber);
   if (!pr) return { error: `PR #${prNumber} from the firing event is not in the open-PR list — it may be closed or merged.` };
-  return pr.headRefName;
+  return { branch: pr.headRefName, pullRequestNumber: pr.number };
 }
 
 /**
@@ -131,16 +142,21 @@ function contextFromLease(
 /** Managed worktree checked out at the PR's own branch (spec 15, FR-P1). */
 async function resolveEventPrWorktree(host: OrchestratorHost, loop: Loop, run: LoopRun | undefined): Promise<ResolveResult> {
   const branch = await eventPrBranch(host, run);
-  if (typeof branch !== 'string') return { loop, blocked: branch.error };
+  if ('error' in branch) return { loop, blocked: branch.error };
   const worktreeKey = worktreeKeyFor(loop);
   const outcome = await host
-    .acquireWorktree({ holder: worktreeKey, title: loop.title, existingBranch: branch })
+    .acquireWorktree({
+      holder: worktreeKey,
+      title: loop.title,
+      existingBranch: branch.branch,
+      pullRequestNumber: branch.pullRequestNumber,
+    })
     .catch((error: unknown) => ({
       status: 'blocked' as const,
       reason: error instanceof Error ? error.message : String(error),
     }));
   if (outcome.status !== 'acquired') {
-    return { loop, blocked: `Could not check out branch "${branch}": ${outcome.reason}` };
+    return { loop, blocked: `Could not check out branch "${branch.branch}": ${outcome.reason}` };
   }
   const resolved = contextFromLease(host, outcome.lease, worktreeKey, 'create-option');
   return { loop: withResolved(loop, resolved), workspace: resolved };


### PR DESCRIPTION
## Stack

PR 2 of #473. This draft PR **depends on #474** and intentionally targets `claude/github-issue-473-vgi8i7`, not `main`.

## Implementation

- Reuses numbered `slot-<n>` checkouts only after state, filesystem, Git registration, cleanliness, prepared HEAD, and process proofs agree.
- Mints a new immutable lease ID on every acquisition, including same-holder slot reuse.
- Keeps active lease capacity unlimited and retains at most two proved-safe idle slots per repository.
- Tracks Sero-owned terminals, agent sessions, commands, and managed development servers, requests shutdown through their owners, waits for confirmation, then checks for remaining rooted processes.
- Adds a narrow, injectable process detector: macOS and Linux use machine-readable `lsof -F`; Windows, permission failures, missing `lsof`, and all detection errors fail closed.
- Persists PR identity, acquisition evidence, exact reset targets, and verified prepared HEADs.
- Classifies merge commits by exact-target ancestry and squash/rebase merges by authoritative GitHub merged state. Open, closed-unmerged, unknown, and local-unmerged work is preserved.
- Resets to the pre-recorded exact commit with `git clean -fd`, retaining ignored dependencies, build output, and caches.
- Leaves external PR branches untouched while allowing their safely merged physical checkout to be recycled.
- Preserves conventional fresh-branch naming, validated external-branch fetch/checkout, greenfield behavior, and Workflow/Room acquisition behavior.

## Safety invariants

- Every state-changing release/reset remains fenced by exact slot and lease identity.
- Logical holder names are never resolved to a current lease for mutation.
- Unverifiable, stale, active, dirty, damaged, colliding, or partially transitioned slots are never made available.
- Sero-owned shutdown is confirmed before reset; foreign processes are never terminated.
- Git operation failures preserve checkout contents and ownership evidence.
- Registration mutations remain serialized while independent fetches may overlap.
- Delayed releases from earlier leases cannot affect a reused slot.
- External PR branches are never deleted.
- Workflow lease removals retain PR 1's incremental persistence and disposition-aware idempotency.

## Decisions

- **Supported detection:** macOS and Linux through `lsof`; Windows fails closed until a native adapter exists.
- **Retained idle capacity:** two slots per repository, as a host policy constant. No new settings surface.
- **Active limit:** none. Workflow and Room concurrency is not capped.
- **Disposal evidence:** exact reset-target ancestry for ordinary merges; authoritative GitHub merged state for squash/rebase cases; external branches always require authoritative merged evidence.
- **Owned shutdown:** use the existing terminal/session/command/dev-server owners and await their confirmed exit before OS detection and reset.
- **Detection failure:** surfaced as typed `unverifiable` evidence and a caller-visible `recovery-required`/blocked reason.

## Schema and compatibility

Pool schema moves from v2 to v3. The migration adds only null safety fields and never promotes a v2 checkout to reusable. A v2 shape that cannot satisfy v3 invariants, plus every unknown version, remains unavailable and is preserved for recovery.

The public release result keeps `checkout: removed | retained | unknown`. A successful recycle reports `removed` for the old lease's branch checkout even though its physical directory may remain as a detached warm slot.

## Validation

- `corepack pnpm@10.34.5 typecheck`: 27/27 monorepo tasks passed.
- Desktop source and test typecheck passed.
- Worktree pool suite: 10 files, 73 tests passed; 9.9 seconds wall-clock standalone.
- Affected host/runtime suite: 7 files, 44 tests passed in 2.1 seconds.
- Orchestrator suite: 136 files passed, 1 skipped; 1,372 tests passed, 1 skipped.
- Repository layout check and `git diff --check` passed.

The new CI coverage is kept focused: process/lock tests use deterministic fakes, merge classifications share real repositories, and authoritative PR lookup is skipped when exact ancestry already proves disposal.

A broader, non-required host-directory invocation was not counted as passing: one unrelated test could not load the Electron binary because this checkout was hydrated with install scripts disabled, and another unrelated Room skill test timed out under concurrent load. All affected host/runtime files passed in the focused run above.

## Remaining work

PR 3 remains out of scope: cleanup planning APIs, confirmation tokens/fingerprints, Admin/Git pool UI, renderer-controlled cleanup, broad pruning, and any cleanup-management workflow are not included.