### PR TITLE
fix(worktree): preserve checkouts when cleanup fails

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/runtime/capabilities/skills.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/capabilities/skills.test.ts
@@ -46,6 +46,11 @@ beforeAll(async () => {
   await mkdir(bundled, { recursive: true });
   await mkdir(imposter, { recursive: true });
   discovery.paths = [bundled];
+
+  // Load the Pi SDK-backed skill store during suite setup. Under a concurrent
+  // monorepo run, charging this one-time module cost to the first gate test can
+  // exhaust that test's timeout before its assertion runs.
+  await Promise.all([importCapability(), importApprovals()]);
 });
 
 beforeEach(() => {

--- a/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
@@ -7,10 +7,10 @@
  */
 
 import { execFile } from 'node:child_process';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { WorktreeManager } from '@electron/features/git/worktree/manager';
 import { createRepoFromTemplate } from '../git-service/git-test-helpers';
@@ -56,6 +56,8 @@ async function newWorkspace(): Promise<{ root: string; workspace: string }> {
 afterAll(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
+
+afterEach(() => vi.unstubAllEnvs());
 
 describe('WorktreeManager.create with existingBranch', () => {
   const manager = new WorktreeManager();
@@ -131,5 +133,50 @@ describe('WorktreeManager merged-branch cleanup', () => {
     await manager.remove(workspace, 'loop-1-r2', { force: true, deleteMergedBranch: true });
 
     expect(await git(workspace, 'rev-parse', '--verify', `refs/heads/${worktree.branchName}`)).toBeTruthy();
+  });
+
+  it('preserves uncommitted work and its branch when routine removal is refused', async () => {
+    const { workspace } = await newWorkspace();
+    const worktree = await manager.create(workspace, 'loop-1-r3', 'Protect local work');
+    const workFile = path.join(worktree.worktreePath, 'unfinished.md');
+    await writeFile(workFile, 'not committed');
+
+    await expect(manager.remove(workspace, 'loop-1-r3', { deleteBranch: true })).rejects.toThrow(
+      'checkout and branch were kept',
+    );
+
+    expect(await readFile(workFile, 'utf8')).toBe('not committed');
+    expect(await git(workspace, 'rev-parse', '--verify', `refs/heads/${worktree.branchName}`)).toBeTruthy();
+    expect(await manager.exists(workspace, 'loop-1-r3')).toBe(true);
+  });
+
+  it('does not treat an unregistered directory as a worktree', async () => {
+    const { workspace } = await newWorkspace();
+    const worktree = await manager.create(workspace, 'loop-1-r4', 'Routine scan');
+    await git(workspace, 'worktree', 'remove', worktree.worktreePath);
+    await mkdir(worktree.worktreePath, { recursive: true });
+    await writeFile(path.join(worktree.worktreePath, 'keep.md'), 'unregistered');
+
+    expect(await stat(worktree.worktreePath)).toBeTruthy();
+    expect(await manager.exists(workspace, 'loop-1-r4')).toBe(false);
+  });
+});
+
+describe('WorktreeManager greenfield bootstrap', () => {
+  const manager = new WorktreeManager();
+
+  it('creates its initial commit without a configured Git identity', async () => {
+    const { root } = await newWorkspace();
+    const workspace = path.join(root, 'greenfield');
+    await mkdir(workspace);
+    vi.stubEnv('GIT_CONFIG_COUNT', '2');
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'user.name');
+    vi.stubEnv('GIT_CONFIG_VALUE_0', '');
+    vi.stubEnv('GIT_CONFIG_KEY_1', 'user.email');
+    vi.stubEnv('GIT_CONFIG_VALUE_1', '');
+
+    await manager.create(workspace, 'loop-greenfield', 'Start project');
+
+    expect(await git(workspace, 'show', '-s', '--format=%an <%ae>', 'HEAD')).toBe('Sero <sero@local>');
   });
 });

--- a/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
@@ -150,15 +150,34 @@ describe('WorktreeManager merged-branch cleanup', () => {
     expect(await manager.exists(workspace, 'loop-1-r3')).toBe(true);
   });
 
-  it('does not treat an unregistered directory as a worktree', async () => {
+  it('keeps a non-empty unregistered directory and reports that it remains', async () => {
     const { workspace } = await newWorkspace();
     const worktree = await manager.create(workspace, 'loop-1-r4', 'Routine scan');
     await git(workspace, 'worktree', 'remove', worktree.worktreePath);
     await mkdir(worktree.worktreePath, { recursive: true });
-    await writeFile(path.join(worktree.worktreePath, 'keep.md'), 'unregistered');
+    const residue = path.join(worktree.worktreePath, 'keep.md');
+    await writeFile(residue, 'unregistered');
 
-    expect(await stat(worktree.worktreePath)).toBeTruthy();
-    expect(await manager.exists(workspace, 'loop-1-r4')).toBe(false);
+    await expect(manager.remove(workspace, 'loop-1-r4')).rejects.toThrow('unregistered directory contains files');
+    expect(await readFile(residue, 'utf8')).toBe('unregistered');
+  });
+
+  it('removes an empty unregistered directory', async () => {
+    const { workspace } = await newWorkspace();
+    const worktree = await manager.create(workspace, 'loop-1-r5', 'Routine scan');
+    await git(workspace, 'worktree', 'remove', worktree.worktreePath);
+    await mkdir(worktree.worktreePath, { recursive: true });
+
+    await manager.remove(workspace, 'loop-1-r5');
+
+    await expect(stat(worktree.worktreePath)).rejects.toThrow();
+  });
+
+  it('accepts cleanup after the workspace directory is already gone', async () => {
+    const { workspace } = await newWorkspace();
+    await rm(workspace, { recursive: true });
+
+    await expect(manager.remove(workspace, 'loop-1-r6')).resolves.toBeUndefined();
   });
 });
 

--- a/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/worktree/manager-existing-branch.test.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
+import { createCheckpointInWorktree } from '@electron/features/git/worktree/git';
 import { WorktreeManager } from '@electron/features/git/worktree/manager';
 import { createRepoFromTemplate } from '../git-service/git-test-helpers';
 
@@ -173,11 +174,34 @@ describe('WorktreeManager merged-branch cleanup', () => {
     await expect(stat(worktree.worktreePath)).rejects.toThrow();
   });
 
+  it('force removes a non-empty unregistered directory for stale recovery', async () => {
+    const { workspace } = await newWorkspace();
+    const worktree = await manager.create(workspace, 'loop-1-r6', 'Routine scan');
+    await git(workspace, 'worktree', 'remove', worktree.worktreePath);
+    await mkdir(worktree.worktreePath, { recursive: true });
+    await writeFile(path.join(worktree.worktreePath, 'stale.md'), 'stale');
+
+    await manager.remove(workspace, 'loop-1-r6', { force: true });
+
+    await expect(stat(worktree.worktreePath)).rejects.toThrow();
+  });
+
+  it('force removes a locked dirty worktree after explicit deletion', async () => {
+    const { workspace } = await newWorkspace();
+    const worktree = await manager.create(workspace, 'loop-1-r7', 'Routine scan');
+    await writeFile(path.join(worktree.worktreePath, 'unfinished.md'), 'discard me');
+    await git(workspace, 'worktree', 'lock', worktree.worktreePath);
+
+    await manager.remove(workspace, 'loop-1-r7', { force: true });
+
+    await expect(stat(worktree.worktreePath)).rejects.toThrow();
+  });
+
   it('accepts cleanup after the workspace directory is already gone', async () => {
     const { workspace } = await newWorkspace();
     await rm(workspace, { recursive: true });
 
-    await expect(manager.remove(workspace, 'loop-1-r6')).resolves.toBeUndefined();
+    await expect(manager.remove(workspace, 'loop-1-r8')).resolves.toBeUndefined();
   });
 });
 
@@ -194,8 +218,31 @@ describe('WorktreeManager greenfield bootstrap', () => {
     vi.stubEnv('GIT_CONFIG_KEY_1', 'user.email');
     vi.stubEnv('GIT_CONFIG_VALUE_1', '');
 
-    await manager.create(workspace, 'loop-greenfield', 'Start project');
+    const worktree = await manager.create(workspace, 'loop-greenfield', 'Start project');
 
     expect(await git(workspace, 'show', '-s', '--format=%an <%ae>', 'HEAD')).toBe('Sero <sero@local>');
+
+    await writeFile(path.join(worktree.worktreePath, 'checkpoint.md'), 'saved work');
+    await createCheckpointInWorktree(worktree.worktreePath, 'Save work');
+    expect(await git(worktree.worktreePath, 'show', '-s', '--format=%an <%ae>', 'HEAD')).toBe('Sero <sero@local>');
+  });
+
+  it('keeps a configured identity for the initial commit', async () => {
+    const { root } = await newWorkspace();
+    const workspace = path.join(root, 'configured-greenfield');
+    await mkdir(workspace);
+    await git(workspace, 'init', '-b', 'main');
+    await git(workspace, 'config', 'user.name', 'Project Author');
+    await git(workspace, 'config', 'user.email', 'author@example.com');
+
+    const worktree = await manager.create(workspace, 'loop-configured', 'Start project');
+
+    expect(await git(workspace, 'show', '-s', '--format=%an <%ae>', 'HEAD'))
+      .toBe('Project Author <author@example.com>');
+
+    await writeFile(path.join(worktree.worktreePath, 'checkpoint.md'), 'saved work');
+    await createCheckpointInWorktree(worktree.worktreePath, 'Save work');
+    expect(await git(worktree.worktreePath, 'show', '-s', '--format=%an <%ae>', 'HEAD'))
+      .toBe('Project Author <author@example.com>');
   });
 });

