### PR TITLE
fix(design-library): load background runtime

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/runtime/loader.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/loader.test.ts
@@ -5,6 +5,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { loadAppRuntimeModule } from '@electron/features/apps/runtime/loader';
 
 const tempDirs: string[] = [];
+const designLibraryRuntime = path.resolve(
+  process.cwd(),
+  '../../plugins/sero-design-library-plugin/runtime/index.ts',
+);
 
 async function createTempDir(): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'sero-app-runtime-loader-'));
@@ -21,6 +25,14 @@ function wait(ms: number): Promise<void> {
 }
 
 describe('loadAppRuntimeModule', () => {
+  it('loads the Design Library background runtime', async () => {
+    const runtimeModule = await loadAppRuntimeModule(designLibraryRuntime, {
+      externals: ['esbuild'],
+    });
+
+    expect(typeof runtimeModule.createAppRuntime).toBe('function');
+  });
+
   it('loads named createAppRuntime exports from JavaScript runtime entries', async () => {
     const dir = await createTempDir();
     const runtimePath = path.join(dir, 'runtime.mjs');

--- a/apps/desktop/electron/__tests__/features/apps/runtime/loader.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/loader.test.ts
@@ -5,10 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { loadAppRuntimeModule } from '@electron/features/apps/runtime/loader';
 
 const tempDirs: string[] = [];
-const designLibraryRuntime = path.resolve(
-  process.cwd(),
-  '../../plugins/sero-design-library-plugin/runtime/index.ts',
-);
+const runtimePlugins = ['design-library', 'graphify', 'orchestrator'];
 
 async function createTempDir(): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'sero-app-runtime-loader-'));
@@ -25,9 +22,12 @@ function wait(ms: number): Promise<void> {
 }
 
 describe('loadAppRuntimeModule', () => {
-  it('loads the Design Library background runtime', async () => {
-    const runtimeModule = await loadAppRuntimeModule(designLibraryRuntime, {
-      externals: ['esbuild'],
+  it.each(runtimePlugins)('loads the %s background runtime with its manifest settings', async (id) => {
+    const pluginDir = path.resolve(process.cwd(), `../../plugins/sero-${id}-plugin`);
+    const manifest: { sero: { app: { runtime: string; runtimeExternals?: string[] } } } =
+      JSON.parse(await readFile(path.join(pluginDir, 'package.json'), 'utf8'));
+    const runtimeModule = await loadAppRuntimeModule(path.resolve(pluginDir, manifest.sero.app.runtime), {
+      externals: manifest.sero.app.runtimeExternals ?? [],
     });
 
     expect(typeof runtimeModule.createAppRuntime).toBe('function');

--- a/plugins/sero-admin-plugin/shared/tsconfig.json
+++ b/plugins/sero-admin-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-cron-plugin/shared/tsconfig.json
+++ b/plugins/sero-cron-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { withLock } from '@sero-ai/extension-runtime';
+import { withLock } from '@sero-ai/extension-runtime/file-lock';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from './paths';
 import {
   StaleStateError,

--- a/plugins/sero-design-library-plugin/shared/state-io.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { withLock, type FileLockOptions } from '@sero-ai/extension-runtime';
+import { withLock, type FileLockOptions } from '@sero-ai/extension-runtime/file-lock';
 import {
   normalizeDesignIndex,
   normalizeExportIndex,

--- a/plugins/sero-design-library-plugin/shared/tsconfig.json
+++ b/plugins/sero-design-library-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-git-plugin/shared/tsconfig.json
+++ b/plugins/sero-git-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-graphify-plugin/shared/tsconfig.json
+++ b/plugins/sero-graphify-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-mcp-plugin/shared/tsconfig.json
+++ b/plugins/sero-mcp-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-memory-plugin/shared/tsconfig.json
+++ b/plugins/sero-memory-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-orchestrator-plugin/shared/tsconfig.json
+++ b/plugins/sero-orchestrator-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-usage-plugin/shared/tsconfig.json
+++ b/plugins/sero-usage-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-user-feedback-plugin/shared/tsconfig.json
+++ b/plugins/sero-user-feedback-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}

--- a/plugins/sero-web-plugin/shared/tsconfig.json
+++ b/plugins/sero-web-plugin/shared/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary

- import file locking through the focused extension-runtime subpath
- prevent Pi and cross-spawn code from entering the Design Library runtime bundle
- load the real Design Library runtime in the desktop loader regression test

## Cause

The Design Library state writer imported from the extension-runtime root barrel. That barrel also exports isolated-completion helpers, so the runtime bundle included pi-coding-agent and cross-spawn. Electron then rejected cross-spawn's dynamic child_process require and never started the background runtime.

## Audit

Checked every direct extension-runtime root import. No other background runtime has the same dependency path. Graphify's similar state helper is used by its extension process, not its background runtime. Other root imports intentionally use isolated-completion helpers or are tests and templates.

## Validation

- pnpm --filter @sero/desktop exec vitest run electron/__tests__/features/apps/runtime/loader.test.ts
- pnpm --filter @sero-ai/plugin-design-library test
- pnpm --filter @sero-ai/plugin-design-library typecheck
- pnpm --filter @sero/desktop typecheck
- pnpm typecheck
- git diff --check
- live Electron test with the OrchestratorDemo profile: the 51-request backlog drained, Library opened, Designs opened the newest Design, and the runtime log had no startup or request failures

Docs are unchanged because this fixes runtime loading without changing user-visible behavior or interfaces.