--- a/apps/desktop/electron/features/git/worktree/exec.ts
+++ b/apps/desktop/electron/features/git/worktree/exec.ts
@@ -97,6 +97,21 @@ export function execWorktreeGit(
   return execWithAuth('git', args, options);
 }
 
+/** Use the configured Git identity, with a Sero fallback for unmanaged hosts. */
+export async function execWorktreeGitCommit(
+  args: string[],
+  options: WorktreeExecOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  const hasIdentity = await Promise.all([
+    execWorktreeGit(['var', 'GIT_AUTHOR_IDENT'], { cwd: options.cwd, timeout: 5_000 }),
+    execWorktreeGit(['var', 'GIT_COMMITTER_IDENT'], { cwd: options.cwd, timeout: 5_000 }),
+  ]).then(() => true, () => false);
+  const identityArgs = hasIdentity
+    ? []
+    : ['-c', 'user.name=Sero', '-c', 'user.email=sero@local'];
+  return execWorktreeGit([...identityArgs, 'commit', ...args], options);
+}
+
 export function execWorktreeGh(
   args: string[],
   options: WorktreeExecOptions,

--- a/apps/desktop/electron/features/git/worktree/git.ts
+++ b/apps/desktop/electron/features/git/worktree/git.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { WORKSPACE_COMMON_IGNORES } from '@sero-ai/common';
 import { warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
-import { execWorktreeGit } from './exec';
+import { execWorktreeGit, execWorktreeGitCommit } from './exec';
 import { ghError as execError } from '../github/helpers';
 export { ensureRemoteDefaultBranch, createPrFromWorktree } from './pull-request';
 
@@ -56,7 +56,7 @@ export async function createCheckpointInWorktree(
   });
 
   // Commit
-  await execWorktreeGit(['commit', '-m', message], {
+  await execWorktreeGitCommit(['-m', message], {
     cwd: worktreePath,
     timeout: 15_000,
   });

--- a/apps/desktop/electron/features/git/worktree/manager.ts
+++ b/apps/desktop/electron/features/git/worktree/manager.ts
@@ -12,13 +12,34 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
+import { withLock } from '@sero-ai/extension-runtime';
 import type { AppRuntimeWorktreeRemoveOptions } from '@sero-ai/common';
 
 import { inferConventionalType, slugifyBranchLabel } from '@electron/features/git/support/branch-naming';
 import { ensureBootstrapGitignore } from '@electron/features/git/support/bootstrap-gitignore';
 import { resolvePreferredBaseRef } from './workspace-sync';
-import { isMissingPathError, warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
+import { warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
 import { execWorktreeGit } from './exec';
+
+async function canonicalPath(targetPath: string): Promise<string> {
+  return fs.realpath(targetPath).catch(() => path.resolve(targetPath));
+}
+
+async function worktreeMutationLockPath(workspacePath: string): Promise<string> {
+  const { stdout } = await execWorktreeGit(['rev-parse', '--git-common-dir'], {
+    cwd: workspacePath,
+    timeout: 5_000,
+  });
+  const commonDir = await canonicalPath(path.resolve(workspacePath, stdout.trim()));
+  return path.join(commonDir, 'sero-worktree-mutation.lock');
+}
+
+async function withWorktreeMutationLock<T>(
+  workspacePath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return withLock(await worktreeMutationLockPath(workspacePath), operation, { timeoutMs: 30_000 });
+}
 
 /**
  * Ensure a workspace directory is a git repo with at least one commit.
@@ -66,6 +87,8 @@ async function ensureGitReady(workspacePath: string): Promise<boolean> {
     } catch { /* branch may not exist yet — that's fine, init -b main handles it */ }
     await execWorktreeGit(['add', '--', '.gitignore'], { cwd: workspacePath, timeout: 10_000 });
     await execWorktreeGit([
+      '-c', 'user.name=Sero',
+      '-c', 'user.email=sero@local',
       'commit', '--allow-empty', '-m', 'Initial commit',
     ], { cwd: workspacePath, timeout: 10_000 });
     bootstrapped = true;
@@ -127,41 +150,32 @@ export class WorktreeManager {
     const branchName = this.buildBranchName(cardTitle, cardId);
     const baseRef = await resolvePreferredBaseRef(workspacePath);
 
-    // Ensure parent directory exists
-    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
-
-    // Create worktree with a new branch from the current HEAD
-    const addArgs = [
-      'worktree', 'add',
-      worktreePath,
-      '-b', branchName,
-      ...(baseRef ? [baseRef] : []),
-    ];
-    try {
-      await execWorktreeGit(addArgs, {
-        cwd: workspacePath,
-        timeout: 30_000,
-      });
-    } catch (err: unknown) {
-      const stderr = err && typeof err === 'object' && 'stderr' in err
-        ? String((err as { stderr: unknown }).stderr) : '';
-      const message = err instanceof Error ? err.message : String(err);
-      // If branch already exists, try without -b
-      if (stderr.includes('already exists')) {
-        await execWorktreeGit([
-          'worktree', 'add',
-          worktreePath,
-          branchName,
-        ], {
-          cwd: workspacePath,
-          timeout: 30_000,
-        });
-      } else {
-        throw new Error(
-          `Failed to create worktree for card ${cardId}: ${stderr || message || 'Unknown error'}`,
-        );
+    await withWorktreeMutationLock(workspacePath, async () => {
+      await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+      const addArgs = [
+        'worktree', 'add',
+        worktreePath,
+        '-b', branchName,
+        ...(baseRef ? [baseRef] : []),
+      ];
+      try {
+        await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
+      } catch (err: unknown) {
+        const stderr = err && typeof err === 'object' && 'stderr' in err
+          ? String((err as { stderr: unknown }).stderr) : '';
+        const message = err instanceof Error ? err.message : String(err);
+        if (stderr.includes('already exists')) {
+          await execWorktreeGit(['worktree', 'add', worktreePath, branchName], {
+            cwd: workspacePath,
+            timeout: 30_000,
+          });
+        } else {
+          throw new Error(
+            `Failed to create worktree for card ${cardId}: ${stderr || message || 'Unknown error'}`,
+          );
+        }
       }
-    }
+    });
 
     console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (branch: ${branchName})${greenfield ? ' [greenfield]' : ''}`);
     return { worktreePath, branchName, greenfield };
@@ -210,13 +224,15 @@ export class WorktreeManager {
     if (!addArgs) {
       throw new Error(`Branch "${branchName}" exists neither locally nor on origin`);
     }
-    try {
-      await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
-    } catch (err: unknown) {
-      const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to check out branch "${branchName}" for card ${cardId}: ${stderr || message}`);
-    }
+    await withWorktreeMutationLock(workspacePath, async () => {
+      try {
+        await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
+      } catch (err: unknown) {
+        const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to check out branch "${branchName}" for card ${cardId}: ${stderr || message}`);
+      }
+    });
 
     console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (existing branch: ${branchName})`);
     return { worktreePath, branchName, greenfield: false };
@@ -230,82 +246,63 @@ export class WorktreeManager {
     cardId: string,
     opts?: AppRuntimeWorktreeRemoveOptions,
   ): Promise<void> {
-    const worktreePath = this.getPath(workspacePath, cardId);
-
-    // Get branch name before removal
-    let branchName: string | null = null;
-    if (opts?.deleteBranch || opts?.deleteMergedBranch) {
-      try {
-        const { stdout } = await execWorktreeGit([
-          'rev-parse', '--abbrev-ref', 'HEAD',
-        ], { cwd: worktreePath, timeout: 5_000 });
-        branchName = stdout.trim();
-      } catch {
-        // Worktree may already be gone
+    await withWorktreeMutationLock(workspacePath, async () => {
+      const worktreePath = this.getPath(workspacePath, cardId);
+      let branchName: string | null = null;
+      if (opts?.deleteBranch || opts?.deleteMergedBranch) {
+        try {
+          const { stdout } = await execWorktreeGit(['rev-parse', '--abbrev-ref', 'HEAD'], {
+            cwd: worktreePath,
+            timeout: 5_000,
+          });
+          branchName = stdout.trim();
+        } catch {
+          // Worktree may already be gone.
+        }
       }
-    }
 
-    // Remove worktree
-    const args = ['worktree', 'remove', worktreePath];
-    if (opts?.force) args.push('--force');
-
-    try {
-      await execWorktreeGit(args, {
-        cwd: workspacePath,
-        timeout: 15_000,
-      });
+      const args = ['worktree', 'remove', worktreePath];
+      if (opts?.force) args.push('--force');
       try {
-        await execWorktreeGit(['worktree', 'prune'], {
-          cwd: workspacePath,
-          timeout: 10_000,
-        });
+        await execWorktreeGit(args, { cwd: workspacePath, timeout: 15_000 });
+      } catch (error: unknown) {
+        const stderr = error && typeof error === 'object' && 'stderr' in error
+          ? String((error as { stderr: unknown }).stderr) : '';
+        const message = error instanceof Error ? error.message : String(error);
+        const detail = stderr || message;
+        if (detail.includes('is not a working tree') || detail.includes('No such file or directory')) {
+          try {
+            await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
+          } catch (pruneError) {
+            warnCleanupFailure(`failed to prune missing worktree for card-${cardId}`, pruneError);
+          }
+          return;
+        }
+        throw new Error(`Could not remove card-${cardId}, so its checkout and branch were kept: ${detail}`);
+      }
+
+      try {
+        await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
       } catch (error) {
         warnCleanupFailure(`failed to prune worktrees in ${workspacePath}`, error);
       }
-    } catch (err: unknown) {
-      const stderr = err && typeof err === 'object' && 'stderr' in err
-        ? String((err as { stderr: unknown }).stderr) : '';
-      const message = err instanceof Error ? err.message : String(err);
-      // If the directory is already gone, prune instead
-      if (stderr.includes('is not a working tree')) {
+
+      if (branchName && (opts?.deleteBranch || opts?.deleteMergedBranch)) {
         try {
-          await execWorktreeGit(['worktree', 'prune'], {
+          await execWorktreeGit(['branch', opts.deleteBranch ? '-D' : '-d', branchName], {
             cwd: workspacePath,
             timeout: 10_000,
           });
-        } catch (pruneError) {
-          warnCleanupFailure(`failed to prune missing worktree for card-${cardId} in ${workspacePath}`, pruneError);
-        }
-      } else {
-        console.warn(`[worktree] Failed to remove card-${cardId}:`, stderr || message);
-      }
-    }
-
-    // Clean up the directory if it still exists
-    try {
-      await fs.rm(worktreePath, { recursive: true, force: true });
-    } catch (error) {
-      if (!isMissingPathError(error)) {
-        warnCleanupFailure(`failed to remove worktree directory ${worktreePath}`, error);
-      }
-    }
-
-    // Delete branch if requested
-    if (branchName && (opts?.deleteBranch || opts?.deleteMergedBranch)) {
-      try {
-        await execWorktreeGit(['branch', opts.deleteBranch ? '-D' : '-d', branchName], {
-          cwd: workspacePath,
-          timeout: 10_000,
-        });
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        if (!opts.deleteMergedBranch || !detail.includes('not fully merged')) {
-          warnCleanupFailure(`failed to delete branch ${branchName} for card-${cardId}`, error);
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          if (!opts.deleteMergedBranch || !detail.includes('not fully merged')) {
+            warnCleanupFailure(`failed to delete branch ${branchName} for card-${cardId}`, error);
+          }
         }
       }
-    }
 
-    console.log(`[worktree] Removed worktree for card-${cardId}`);
+      console.log(`[worktree] Removed worktree for card-${cardId}`);
+    });
   }
 
   /**
@@ -350,11 +347,15 @@ export class WorktreeManager {
    */
   async exists(workspacePath: string, cardId: string): Promise<boolean> {
     const worktreePath = this.getPath(workspacePath, cardId);
-    try {
-      await fs.access(worktreePath);
-      return true;
-    } catch {
-      return false;
+    const [expectedPath, worktrees, stats] = await Promise.all([
+      canonicalPath(worktreePath),
+      this.list(workspacePath),
+      fs.stat(worktreePath).catch(() => null),
+    ]);
+    if (!stats?.isDirectory()) return false;
+    for (const worktree of worktrees) {
+      if (await canonicalPath(worktree.worktreePath) === expectedPath) return true;
     }
+    return false;
   }
 }

--- a/apps/desktop/electron/features/git/worktree/manager.ts
+++ b/apps/desktop/electron/features/git/worktree/manager.ts
@@ -18,7 +18,7 @@ import { inferConventionalType, slugifyBranchLabel } from '@electron/features/gi
 import { ensureBootstrapGitignore } from '@electron/features/git/support/bootstrap-gitignore';
 import { resolvePreferredBaseRef } from './workspace-sync';
 import { isMissingPathError, warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
-import { execWorktreeGit } from './exec';
+import { execWorktreeGit, execWorktreeGitCommit } from './exec';
 
 function hasErrorCode(error: unknown, ...codes: string[]): boolean {
   return typeof error === 'object'
@@ -72,11 +72,10 @@ async function ensureGitReady(workspacePath: string): Promise<boolean> {
       await execWorktreeGit(['branch', '-M', 'main'], { cwd: workspacePath, timeout: 5_000 });
     } catch { /* branch may not exist yet — that's fine, init -b main handles it */ }
     await execWorktreeGit(['add', '--', '.gitignore'], { cwd: workspacePath, timeout: 10_000 });
-    await execWorktreeGit([
-      '-c', 'user.name=Sero',
-      '-c', 'user.email=sero@local',
-      'commit', '--allow-empty', '-m', 'Initial commit',
-    ], { cwd: workspacePath, timeout: 10_000 });
+    await execWorktreeGitCommit(['--allow-empty', '-m', 'Initial commit'], {
+      cwd: workspacePath,
+      timeout: 10_000,
+    });
     bootstrapped = true;
   }
 
@@ -255,7 +254,7 @@ export class WorktreeManager {
     }
 
     const args = ['worktree', 'remove', worktreePath];
-    if (opts?.force) args.push('--force');
+    if (opts?.force) args.push('--force', '--force');
     try {
       await execWorktreeGit(args, { cwd: workspacePath, timeout: 15_000 });
     } catch (error: unknown) {
@@ -266,28 +265,40 @@ export class WorktreeManager {
       const missingRegistration = detail.includes('is not a working tree')
         || detail.includes('No such file or directory')
         || detail.includes('does not exist');
-      if (!missingRegistration) {
-        throw new Error(`Could not remove card-${cardId}, so its checkout and branch were kept: ${detail}`);
-      }
-      try {
-        await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
-      } catch (pruneError) {
-        warnCleanupFailure(`failed to prune missing worktree for card-${cardId}`, pruneError);
-      }
-      try {
-        await fs.rmdir(worktreePath);
-      } catch (residueError) {
-        if (!isMissingPathError(residueError)) {
-          if (hasErrorCode(residueError, 'ENOTEMPTY', 'EEXIST')) {
-            throw new Error(
-              `Could not remove card-${cardId}. Its unregistered directory contains files and was kept at ${worktreePath}.`,
-            );
-          }
-          throw residueError;
+      if (opts?.force) {
+        try {
+          await fs.rm(worktreePath, { recursive: true, force: true });
+        } catch (residueError) {
+          warnCleanupFailure(`failed to force-remove residue for card-${cardId}`, residueError);
         }
+        try {
+          await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
+        } catch (pruneError) {
+          warnCleanupFailure(`failed to prune forced removal for card-${cardId}`, pruneError);
+        }
+      } else if (!missingRegistration) {
+        throw new Error(`Could not remove card-${cardId}, so its checkout and branch were kept: ${detail}`);
+      } else {
+        try {
+          await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
+        } catch (pruneError) {
+          warnCleanupFailure(`failed to prune missing worktree for card-${cardId}`, pruneError);
+        }
+        try {
+          await fs.rmdir(worktreePath);
+        } catch (residueError) {
+          if (!isMissingPathError(residueError)) {
+            if (hasErrorCode(residueError, 'ENOTEMPTY', 'EEXIST')) {
+              throw new Error(
+                `Could not remove card-${cardId}. Its unregistered directory contains files and was kept at ${worktreePath}.`,
+              );
+            }
+            throw residueError;
+          }
+        }
+        console.log(`[worktree] Removed empty residue for card-${cardId}`);
+        return;
       }
-      console.log(`[worktree] Removed empty residue for card-${cardId}`);
-      return;
     }
 
     try {

--- a/apps/desktop/electron/features/git/worktree/manager.ts
+++ b/apps/desktop/electron/features/git/worktree/manager.ts
@@ -12,33 +12,19 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import { withLock } from '@sero-ai/extension-runtime';
 import type { AppRuntimeWorktreeRemoveOptions } from '@sero-ai/common';
 
 import { inferConventionalType, slugifyBranchLabel } from '@electron/features/git/support/branch-naming';
 import { ensureBootstrapGitignore } from '@electron/features/git/support/bootstrap-gitignore';
 import { resolvePreferredBaseRef } from './workspace-sync';
-import { warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
+import { isMissingPathError, warnCleanupFailure } from '@electron/features/git/support/cleanup-warnings';
 import { execWorktreeGit } from './exec';
 
-async function canonicalPath(targetPath: string): Promise<string> {
-  return fs.realpath(targetPath).catch(() => path.resolve(targetPath));
-}
-
-async function worktreeMutationLockPath(workspacePath: string): Promise<string> {
-  const { stdout } = await execWorktreeGit(['rev-parse', '--git-common-dir'], {
-    cwd: workspacePath,
-    timeout: 5_000,
-  });
-  const commonDir = await canonicalPath(path.resolve(workspacePath, stdout.trim()));
-  return path.join(commonDir, 'sero-worktree-mutation.lock');
-}
-
-async function withWorktreeMutationLock<T>(
-  workspacePath: string,
-  operation: () => Promise<T>,
-): Promise<T> {
-  return withLock(await worktreeMutationLockPath(workspacePath), operation, { timeoutMs: 30_000 });
+function hasErrorCode(error: unknown, ...codes: string[]): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && codes.includes(String(error.code));
 }
 
 /**
@@ -150,32 +136,30 @@ export class WorktreeManager {
     const branchName = this.buildBranchName(cardTitle, cardId);
     const baseRef = await resolvePreferredBaseRef(workspacePath);
 
-    await withWorktreeMutationLock(workspacePath, async () => {
-      await fs.mkdir(path.dirname(worktreePath), { recursive: true });
-      const addArgs = [
-        'worktree', 'add',
-        worktreePath,
-        '-b', branchName,
-        ...(baseRef ? [baseRef] : []),
-      ];
-      try {
-        await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
-      } catch (err: unknown) {
-        const stderr = err && typeof err === 'object' && 'stderr' in err
-          ? String((err as { stderr: unknown }).stderr) : '';
-        const message = err instanceof Error ? err.message : String(err);
-        if (stderr.includes('already exists')) {
-          await execWorktreeGit(['worktree', 'add', worktreePath, branchName], {
-            cwd: workspacePath,
-            timeout: 30_000,
-          });
-        } else {
-          throw new Error(
-            `Failed to create worktree for card ${cardId}: ${stderr || message || 'Unknown error'}`,
-          );
-        }
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+    const addArgs = [
+      'worktree', 'add',
+      worktreePath,
+      '-b', branchName,
+      ...(baseRef ? [baseRef] : []),
+    ];
+    try {
+      await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
+    } catch (err: unknown) {
+      const stderr = err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr) : '';
+      const message = err instanceof Error ? err.message : String(err);
+      if (stderr.includes('already exists')) {
+        await execWorktreeGit(['worktree', 'add', worktreePath, branchName], {
+          cwd: workspacePath,
+          timeout: 30_000,
+        });
+      } else {
+        throw new Error(
+          `Failed to create worktree for card ${cardId}: ${stderr || message || 'Unknown error'}`,
+        );
       }
-    });
+    }
 
     console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (branch: ${branchName})${greenfield ? ' [greenfield]' : ''}`);
     return { worktreePath, branchName, greenfield };
@@ -224,15 +208,13 @@ export class WorktreeManager {
     if (!addArgs) {
       throw new Error(`Branch "${branchName}" exists neither locally nor on origin`);
     }
-    await withWorktreeMutationLock(workspacePath, async () => {
-      try {
-        await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
-      } catch (err: unknown) {
-        const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
-        const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to check out branch "${branchName}" for card ${cardId}: ${stderr || message}`);
-      }
-    });
+    try {
+      await execWorktreeGit(addArgs, { cwd: workspacePath, timeout: 30_000 });
+    } catch (err: unknown) {
+      const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to check out branch "${branchName}" for card ${cardId}: ${stderr || message}`);
+    }
 
     console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (existing branch: ${branchName})`);
     return { worktreePath, branchName, greenfield: false };
@@ -246,63 +228,89 @@ export class WorktreeManager {
     cardId: string,
     opts?: AppRuntimeWorktreeRemoveOptions,
   ): Promise<void> {
-    await withWorktreeMutationLock(workspacePath, async () => {
-      const worktreePath = this.getPath(workspacePath, cardId);
-      let branchName: string | null = null;
-      if (opts?.deleteBranch || opts?.deleteMergedBranch) {
-        try {
-          const { stdout } = await execWorktreeGit(['rev-parse', '--abbrev-ref', 'HEAD'], {
-            cwd: worktreePath,
-            timeout: 5_000,
-          });
-          branchName = stdout.trim();
-        } catch {
-          // Worktree may already be gone.
-        }
-      }
+    const worktreePath = this.getPath(workspacePath, cardId);
+    const workspaceExists = await fs.stat(workspacePath).then(
+      () => true,
+      (error: unknown) => {
+        if (isMissingPathError(error)) return false;
+        throw error;
+      },
+    );
+    if (!workspaceExists) {
+      console.log(`[worktree] Workspace is already gone; nothing to remove for card-${cardId}`);
+      return;
+    }
 
-      const args = ['worktree', 'remove', worktreePath];
-      if (opts?.force) args.push('--force');
+    let branchName: string | null = null;
+    if (opts?.deleteBranch || opts?.deleteMergedBranch) {
       try {
-        await execWorktreeGit(args, { cwd: workspacePath, timeout: 15_000 });
-      } catch (error: unknown) {
-        const stderr = error && typeof error === 'object' && 'stderr' in error
-          ? String((error as { stderr: unknown }).stderr) : '';
-        const message = error instanceof Error ? error.message : String(error);
-        const detail = stderr || message;
-        if (detail.includes('is not a working tree') || detail.includes('No such file or directory')) {
-          try {
-            await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
-          } catch (pruneError) {
-            warnCleanupFailure(`failed to prune missing worktree for card-${cardId}`, pruneError);
-          }
-          return;
-        }
+        const { stdout } = await execWorktreeGit(['rev-parse', '--abbrev-ref', 'HEAD'], {
+          cwd: worktreePath,
+          timeout: 5_000,
+        });
+        branchName = stdout.trim();
+      } catch {
+        // Worktree may already be gone.
+      }
+    }
+
+    const args = ['worktree', 'remove', worktreePath];
+    if (opts?.force) args.push('--force');
+    try {
+      await execWorktreeGit(args, { cwd: workspacePath, timeout: 15_000 });
+    } catch (error: unknown) {
+      const stderr = error && typeof error === 'object' && 'stderr' in error
+        ? String((error as { stderr: unknown }).stderr) : '';
+      const message = error instanceof Error ? error.message : String(error);
+      const detail = stderr || message;
+      const missingRegistration = detail.includes('is not a working tree')
+        || detail.includes('No such file or directory')
+        || detail.includes('does not exist');
+      if (!missingRegistration) {
         throw new Error(`Could not remove card-${cardId}, so its checkout and branch were kept: ${detail}`);
       }
-
       try {
         await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
-      } catch (error) {
-        warnCleanupFailure(`failed to prune worktrees in ${workspacePath}`, error);
+      } catch (pruneError) {
+        warnCleanupFailure(`failed to prune missing worktree for card-${cardId}`, pruneError);
       }
-
-      if (branchName && (opts?.deleteBranch || opts?.deleteMergedBranch)) {
-        try {
-          await execWorktreeGit(['branch', opts.deleteBranch ? '-D' : '-d', branchName], {
-            cwd: workspacePath,
-            timeout: 10_000,
-          });
-        } catch (error) {
-          const detail = error instanceof Error ? error.message : String(error);
-          if (!opts.deleteMergedBranch || !detail.includes('not fully merged')) {
-            warnCleanupFailure(`failed to delete branch ${branchName} for card-${cardId}`, error);
+      try {
+        await fs.rmdir(worktreePath);
+      } catch (residueError) {
+        if (!isMissingPathError(residueError)) {
+          if (hasErrorCode(residueError, 'ENOTEMPTY', 'EEXIST')) {
+            throw new Error(
+              `Could not remove card-${cardId}. Its unregistered directory contains files and was kept at ${worktreePath}.`,
+            );
           }
+          throw residueError;
         }
       }
+      console.log(`[worktree] Removed empty residue for card-${cardId}`);
+      return;
+    }
 
-      console.log(`[worktree] Removed worktree for card-${cardId}`);
-    });
+    try {
+      await execWorktreeGit(['worktree', 'prune'], { cwd: workspacePath, timeout: 10_000 });
+    } catch (error) {
+      warnCleanupFailure(`failed to prune worktrees in ${workspacePath}`, error);
+    }
+
+    if (branchName && (opts?.deleteBranch || opts?.deleteMergedBranch)) {
+      try {
+        await execWorktreeGit(['branch', opts.deleteBranch ? '-D' : '-d', branchName], {
+          cwd: workspacePath,
+          timeout: 10_000,
+        });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        if (!opts.deleteMergedBranch || !detail.includes('not fully merged')) {
+          warnCleanupFailure(`failed to delete branch ${branchName} for card-${cardId}`, error);
+        }
+      }
+    }
+
+    console.log(`[worktree] Removed worktree for card-${cardId}`);
   }
 
   /**
@@ -347,15 +355,11 @@ export class WorktreeManager {
    */
   async exists(workspacePath: string, cardId: string): Promise<boolean> {
     const worktreePath = this.getPath(workspacePath, cardId);
-    const [expectedPath, worktrees, stats] = await Promise.all([
-      canonicalPath(worktreePath),
-      this.list(workspacePath),
-      fs.stat(worktreePath).catch(() => null),
-    ]);
-    if (!stats?.isDirectory()) return false;
-    for (const worktree of worktrees) {
-      if (await canonicalPath(worktree.worktreePath) === expectedPath) return true;
+    try {
+      await fs.access(worktreePath);
+      return true;
+    } catch {
+      return false;
     }
-    return false;
   }
 }

--- a/packages/common/src/app-runtime-git.ts
+++ b/packages/common/src/app-runtime-git.ts
@@ -19,6 +19,10 @@ export interface AppRuntimeWorktreeRemoveOptions {
   deleteBranch?: boolean;
   /** Delete the local branch only when Git confirms it is fully merged. */
   deleteMergedBranch?: boolean;
+  /**
+   * Let Git discard uncommitted checkout contents.
+   * Use only after explicit user authorization.
+   */
   force?: boolean;
 }
 

--- a/packages/common/src/app-runtime-git.ts
+++ b/packages/common/src/app-runtime-git.ts
@@ -21,7 +21,7 @@ export interface AppRuntimeWorktreeRemoveOptions {
   deleteMergedBranch?: boolean;
   /**
    * Let Git discard uncommitted checkout contents.
-   * Use only after explicit user authorization.
+   * Also removes unregistered residue. Use only after explicit user authorization.
    */
   force?: boolean;
 }
@@ -118,6 +118,7 @@ export interface AppRuntimeGitApi {
     cardTitle: string,
     options?: AppRuntimeWorktreeCreateOptions,
   ): Promise<AppRuntimeWorktreeCreateResult>;
+  /** Rejects when normal removal must keep the checkout or its files. */
   removeWorktree(
     workspacePath: string,
     cardId: string,

--- a/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
@@ -56,7 +56,7 @@ async function settled(designId: string) {
   await vi.waitFor(async () => {
     const design = await readDesign(harness.paths, designId);
     expect(design?.variants.every((variant) => variant.status !== 'pending' && variant.status !== 'running')).toBe(true);
-  }, FAST_POLL);
+  }, { ...FAST_POLL, timeout: 5_000 });
   return (await readDesign(harness.paths, designId))!;
 }
 

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-core.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-core.test.ts
@@ -193,6 +193,22 @@ describe('Coordinator delete', () => {
     expect(host.state.loops).toHaveLength(0);
   });
 
+  it('deletes loop state when its checkout is already unavailable', async () => {
+    const host = createFakeHost();
+    const loop = seedActiveLoop(host, oneStepPlan().plan);
+    loop.runtime.workspace.resolved = managedWorktree;
+    host.state = { ...host.state, loops: [loop] };
+    host.removeWorktree = async () => {
+      throw new Error('workspace is gone');
+    };
+
+    const result = await new Coordinator(host).requestAction({ kind: 'delete', loopId: 'loop-1' });
+
+    expect(result.ok).toBe(true);
+    expect(host.state.loops).toHaveLength(0);
+    expect(host.logs.some((entry) => entry.includes('workspace is gone'))).toBe(true);
+  });
+
   it('deletes the local branch too when deleteBranch is set', async () => {
     const host = createFakeHost();
     const loop = seedActiveLoop(host, oneStepPlan().plan);

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
@@ -140,6 +140,31 @@ describe('fireEvent broadcast', () => {
     expect(task).toContain('"pr": 42');
   });
 
+  it('runs the event iteration when cleanup keeps the previous checkout', async () => {
+    const host = createFakeHost();
+    host.frozenNow = NOW;
+    const loop = seedActiveLoop(host, oneStepPlan().plan);
+    const previousPath = `${host.workspacePath}/.sero/worktrees/card-loop-1-r0`;
+    loop.runtime.workspace.resolved = {
+      id: 'ws-old', type: 'managed-worktree', workspaceRoot: host.workspacePath,
+      cwd: previousPath, worktreePath: previousPath, branchName: 'chore/old',
+      worktreeKey: 'loop-1-r0', resolvedBy: 'create-option', createdAt: NOW,
+    };
+    host.state = { ...host.state, loops: [loop] };
+    setTriggers(host, 'loop-1', [eventTrigger()]);
+    host.removeWorktree = async () => {
+      throw new Error('dirty checkout');
+    };
+
+    await coordinator(host, { executor: fakeExecutor({ 'step-1': SUCCESS }) }).fireEvent(ciEvent());
+
+    const updated = host.state.loops[0];
+    expect(updated.runs).toHaveLength(1);
+    expect(updated.runtime.pendingEvents).toBeUndefined();
+    expect(host.checkpoints[0]?.worktreePath).toBe(previousPath);
+    expect(host.logs.some((entry) => entry.includes(`checkout was kept at ${previousPath}`))).toBe(true);
+  });
+
   it('an event carrying a dedupeKey is delivered at most once', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
@@ -140,7 +140,7 @@ describe('fireEvent broadcast', () => {
     expect(task).toContain('"pr": 42');
   });
 
-  it('runs the event iteration when cleanup keeps the previous checkout', async () => {
+  it('keeps the prior checkout and queued event when cleanup refuses removal', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;
     const loop = seedActiveLoop(host, oneStepPlan().plan);
@@ -159,9 +159,10 @@ describe('fireEvent broadcast', () => {
     await coordinator(host, { executor: fakeExecutor({ 'step-1': SUCCESS }) }).fireEvent(ciEvent());
 
     const updated = host.state.loops[0];
-    expect(updated.runs).toHaveLength(1);
-    expect(updated.runtime.pendingEvents).toBeUndefined();
-    expect(host.checkpoints[0]?.worktreePath).toBe(previousPath);
+    expect(updated.runs).toHaveLength(0);
+    expect(updated.runtime.pendingEvents?.[0]?.id).toBe('evt-1');
+    expect(updated.runtime.workspace.resolved?.worktreePath).toBe(previousPath);
+    expect(host.checkpoints).toEqual([]);
     expect(host.logs.some((entry) => entry.includes(`checkout was kept at ${previousPath}`))).toBe(true);
   });
 

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
@@ -3,7 +3,7 @@ import { Coordinator } from '../coordinator';
 import { LoopLocks } from '../locks';
 import { createEngineDeps } from '../executors';
 import type { EngineDeps, StepExecutor } from '../engine-types';
-import type { Loop, LoopTrigger, StepOutcome } from '../../shared/types';
+import type { Loop, LoopTrigger, ResolvedWorkspaceContext, StepOutcome } from '../../shared/types';
 import { createFakeHost, type FakeHost } from './fake-host';
 import { oneStepPlan, seedActiveLoop, sequentialPlan } from './fixtures';
 import { fakeExecutor, gatedExecutor } from './engine-fakes';
@@ -26,6 +26,21 @@ function addTrigger(host: FakeHost, trigger: LoopTrigger): Loop {
   return loop;
 }
 
+function priorWorktree(key: string): ResolvedWorkspaceContext {
+  const worktreePath = `/workspaces/ws-1/.sero/worktrees/card-${key}`;
+  return {
+    id: `ws-${key}`,
+    type: 'managed-worktree',
+    workspaceRoot: '/workspaces/ws-1',
+    cwd: worktreePath,
+    worktreePath,
+    branchName: `chore/${key}`,
+    worktreeKey: key,
+    resolvedBy: 'create-option',
+    createdAt: NOW,
+  };
+}
+
 describe('Coordinator scheduling (Phase 7)', () => {
   it('runs a cron loop that came due while the workspace was closed', async () => {
     const host = createFakeHost();
@@ -37,6 +52,37 @@ describe('Coordinator scheduling (Phase 7)', () => {
     expect(host.state.loops[0].runtime.stepStates['step-1'].status).toBe('succeeded');
     expect(host.state.loops[0].triggers[0].fireCount).toBe(1); // collapsed to one fire
     expect(host.state.loops[0].runs[0].triggerId).toBe('c');
+  });
+
+  it('runs every due loop when one previous checkout cannot be removed', async () => {
+    const host = createFakeHost();
+    host.frozenNow = NOW;
+    const first = seedActiveLoop(host, oneStepPlan().plan, 'loop-1');
+    const second = seedActiveLoop(host, oneStepPlan().plan, 'loop-2');
+    first.runtime.workspace.resolved = priorWorktree('old-loop-1');
+    second.runtime.workspace.resolved = priorWorktree('old-loop-2');
+    first.triggers = [{
+      id: 'c1', loopId: first.id, workspaceId: 'ws-1', type: 'cron',
+      schedule: '* * * * *', nextFireAt: '2026-06-22T09:59:00.000Z', fireCount: 0,
+    }];
+    second.triggers = [{
+      id: 'c2', loopId: second.id, workspaceId: 'ws-1', type: 'cron',
+      schedule: '* * * * *', nextFireAt: '2026-06-22T09:59:00.000Z', fireCount: 0,
+    }];
+    host.state = { ...host.state, loops: [first, second] };
+    const removeWorktree = host.removeWorktree.bind(host);
+    host.removeWorktree = async (key, options) => {
+      if (key === 'old-loop-1') throw new Error('dirty checkout');
+      await removeWorktree(key, options);
+    };
+
+    await coordinator(host, { executor: fakeExecutor({ 'step-1': SUCCESS }) }).tick();
+
+    expect(host.state.loops.map((loop) => loop.runs)).toEqual([
+      [expect.objectContaining({ triggerId: 'c1' })],
+      [expect.objectContaining({ triggerId: 'c2' })],
+    ]);
+    expect(host.logs.some((entry) => entry.includes('dirty checkout'))).toBe(true);
   });
 
   it('holds a snoozed scheduled run and retries it once the snooze expires', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
@@ -54,7 +54,7 @@ describe('Coordinator scheduling (Phase 7)', () => {
     expect(host.state.loops[0].runs[0].triggerId).toBe('c');
   });
 
-  it('runs every due loop when one previous checkout cannot be removed', async () => {
+  it('keeps one blocked checkout and still runs the other due loop', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;
     const first = seedActiveLoop(host, oneStepPlan().plan, 'loop-1');
@@ -78,10 +78,10 @@ describe('Coordinator scheduling (Phase 7)', () => {
 
     await coordinator(host, { executor: fakeExecutor({ 'step-1': SUCCESS }) }).tick();
 
-    expect(host.state.loops.map((loop) => loop.runs)).toEqual([
-      [expect.objectContaining({ triggerId: 'c1' })],
-      [expect.objectContaining({ triggerId: 'c2' })],
-    ]);
+    expect(host.state.loops[0].runs).toEqual([]);
+    expect(host.state.loops[0].runtime.workspace.resolved).toEqual(priorWorktree('old-loop-1'));
+    expect(host.state.loops[1].runs).toEqual([expect.objectContaining({ triggerId: 'c2' })]);
+    expect(host.checkpoints).toEqual([]);
     expect(host.logs.some((entry) => entry.includes('dirty checkout'))).toBe(true);
   });
 
@@ -297,6 +297,31 @@ describe('Coordinator scheduling (Phase 7)', () => {
     expect(host.state.loops[0].triggers[0].disabled).toBeFalsy(); // schedule resumed
     expect(host.state.loops[0].triggers[0].nextFireAt).toBeDefined();
     expect(executor.calls).toEqual(['step-1']); // ran a fresh pass
+  });
+
+  it('run again keeps the previous loop state when cleanup refuses removal', async () => {
+    const host = createFakeHost();
+    host.frozenNow = NOW;
+    const loop = seedActiveLoop(host, oneStepPlan().plan);
+    loop.status = 'complete';
+    loop.runtime.workspace.resolved = priorWorktree('old-loop-1');
+    loop.runtime.stepStates['step-1'] = {
+      status: 'succeeded', attempts: 1,
+      outcome: { status: 'succeeded', summary: 'done' }, updatedAt: NOW,
+    };
+    host.state = { ...host.state, loops: [loop] };
+    host.removeWorktree = async () => {
+      throw new Error('dirty checkout');
+    };
+    const executor = fakeExecutor({ 'step-1': SUCCESS });
+
+    const result = await coordinator(host, { executor }).requestAction({ kind: 'run_again', loopId: 'loop-1' });
+
+    expect(result).toMatchObject({ ok: false, error: expect.stringContaining('dirty checkout') });
+    expect(host.state.loops[0].status).toBe('complete');
+    expect(host.state.loops[0].runtime.workspace.resolved).toEqual(priorWorktree('old-loop-1'));
+    expect(host.state.loops[0].runtime.stepStates['step-1'].status).toBe('succeeded');
+    expect(executor.calls).toEqual([]);
   });
 
   it('start over re-runs a BLOCKED loop from the first step (clears the block, re-arms every step)', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/room-workspace.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/room-workspace.test.ts
@@ -412,6 +412,27 @@ describe('preserving uncommitted work', () => {
     expect(host.worktreeRemovals[0].force).toBeUndefined();
     expect((await memberOf(roomId, 'api')).worktreePath).toBeNull();
   });
+
+  it('keeps one failed checkout and releases the remaining members', async () => {
+    const roomId = await draftRoom();
+    const placements = await workspaces.prepare(roomId);
+    const apiTree = placements.find((placement) => placement.memberId === 'api')?.cwd ?? '';
+    const removeWorktree = host.removeWorktree.bind(host);
+    host.removeWorktree = async (key, options) => {
+      if (key.endsWith('-api')) throw new Error('worktree is busy');
+      await removeWorktree(key, options);
+    };
+
+    const results = await workspaces.releaseRoom(roomId, 'completed');
+
+    expect(results).toEqual([
+      expect.objectContaining({ memberId: 'api', removed: false }),
+      expect.objectContaining({ memberId: 'ui', removed: true }),
+    ]);
+    expect((await memberOf(roomId, 'api')).worktreePath).toBe(apiTree);
+    expect((await memberOf(roomId, 'ui')).worktreePath).toBeNull();
+    expect((await store.readTimeline(roomId, 20)).some((event) => event.summary.includes('worktree was kept'))).toBe(true);
+  });
 });
 
 describe('collecting commits', () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/room-workspace.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/room-workspace.test.ts
@@ -409,6 +409,7 @@ describe('preserving uncommitted work', () => {
     expect(host.worktreesRemoved).toEqual([`room-${roomId}-api`]);
     expect(host.worktreeRemovals[0]).toMatchObject({ deleteMergedBranch: true });
     expect(host.worktreeRemovals[0].deleteBranch).toBeUndefined();
+    expect(host.worktreeRemovals[0].force).toBeUndefined();
     expect((await memberOf(roomId, 'api')).worktreePath).toBeNull();
   });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
@@ -18,10 +18,9 @@ const managed: ResolvedWorkspaceContext = {
 describe('cleanupPreviousWorktree', () => {
   it('removes merged loop-owned branches safely', async () => {
     const host = createFakeHost();
-    await cleanupPreviousWorktree(host, 'loop-1', managed);
-    expect(host.checkpoints).toEqual([
-      { worktreePath: managed.worktreePath, message: 'Loop checkpoint before cleanup: loop-1' },
-    ]);
+    const result = await cleanupPreviousWorktree(host, 'loop-1', managed);
+    expect(result).toEqual({ removed: true });
+    expect(host.checkpoints).toEqual([]);
     expect(host.worktreeRemovals).toEqual([
       { loopId: 'loop-1-r4', force: undefined, deleteMergedBranch: true, deleteBranch: undefined },
     ]);
@@ -31,22 +30,22 @@ describe('cleanupPreviousWorktree', () => {
     const host = createFakeHost();
     await cleanupPreviousWorktree(host, 'loop-1', { ...managed, externalBranch: true });
     expect(host.worktreeRemovals[0].deleteMergedBranch).toBeUndefined();
+    expect(host.checkpoints).toEqual([]);
   });
 
-  it('keeps cleanup failures inside the loop boundary', async () => {
+  it('reports a kept checkout without creating a commit', async () => {
     const host = createFakeHost();
-    host.createCheckpoint = async () => {
-      throw new Error('checkpoint failed');
-    };
     host.removeWorktree = async () => {
       throw new Error('dirty checkout');
     };
 
-    await expect(cleanupPreviousWorktree(host, 'loop-1', managed)).resolves.toBeUndefined();
+    const result = await cleanupPreviousWorktree(host, 'loop-1', managed);
 
-    expect(host.logs).toEqual(expect.arrayContaining([
-      expect.stringContaining('checkpoint failed'),
-      expect.stringContaining(`checkout was kept at ${managed.worktreePath}`),
-    ]));
+    expect(result).toEqual({
+      removed: false,
+      error: expect.stringContaining(`checkout was kept at ${managed.worktreePath}`),
+    });
+    expect(host.checkpoints).toEqual([]);
+    expect(host.logs).toEqual([expect.stringContaining('dirty checkout')]);
   });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
@@ -20,7 +20,7 @@ describe('cleanupPreviousWorktree', () => {
     const host = createFakeHost();
     await cleanupPreviousWorktree(host, 'loop-1', managed);
     expect(host.worktreeRemovals).toEqual([
-      { loopId: 'loop-1-r4', force: true, deleteMergedBranch: true, deleteBranch: undefined },
+      { loopId: 'loop-1-r4', force: undefined, deleteMergedBranch: true, deleteBranch: undefined },
     ]);
   });
 

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/worktree-cleanup.test.ts
@@ -19,6 +19,9 @@ describe('cleanupPreviousWorktree', () => {
   it('removes merged loop-owned branches safely', async () => {
     const host = createFakeHost();
     await cleanupPreviousWorktree(host, 'loop-1', managed);
+    expect(host.checkpoints).toEqual([
+      { worktreePath: managed.worktreePath, message: 'Loop checkpoint before cleanup: loop-1' },
+    ]);
     expect(host.worktreeRemovals).toEqual([
       { loopId: 'loop-1-r4', force: undefined, deleteMergedBranch: true, deleteBranch: undefined },
     ]);
@@ -28,5 +31,22 @@ describe('cleanupPreviousWorktree', () => {
     const host = createFakeHost();
     await cleanupPreviousWorktree(host, 'loop-1', { ...managed, externalBranch: true });
     expect(host.worktreeRemovals[0].deleteMergedBranch).toBeUndefined();
+  });
+
+  it('keeps cleanup failures inside the loop boundary', async () => {
+    const host = createFakeHost();
+    host.createCheckpoint = async () => {
+      throw new Error('checkpoint failed');
+    };
+    host.removeWorktree = async () => {
+      throw new Error('dirty checkout');
+    };
+
+    await expect(cleanupPreviousWorktree(host, 'loop-1', managed)).resolves.toBeUndefined();
+
+    expect(host.logs).toEqual(expect.arrayContaining([
+      expect.stringContaining('checkpoint failed'),
+      expect.stringContaining(`checkout was kept at ${managed.worktreePath}`),
+    ]));
   });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -4,9 +4,6 @@
  * UI, tools, and slash commands send `OrchestratorAction` envelopes through
  * `requestAction`. The coordinator owns lifecycle transitions and (from
  * Phase 3) coordinator runs. Nothing else mutates loop runtime state.
- *
- * This Phase 1 implementation wires every action and persists state. Planning
- * (Phase 2) and the run engine, locks, and recovery (Phase 3+) extend it.
  */
 
 import type {
@@ -305,7 +302,9 @@ export class Coordinator {
       await this.host.removeWorktree(resolved.worktreeKey ?? loopId, {
         force: true,
         deleteBranch: resolved.externalBranch ? undefined : deleteBranch,
-      });
+      }).catch((error: unknown) => this.host.log(
+        `Could not remove the checkout for deleted loop ${loopId}: ${String(error)}`,
+      ));
     }
     await this.host.updateState((state) => ({
       ...state,
@@ -368,11 +367,6 @@ export class Coordinator {
 
   // ── Run / revise / recovery (extended in later phases) ────
 
-  /**
-   * Requests one coordinator run for a loop. Phase 1 only validates that the
-   * loop is active; the run engine, locks, and step execution arrive in later
-   * phases. `known` lets callers pass a freshly-transitioned loop.
-   */
   /**
    * Manual "Run next". A whole pass runs in one `runNext`, so if the previous
    * pass already finished (no run in flight, nothing ready or running) on a

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -111,7 +111,8 @@ export class Coordinator {
    * whose previous pass already finished.
    */
   private async runFreshPass(loop: Loop, triggerId?: string): Promise<OrchestratorActionResult> {
-    await cleanupPreviousWorktree(this.host, loop.id, loop.runtime.workspace.resolved);
+    const cleanup = await cleanupPreviousWorktree(this.host, loop.id, loop.runtime.workspace.resolved);
+    if (!cleanup.removed) return { ok: false, error: cleanup.error };
     const base = rearmLoop(loop, this.host.now());
     const rearmed = triggerId
       ? { ...base, runtime: { ...base.runtime, pendingTriggerId: triggerId } }

--- a/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
@@ -184,24 +184,22 @@ function isSnoozed(loop: Loop, now: string): boolean {
 }
 
 /**
- * Starts the next event-fired iteration (cron semantics): drops the previous
- * iteration's worktree and re-arms the plan. The re-arm reads the CURRENT
- * on-disk loop inside updateState — never a caller-held copy — so an event
- * enqueued concurrently is never overwritten. The queued events survive the
- * re-arm; the engine consumes the head into the run's `firedBy` and an
- * `event` observation.
+ * Starts the next event-fired iteration after normal cleanup accepts the
+ * previous checkout. The second read keeps events that arrive during cleanup.
  */
 async function runEventPass(host: OrchestratorHost, seam: CoordinatorRunSeam, loopId: string): Promise<void> {
+  const loop = await seam.findLoop(loopId);
+  if (!loop || loop.status !== 'active') return;
+  const cleanup = await cleanupPreviousWorktree(host, loopId, loop.runtime.workspace.resolved);
+  if (!cleanup.removed) return;
+
   let rearmed: Loop | undefined;
-  let prior: Loop['runtime']['workspace']['resolved'];
   await host.updateState((state) => {
     const current = state.loops.find((l) => l.id === loopId);
     if (!current || current.status !== 'active') return state;
-    prior = current.runtime.workspace.resolved; // captured pre-rearm: rearmLoop clears workspace
     rearmed = rearmLoop(current, host.now());
     return { ...state, loops: state.loops.map((l) => (l.id === loopId ? rearmed! : l)) };
   });
   if (!rearmed) return;
-  await cleanupPreviousWorktree(host, loopId, prior);
   await seam.runNext(loopId, rearmed);
 }

--- a/plugins/sero-orchestrator-plugin/runtime/restart-actions.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/restart-actions.ts
@@ -38,7 +38,8 @@ export async function runAgain(
     return { ok: false, error: 'A run is already in progress — disable it first, then restart.' };
   }
   const now = host.now();
-  await cleanupPreviousWorktree(host, loopId, loop.runtime.workspace.resolved);
+  const cleanup = await cleanupPreviousWorktree(host, loopId, loop.runtime.workspace.resolved);
+  if (!cleanup.removed) return { ok: false, error: cleanup.error };
   const reactivated: Loop = {
     ...rearmLoop({ ...loop, triggers: reenableSchedule(loop, now) }, now),
     status: 'active',

--- a/plugins/sero-orchestrator-plugin/runtime/rooms/room-workspace.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/rooms/room-workspace.ts
@@ -308,7 +308,27 @@ export function createRoomWorkspaces(ctx: RoomWorkspacesContext): RoomWorkspaces
     }
     // `deleteMergedBranch`, never `deleteBranch`: Git decides whether the branch
     // is redundant, so a checkpoint that is not yet merged keeps its branch.
-    await host.removeWorktree(worktreeKeyFor(roomId, member.id), { deleteMergedBranch: true });
+    const removalError = await host
+      .removeWorktree(worktreeKeyFor(roomId, member.id), { deleteMergedBranch: true })
+      .then(() => null, (error: unknown) => (error instanceof Error ? error.message : String(error)));
+    if (removalError) {
+      const failureReason = `The worktree could not be removed (${removalError}), so it was kept.`;
+      await store.appendTimeline(roomId, [
+        timelineEvent(host, roomId, 'work', member.id, `${member.displayName}'s worktree was kept: ${removalError}.`, {
+          branch: preserved.branch ?? '',
+          commit: preserved.commit ?? '',
+          error: removalError,
+        }),
+      ]);
+      return {
+        memberId: member.id,
+        preserved,
+        removed: false,
+        reason: preserved.commit
+          ? `Its work was committed to ${preserved.branch ?? 'its branch'}. ${failureReason}`
+          : failureReason,
+      };
+    }
     await store.updateMember(roomId, member.id, (current) => ({ ...current, worktreePath: null }));
     await store.appendTimeline(roomId, [
       timelineEvent(host, roomId, 'work', member.id, `${member.displayName}'s worktree was released: ${reason}.`, {

--- a/plugins/sero-orchestrator-plugin/runtime/rooms/room-workspace.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/rooms/room-workspace.ts
@@ -308,7 +308,7 @@ export function createRoomWorkspaces(ctx: RoomWorkspacesContext): RoomWorkspaces
     }
     // `deleteMergedBranch`, never `deleteBranch`: Git decides whether the branch
     // is redundant, so a checkpoint that is not yet merged keeps its branch.
-    await host.removeWorktree(worktreeKeyFor(roomId, member.id), { force: true, deleteMergedBranch: true });
+    await host.removeWorktree(worktreeKeyFor(roomId, member.id), { deleteMergedBranch: true });
     await store.updateMember(roomId, member.id, (current) => ({ ...current, worktreePath: null }));
     await store.appendTimeline(roomId, [
       timelineEvent(host, roomId, 'work', member.id, `${member.displayName}'s worktree was released: ${reason}.`, {

--- a/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
@@ -2,9 +2,8 @@ import type { ResolvedWorkspaceContext } from '../shared/types';
 import type { OrchestratorHost } from './host';
 
 /**
- * Removes a completed iteration's checkout. Loop-owned branches are deleted
- * only when Git confirms they are fully merged; unmerged work and branches
- * checked out from external pull requests are preserved.
+ * Saves and removes a completed iteration's checkout. A failed checkpoint or
+ * removal keeps the checkout and must not stop the next loop iteration.
  */
 export async function cleanupPreviousWorktree(
   host: OrchestratorHost,
@@ -12,7 +11,18 @@ export async function cleanupPreviousWorktree(
   workspace: ResolvedWorkspaceContext | undefined,
 ): Promise<void> {
   if (workspace?.type !== 'managed-worktree') return;
-  await host.removeWorktree(workspace.worktreeKey ?? loopId, {
-    deleteMergedBranch: workspace.externalBranch ? undefined : true,
-  });
+  const worktreeKey = workspace.worktreeKey ?? loopId;
+  const worktreePath = workspace.worktreePath ?? workspace.cwd;
+  try {
+    await host.createCheckpoint(worktreePath, `Loop checkpoint before cleanup: ${loopId}`);
+  } catch (error) {
+    host.log(`Could not checkpoint ${worktreeKey} before cleanup: ${String(error)}`);
+  }
+  try {
+    await host.removeWorktree(worktreeKey, {
+      deleteMergedBranch: workspace.externalBranch ? undefined : true,
+    });
+  } catch (error) {
+    host.log(`Could not remove ${worktreeKey}, so its checkout was kept at ${worktreePath}: ${String(error)}`);
+  }
 }

--- a/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
@@ -1,28 +1,27 @@
 import type { ResolvedWorkspaceContext } from '../shared/types';
 import type { OrchestratorHost } from './host';
 
-/**
- * Saves and removes a completed iteration's checkout. A failed checkpoint or
- * removal keeps the checkout and must not stop the next loop iteration.
- */
+export type WorktreeCleanupResult =
+  | { removed: true }
+  | { removed: false; error: string };
+
+/** Remove a completed iteration's checkout without discarding local changes. */
 export async function cleanupPreviousWorktree(
   host: OrchestratorHost,
   loopId: string,
   workspace: ResolvedWorkspaceContext | undefined,
-): Promise<void> {
-  if (workspace?.type !== 'managed-worktree') return;
+): Promise<WorktreeCleanupResult> {
+  if (workspace?.type !== 'managed-worktree') return { removed: true };
   const worktreeKey = workspace.worktreeKey ?? loopId;
   const worktreePath = workspace.worktreePath ?? workspace.cwd;
-  try {
-    await host.createCheckpoint(worktreePath, `Loop checkpoint before cleanup: ${loopId}`);
-  } catch (error) {
-    host.log(`Could not checkpoint ${worktreeKey} before cleanup: ${String(error)}`);
-  }
   try {
     await host.removeWorktree(worktreeKey, {
       deleteMergedBranch: workspace.externalBranch ? undefined : true,
     });
+    return { removed: true };
   } catch (error) {
-    host.log(`Could not remove ${worktreeKey}, so its checkout was kept at ${worktreePath}: ${String(error)}`);
+    const message = `Could not remove ${worktreeKey}, so its checkout was kept at ${worktreePath}: ${String(error)}`;
+    host.log(message);
+    return { removed: false, error: message };
   }
 }

--- a/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/worktree-cleanup.ts
@@ -13,7 +13,6 @@ export async function cleanupPreviousWorktree(
 ): Promise<void> {
   if (workspace?.type !== 'managed-worktree') return;
   await host.removeWorktree(workspace.worktreeKey ?? loopId, {
-    force: true,
     deleteMergedBranch: workspace.externalBranch ? undefined : true,
   });
 }


### PR DESCRIPTION
## Summary

- keep dirty or non-empty checkouts when normal Git removal refuses cleanup
- keep the stored loop worktree and queued event when cleanup fails, and stop only that iteration
- continue other due loops after one loop cannot clean up its checkout
- retain destructive forced cleanup for explicit deletion and stale Kanban recovery
- use the configured Git author for initial commits and checkpoints, with a Sero fallback when no identity resolves
- contain Room and explicit loop deletion cleanup failures
- stabilize the load-sensitive Skills and Design Library tests found by the full suite

## Context

This is a focused replacement for the small data-loss safeguards from #474. It starts from `main` and does not include a worktree pool, a custom cross-process lock, or the downstream changes from #476 and #477.

Routine loop cleanup does not create commits. If Git refuses normal removal, Sero keeps the checkout and its stored pointer. Explicit user-authorized deletion can still discard the checkout with `force`.

Related to #473.

## Validation

- `pnpm test`: 22 of 22 tasks passed
- Desktop suite: 422 files and 2,331 tests passed
- Orchestrator suite: 135 files passed, 1 skipped; 1,351 tests passed, 1 skipped
- Design Library suite: 96 files and 805 tests passed
- focused Desktop worktree tests: 14 passed
- external Kanban plugin: 12 files and 43 tests passed
- external Kanban plugin typecheck passed
- `pnpm typecheck`: 27 of 27 tasks passed
- `git diff --check`

The first concurrent full-suite run hit existing wall-clock limits in the Room performance and Agent Plugin lifecycle tests. Both passed alone, and the complete rerun passed.

Draft CI jobs are skipped by the repository workflow until the PR is ready for review.
